### PR TITLE
Add GitHub Actions workflow to request Copilot code review on PRs

### DIFF
--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -1,0 +1,31 @@
+# Automatically request GitHub Copilot code review on pull requests
+name: Copilot Code Review
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+jobs:
+  copilot-review:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Request Copilot Review
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Request Copilot as a reviewer
+            // Note: Copilot code review must be enabled in repository settings
+            try {
+              await github.rest.pulls.requestReviewers({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.payload.pull_request.number,
+                reviewers: ['copilot-pull-request-reviewer']
+              });
+              console.log('Copilot review requested successfully');
+            } catch (error) {
+              console.log('Could not request Copilot review:', error.message);
+              console.log('Make sure Copilot code review is enabled in repository settings');
+            }


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow that automatically requests Copilot as a reviewer when a PR is opened or marked ready for review

## Setup Required

For this to work, Copilot code review must be enabled in repository settings:
1. Go to Repository Settings → Code security and analysis
2. Enable "Copilot code review" under the Copilot section

The workflow handles errors gracefully if Copilot review is not enabled.

## Test plan

- [ ] Verify the workflow appears in the Actions tab after merging
- [ ] Enable Copilot code review in settings
- [ ] Open a test PR to confirm Copilot is automatically requested as reviewer