### PR TITLE
Add GitHub Copilot and Claude Code instructions

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -22,14 +22,17 @@ examples/
 ## Crate Responsibilities
 
 ### onnx-ir
+
 - Parses ONNX protobuf files into a clean Intermediate Representation
-- 5-phase pipeline: Initialization → Node Conversion → Type Inference → Post-processing → Finalization
+- 5-phase pipeline: Initialization → Node Conversion → Type Inference → Post-processing →
+  Finalization
 - Each ONNX operator has a `NodeProcessor` implementation
 - Node structs contain: `name`, `inputs`, `outputs`, `config`
 - **Important**: Should extract and preserve ALL ONNX attributes faithfully, even if Burn doesn't
   support them yet. This allows onnx-ir to be reused by other projects
 
 ### burn-onnx
+
 - Converts onnx-ir nodes to Burn Rust code
 - Implements `NodeCodegen` trait for each node type
 - Generates `.rs` files and `.burnpack` weight files
@@ -40,6 +43,7 @@ examples/
 ## Coding Conventions
 
 ### Rust Style
+
 - Edition 2024
 - Use `#[derive(Debug, Clone)]` on public types
 - Prefer `thiserror` for error types
@@ -47,6 +51,7 @@ examples/
 - Document public APIs with `///` doc comments
 
 ### ONNX-IR Patterns
+
 - Node processors are `pub(crate)` - only the node structs and configs are public
 - Use `NodeBuilder` derive macro for test builders
 - Configuration structs should derive `Debug, Clone, Default` when possible
@@ -55,13 +60,15 @@ examples/
 - Config structs should include all ONNX operator attributes, using `Option<T>` for optional ones
 
 ### burn-onnx Patterns
+
 - Implement `NodeCodegen<PS>` directly on onnx-ir node types
 - Use `scope.arg()` for automatic tensor/scalar/shape handling
 - Use `quote!` macro for code generation
-- Add `insta` snapshot tests for ALL code generation branches - each config option, each input
-  type variant, optional vs required inputs should have test coverage
+- Add `insta` snapshot tests for ALL code generation branches - each config option, each input type
+  variant, optional vs required inputs should have test coverage
 
 ### Testing
+
 - Unit tests go in the same file as implementation
 - Integration tests in `crates/onnx-tests/tests/<op_name>/`
 - Use `torch.manual_seed(42)` or `np.random.seed(42)` for reproducibility

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -64,8 +64,8 @@ examples/
 - Implement `NodeCodegen<PS>` directly on onnx-ir node types
 - Use `scope.arg()` for automatic tensor/scalar/shape handling
 - Use `quote!` macro for code generation
-- Add `insta` snapshot tests for ALL code generation branches - each config option, each input
-  type variant, optional vs required inputs should have test coverage
+- Add `insta` snapshot tests for ALL code generation branches - each config option, each input type
+  variant, optional vs required inputs should have test coverage
 
 ### Testing
 
@@ -107,7 +107,8 @@ outputs = ref.run(None, {"input": input_data})
 print("Expected output:", outputs[0])
 ```
 
-This ensures test scripts are self-contained and use the ONNX reference implementation for ground truth.
+This ensures test scripts are self-contained and use the ONNX reference implementation for ground
+truth.
 
 ## Code Review Guidelines
 

--- a/DEVELOPMENT-GUIDE.md
+++ b/DEVELOPMENT-GUIDE.md
@@ -42,9 +42,9 @@ For an introduction to ONNX import in Burn, see
 - Exclude any ONNX/Protobuf-specific logic from the Burn graph
 - **Feature Support Validation**: The [`onnx-ir`](crates/onnx-ir/) crate should extract and preserve
   all ONNX attributes faithfully, even if Burn does not yet support them. Rejection of unsupported
-  features should happen in [`burn-onnx`](crates/burn-onnx/) during code generation, not in `onnx-ir`
-  during configuration extraction. This allows `onnx-ir` to be reused by other projects that may have
-  different feature support
+  features should happen in [`burn-onnx`](crates/burn-onnx/) during code generation, not in
+  `onnx-ir` during configuration extraction. This allows `onnx-ir` to be reused by other projects
+  that may have different feature support
 
 The conversion process involves three main stages:
 
@@ -65,8 +65,7 @@ To extend `burn-onnx` with support for new ONNX operators, follow these steps:
 3. **Visualize ONNX Model**: Use [Netron](https://github.com/lutzroeder/netron) to verify the ONNX
    model contains the expected operators.
 
-4. **Generate IR and Burn Graph**: Navigate to
-   [crates/burn-onnx/](crates/burn-onnx/) and run:
+4. **Generate IR and Burn Graph**: Navigate to [crates/burn-onnx/](crates/burn-onnx/) and run:
 
    ```
    cargo r -- ../onnx-tests/tests/<op>/<op>.onnx ./out
@@ -80,9 +79,8 @@ To extend `burn-onnx` with support for new ONNX operators, follow these steps:
    the Burn model in Rust code, and `my-model.burnpack` contains the model weights.
 
 7. **Integration Test**: Include the test in the `tests/<op_name>/mod.rs` file in the
-   [crates/onnx-tests/tests/](crates/onnx-tests/tests/)
-   directory. Further details can be found in the
-   [onnx-tests README](crates/onnx-tests/README.md).
+   [crates/onnx-tests/tests/](crates/onnx-tests/tests/) directory. Further details can be found in
+   the [onnx-tests README](crates/onnx-tests/README.md).
 
 ## Implementing a New Operator
 
@@ -591,6 +589,7 @@ cargo test --test test_mod my_new_op::test_my_new_op
 #### Best Practices
 
 **Model Generation:**
+
 - Keep models simple, focusing on single operators
 - Use fixed seeds for reproducibility: `torch.manual_seed(42)`
 - Print input/output tensors for reference
@@ -598,6 +597,7 @@ cargo test --test test_mod my_new_op::test_my_new_op
 - Use `do_constant_folding=False` if PyTorch optimizes away operators
 
 **Test Implementation:**
+
 - Test multiple input shapes, data types, and parameters
 - Include edge cases (empty tensors, single elements, large tensors)
 - Use appropriate numerical tolerance levels


### PR DESCRIPTION
## Summary

Add AI assistant instructions to help GitHub Copilot and Claude Code understand the codebase for code reviews and contributions.

### Files Added

| File | Description |
|------|-------------|
| `.github/copilot-instructions.md` | GitHub Copilot instructions |
| `.claude/CLAUDE.md` | Claude Code instructions |

### Contents

Both files include:
- **Project Structure** - Crate organization and responsibilities
- **Coding Conventions** - Rust style, onnx-ir patterns, burn-onnx patterns
- **Testing Guidelines** - Unit tests, integration tests, Python scripts with uv format
- **Key Design Principles**:
  - onnx-ir should extract ALL ONNX attributes (full opset coverage)
  - Unsupported feature rejection belongs in burn-onnx, not onnx-ir
  - Use `insta` snapshots to cover all code generation branches
  - Use `ReferenceEvaluator` for ground truth in tests
- **Common Commands** and key files to know
- **Links** to development guide and documentation

Also updates `DEVELOPMENT-GUIDE.md` with:
- uv inline script format for Python tests
- ReferenceEvaluator usage guidance
- Full ONNX opset coverage guidance
- insta snapshot test coverage requirements