### PR TITLE
Fix Loop node failing to resolve outer-scope graph inputs with colons

### DIFF
--- a/crates/onnx-ir/src/graph_state.rs
+++ b/crates/onnx-ir/src/graph_state.rs
@@ -205,6 +205,7 @@ impl GraphState {
             })
             .collect::<Vec<Argument>>();
 
+        let mut input_idx = 0usize;
         let inputs = inputs
             .iter()
             .filter_map(|x| {
@@ -215,7 +216,14 @@ impl GraphState {
 
                 // Only real graph inputs get added
                 // Preserve the original ONNX input name for better generated code usability
-                graph_input_map.insert(x.name.clone(), graph_input_map.len());
+                let idx = input_idx;
+                input_idx += 1;
+                graph_input_map.insert(x.name.clone(), idx);
+                // Also insert sanitized name for lookups using sanitized outer-scope references
+                let sanitized = crate::proto_conversion::sanitize_name(&x.name);
+                if sanitized != x.name {
+                    graph_input_map.insert(sanitized, idx);
+                }
 
                 // Try to convert from proto, but if no type is available (common for subgraph
                 // inputs that reference outer scope), use the outer scope argument
@@ -600,4 +608,85 @@ fn create_test_constant(
 
     // Return node and data_id for registering in constant_map
     (constant_node, data_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protos::{
+        TypeProto, ValueInfoProto,
+        tensor_proto::DataType,
+        tensor_shape_proto::Dimension,
+        type_proto::{Tensor, Value},
+    };
+
+    /// Create a ValueInfoProto with a tensor type
+    fn make_tensor_value_info(name: &str, rank: usize) -> ValueInfoProto {
+        let dims: Vec<Dimension> = (0..rank)
+            .map(|_| {
+                let mut dim = Dimension::default();
+                dim.value = Some(tensor_shape_proto::dimension::Value::DimParam("N".into()));
+                dim
+            })
+            .collect();
+
+        let mut shape = crate::protos::TensorShapeProto::default();
+        shape.dim = dims;
+
+        let mut tensor = Tensor::default();
+        tensor.elem_type = DataType::FLOAT.value();
+        tensor.shape = protobuf::MessageField::some(shape);
+
+        let mut type_proto = TypeProto::default();
+        type_proto.value = Some(Value::TensorType(tensor));
+
+        let mut vi = ValueInfoProto::default();
+        vi.name = name.to_string();
+        vi.type_ = protobuf::MessageField::some(type_proto);
+        vi
+    }
+
+    use crate::protos::tensor_shape_proto;
+    use protobuf::Enum;
+
+    /// Regression test for https://github.com/tracel-ai/burn-onnx/issues/2
+    ///
+    /// Graph inputs with ONNX names containing colons (e.g. "samples:0") must be
+    /// findable via `init_in` using both the original name and the sanitized name
+    /// ("samples_0"). Before the fix, only the original name worked, causing
+    /// outer-scope references in Loop subgraphs to fall back to rank-0 defaults.
+    #[test]
+    fn init_in_finds_graph_input_by_sanitized_name() {
+        let input = make_tensor_value_info("samples:0", 2);
+        let output = make_tensor_value_info("output:0", 2);
+
+        let state = GraphState::new(&[input], &[output], &[], &[]);
+
+        // Lookup by original ONNX name
+        let arg = state.init_in("samples:0");
+        assert_eq!(arg.name, "samples_0");
+        assert!(matches!(arg.ty, ArgType::Tensor(ref t) if t.rank == 2));
+
+        // Lookup by sanitized name (the regression case)
+        let arg = state.init_in("samples_0");
+        assert_eq!(arg.name, "samples_0");
+        assert!(matches!(arg.ty, ArgType::Tensor(ref t) if t.rank == 2));
+    }
+
+    /// Verify that multiple graph inputs with colon names get correct indices.
+    /// This catches the index corruption bug where using map.len() as index
+    /// would assign wrong indices after inserting sanitized aliases.
+    #[test]
+    fn init_in_correct_indices_with_multiple_colon_inputs() {
+        let input_a = make_tensor_value_info("a:0", 2);
+        let input_b = make_tensor_value_info("b:0", 3);
+
+        let state = GraphState::new(&[input_a, input_b], &[], &[], &[]);
+
+        let arg_a = state.init_in("a_0");
+        assert!(matches!(arg_a.ty, ArgType::Tensor(ref t) if t.rank == 2));
+
+        let arg_b = state.init_in("b_0");
+        assert!(matches!(arg_b.ty, ArgType::Tensor(ref t) if t.rank == 3));
+    }
 }


### PR DESCRIPTION
## Summary

- Fix `graph_input_map` to store sanitized name aliases alongside original ONNX names, so `init_in` can find graph inputs when called with sanitized names (e.g. `samples_0` instead of `samples:0`)
- Use a separate counter for input indices instead of `map.len()` to prevent index corruption from extra alias entries
- Add two regression tests covering both the lookup and index correctness

Fixes #2

**Note:** After this fix, the speech-embedding.onnx model from the issue hits a second, unrelated error (Shape vs Tensor type mismatch in Loop body type inference). Filed as #55.

## Test plan

- [x] `cargo test -p onnx-ir` passes (including 2 new regression tests)
- [x] `cargo test -p burn-onnx` passes
- [x] `cargo test -p onnx-tests` passes (393 tests)