### PR TITLE
Add ONNX operator spec reference docs

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -13,6 +13,10 @@ crates/
 ├── burn-import/     # Legacy crate (deprecated, re-exports burn-onnx)
 └── model-checks/    # Real-world model validation (excluded from workspace)
 
+onnx-spec/
+├── fetch-specs.py   # Script to fetch/update ONNX operator specs
+└── ops/             # Per-operator markdown specs (auto-generated)
+
 examples/
 ├── onnx-inference/          # Standard inference example
 ├── image-classification-web/ # WASM/WebGPU example
@@ -63,6 +67,8 @@ examples/
 - Type inference happens in processors, not in codegen
 - **Strive for full ONNX opset coverage** - extract all attributes even if not yet used by burn-onnx
 - Config structs should include all ONNX operator attributes, using `Option<T>` for optional ones
+- **Reference `onnx-spec/ops/<OpName>.md`** for the official spec when implementing or reviewing
+  operators (attributes, inputs/outputs, type constraints)
 - **Declarative node architecture**: General processing in the onnx-ir framework (pipeline phases,
   graph state, type inference loop, etc.) must NOT contain node-type-specific logic. All
   node-specific behavior is declared in `NodeProcessor` implementations. If a general module needs
@@ -108,6 +114,7 @@ ONNX reference implementation and serves as ground truth.
 ## Adding a New ONNX Operator
 
 1. **onnx-ir**: Create node processor in `crates/onnx-ir/src/node/<op>.rs`
+   - Read `onnx-spec/ops/<OpName>.md` for the full operator spec
    - Define config struct with ALL ONNX attributes
    - Implement `NodeProcessor` trait
    - Register in `crates/onnx-ir/src/registry.rs`
@@ -154,6 +161,7 @@ cargo insta review
 - `crates/burn-onnx/src/burn/graph.rs` - Graph code generation
 - `SUPPORTED-ONNX-OPS.md` - Operator support table
 - `DEVELOPMENT-GUIDE.md` - Detailed implementation guide
+- `onnx-spec/ops/<OpName>.md` - Official ONNX operator specs (update with `./onnx-spec/fetch-specs.py`)
 
 ## Dependencies
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,7 @@
 
 - [ ] Confirmed that `cargo xtask validate` command has been executed.
 - [ ] Confirm relevant documentation has been updated.
+- [ ] For new/modified ONNX operators: verified implementation matches `onnx-spec/ops/<OpName>.md`.
 
 ### Related Issues/PRs
 

--- a/onnx-spec/fetch-specs.py
+++ b/onnx-spec/fetch-specs.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env -S uv run --script
+
+# /// script
+# dependencies = [
+#   "onnx==1.19.0",
+# ]
+# ///
+
+"""Fetch ONNX operator specs and write per-operator markdown files to ops/.
+
+Usage: ./onnx-spec/fetch-specs.py
+"""
+
+import os
+from pathlib import Path
+
+import onnx
+from onnx import defs
+
+# Only the default ONNX domain
+DOMAIN = ""
+
+# Attribute type name mapping
+ATTR_TYPE_NAMES = {
+    0: "UNDEFINED",
+    1: "FLOAT",
+    2: "INT",
+    3: "STRING",
+    4: "TENSOR",
+    5: "GRAPH",
+    6: "FLOATS",
+    7: "INTS",
+    8: "STRINGS",
+    9: "TENSORS",
+    10: "GRAPHS",
+    11: "SPARSE_TENSOR",
+    12: "SPARSE_TENSORS",
+    13: "TYPE_PROTO",
+    14: "TYPE_PROTOS",
+}
+
+# Input/output option mapping
+FORMAL_PARAM_OPTION = {
+    0: "Single",
+    1: "Optional",
+    2: "Variadic",
+}
+
+
+def get_latest_schemas():
+    """Get the latest version of each operator schema."""
+    all_schemas = defs.get_all_schemas_with_history()
+    latest = {}
+    for schema in all_schemas:
+        if schema.domain != DOMAIN:
+            continue
+        name = schema.name
+        if name not in latest or schema.since_version > latest[name].since_version:
+            latest[name] = schema
+    return latest
+
+
+def format_attribute(attr):
+    """Format a single attribute as markdown."""
+    type_name = ATTR_TYPE_NAMES.get(attr.type, f"UNKNOWN({attr.type})")
+    required = "required" if attr.required else "optional"
+    line = f"- **{attr.name}** ({type_name}, {required})"
+    if attr.description:
+        desc = attr.description.strip().split("\n")[0]  # first line only
+        line += f": {desc}"
+    return line
+
+
+def format_io(param, direction):
+    """Format a single input or output as markdown."""
+    option = FORMAL_PARAM_OPTION.get(param.option, "Single")
+    type_str = param.type_str if param.type_str else ""
+    line = f"- **{param.name}**"
+    parts = []
+    if type_str:
+        parts.append(type_str)
+    if option != "Single":
+        parts.append(option.lower())
+    if parts:
+        line += f" ({', '.join(parts)})"
+    if param.description:
+        desc = param.description.strip().split("\n")[0]
+        line += f": {desc}"
+    return line
+
+
+def format_type_constraints(schema):
+    """Format type constraints as markdown."""
+    lines = []
+    for tc in schema.type_constraints:
+        types = ", ".join(sorted(tc.allowed_type_strs))
+        lines.append(f"- **{tc.type_param_str}**: {types}")
+        if tc.description:
+            desc = tc.description.strip().split("\n")[0]
+            lines.append(f"  {desc}")
+    return lines
+
+
+def schema_to_markdown(schema):
+    """Convert an ONNX schema to a markdown string."""
+    lines = []
+    lines.append(f"# {schema.name}")
+    lines.append("")
+    lines.append(f"Since opset **{schema.since_version}**")
+    lines.append("")
+
+    if schema.doc:
+        lines.append("## Description")
+        lines.append("")
+        lines.append(schema.doc.strip())
+        lines.append("")
+
+    # Attributes
+    attrs = list(schema.attributes.values())
+    if attrs:
+        lines.append("## Attributes")
+        lines.append("")
+        for attr in sorted(attrs, key=lambda a: a.name):
+            lines.append(format_attribute(attr))
+        lines.append("")
+
+    # Inputs
+    if schema.inputs:
+        min_inputs = schema.min_input
+        max_inputs = schema.max_input
+        lines.append(f"## Inputs ({min_inputs} - {max_inputs})")
+        lines.append("")
+        for inp in schema.inputs:
+            lines.append(format_io(inp, "input"))
+        lines.append("")
+
+    # Outputs
+    if schema.outputs:
+        min_outputs = schema.min_output
+        max_outputs = schema.max_output
+        lines.append(f"## Outputs ({min_outputs} - {max_outputs})")
+        lines.append("")
+        for out in schema.outputs:
+            lines.append(format_io(out, "output"))
+        lines.append("")
+
+    # Type constraints
+    tc_lines = format_type_constraints(schema)
+    if tc_lines:
+        lines.append("## Type Constraints")
+        lines.append("")
+        lines.extend(tc_lines)
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def main():
+    script_dir = Path(__file__).resolve().parent
+    ops_dir = script_dir / "ops"
+    ops_dir.mkdir(exist_ok=True)
+
+    # Clean existing files
+    for f in ops_dir.glob("*.md"):
+        f.unlink()
+
+    schemas = get_latest_schemas()
+    print(f"Writing {len(schemas)} operator specs to {ops_dir}/")
+
+    for name in sorted(schemas):
+        schema = schemas[name]
+        md = schema_to_markdown(schema)
+        filepath = ops_dir / f"{name}.md"
+        filepath.write_text(md)
+
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/onnx-spec/ops/Abs.md
+++ b/onnx-spec/ops/Abs.md
@@ -1,0 +1,22 @@
+# Abs
+
+Since opset **13**
+
+## Description
+
+Absolute takes one input data (Tensor<T>) and produces one output data
+(Tensor<T>) where absolute value, y = abs(x), is applied to
+the tensor elementwise.
+
+## Inputs (1 - 1)
+
+- **X** (T): Input tensor
+
+## Outputs (1 - 1)
+
+- **Y** (T): Output tensor
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)
+  Constrain input and output types to all numeric tensors.

--- a/onnx-spec/ops/Acos.md
+++ b/onnx-spec/ops/Acos.md
@@ -1,0 +1,20 @@
+# Acos
+
+Since opset **22**
+
+## Description
+
+Calculates the arccosine (inverse of cosine) of the given input tensor, element-wise.
+
+## Inputs (1 - 1)
+
+- **input** (T): Input tensor
+
+## Outputs (1 - 1)
+
+- **output** (T): The arccosine of the input tensor computed element-wise
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain input and output types to float tensors.

--- a/onnx-spec/ops/Acosh.md
+++ b/onnx-spec/ops/Acosh.md
@@ -1,0 +1,20 @@
+# Acosh
+
+Since opset **22**
+
+## Description
+
+Calculates the hyperbolic arccosine of the given input tensor element-wise.
+
+## Inputs (1 - 1)
+
+- **input** (T): Input tensor
+
+## Outputs (1 - 1)
+
+- **output** (T): The hyperbolic arccosine values of the input tensor computed element-wise
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain input and output types to float tensors.

--- a/onnx-spec/ops/Add.md
+++ b/onnx-spec/ops/Add.md
@@ -1,0 +1,25 @@
+# Add
+
+Since opset **14**
+
+## Description
+
+Performs element-wise binary addition (with Numpy-style broadcasting support).
+
+This operator supports **multidirectional (i.e., Numpy-style) broadcasting**; for more details please check [the doc](Broadcasting.md).
+
+(Opset 14 change): Extend supported types to include uint8, int8, uint16, and int16.
+
+## Inputs (2 - 2)
+
+- **A** (T): First operand.
+- **B** (T): Second operand.
+
+## Outputs (1 - 1)
+
+- **C** (T): Result, has same element type as two inputs
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)
+  Constrain input and output types to all numeric tensors.

--- a/onnx-spec/ops/AffineGrid.md
+++ b/onnx-spec/ops/AffineGrid.md
@@ -1,0 +1,53 @@
+# AffineGrid
+
+Since opset **20**
+
+## Description
+
+Generates a 2D or 3D flow field (sampling grid), given a batch of affine matrices theta
+(https://pytorch.org/docs/stable/generated/torch.nn.functional.affine_grid.html).
+An affine matrix `theta` is applied to a position tensor represented in its homogeneous expression. Here is an example in 3D:
+```
+[r00, r01, r02, t0]   [x]   [x']
+[r10, r11, r12, t1] * [y] = [y']
+[r20, r21, r22, t2]   [z]   [z']
+[0,   0,   0,   1 ]   [1]   [1 ]
+```
+where `(x, y, z)` is the position in the original space, `(x', y', z')` is the position in the output space.
+The last row is always `[0, 0, 0, 1]` and is not stored in the affine matrix. Therefore we have `theta` of shape `(N, 2, 3)` for 2D or `(N, 3, 4)` for 3D.
+
+Input `size` is used to define grid of positions evenly spaced in the original 2D or 3D space, with dimensions ranging from `-1` to `1`.
+The output `grid` contains positions in the output space.
+
+When `align_corners=1`, consider `-1` and `1` to refer to the centers of the corner pixels (mark `v` in illustration).
+```
+v            v            v            v
+|-------------------|------------------|
+-1                  0                  1
+```
+When `align_corners=0`, consider `-1` and `1` to refer to the outer edge of the corner pixels.
+```
+    v        v         v         v
+|------------------|-------------------|
+-1                 0                   1
+```
+
+## Attributes
+
+- **align_corners** (INT, optional): if align_corners=1, consider -1 and 1 to refer to the centers of the corner pixels. if align_corners=0, consider -1 and 1 to refer to the outer edge the corner pixels.
+
+## Inputs (2 - 2)
+
+- **theta** (T1): input batch of affine matrices with shape (N, 2, 3) for 2D or (N, 3, 4) for 3D
+- **size** (T2): the target output image size (N, C, H, W) for 2D or (N, C, D, H, W) for 3D
+
+## Outputs (1 - 1)
+
+- **grid** (T1): output tensor of shape (N, H, W, 2) of 2D sample coordinates or (N, D, H, W, 3) of 3D sample coordinates.
+
+## Type Constraints
+
+- **T1**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain grid types to float tensors.
+- **T2**: tensor(int64)
+  Constrain size's type to int64 tensors.

--- a/onnx-spec/ops/And.md
+++ b/onnx-spec/ops/And.md
@@ -1,0 +1,26 @@
+# And
+
+Since opset **7**
+
+## Description
+
+Returns the tensor resulted from performing the `and` logical operation
+elementwise on the input tensors `A` and `B` (with Numpy-style broadcasting support).
+
+This operator supports **multidirectional (i.e., Numpy-style) broadcasting**; for more details please check [the doc](Broadcasting.md).
+
+## Inputs (2 - 2)
+
+- **A** (T): First input operand for the logical operator.
+- **B** (T): Second input operand for the logical operator.
+
+## Outputs (1 - 1)
+
+- **C** (T1): Result tensor.
+
+## Type Constraints
+
+- **T**: tensor(bool)
+  Constrain input to boolean tensor.
+- **T1**: tensor(bool)
+  Constrain output to boolean tensor.

--- a/onnx-spec/ops/ArgMax.md
+++ b/onnx-spec/ops/ArgMax.md
@@ -1,0 +1,32 @@
+# ArgMax
+
+Since opset **13**
+
+## Description
+
+Computes the indices of the max elements of the input tensor's element along the
+provided axis. The resulting tensor has the same rank as the input if keepdims equals 1.
+If keepdims equals 0, then the resulting tensor has the reduced dimension pruned.
+If select_last_index is True (default False), the index of the last occurrence of the max
+is selected if the max appears more than once in the input. Otherwise the index of the
+first occurrence is selected.
+The type of the output tensor is integer.
+
+## Attributes
+
+- **axis** (INT, optional): The axis in which to compute the arg indices. Accepted range is [-r, r-1] where r = rank(data).
+- **keepdims** (INT, optional): Keep the reduced dimension or not, default 1 means keep reduced dimension.
+- **select_last_index** (INT, optional): Whether to select the last index or the first index if the {name} appears in multiple indices, default is False (first index).
+
+## Inputs (1 - 1)
+
+- **data** (T): An input tensor.
+
+## Outputs (1 - 1)
+
+- **reduced** (tensor(int64)): Reduced output tensor with integer data type.
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)
+  Constrain input and output types to all numeric tensors.

--- a/onnx-spec/ops/ArgMin.md
+++ b/onnx-spec/ops/ArgMin.md
@@ -1,0 +1,32 @@
+# ArgMin
+
+Since opset **13**
+
+## Description
+
+Computes the indices of the min elements of the input tensor's element along the
+provided axis. The resulting tensor has the same rank as the input if keepdims equals 1.
+If keepdims equals 0, then the resulting tensor has the reduced dimension pruned.
+If select_last_index is True (default False), the index of the last occurrence of the min
+is selected if the min appears more than once in the input. Otherwise the index of the
+first occurrence is selected.
+The type of the output tensor is integer.
+
+## Attributes
+
+- **axis** (INT, optional): The axis in which to compute the arg indices. Accepted range is [-r, r-1] where r = rank(data).
+- **keepdims** (INT, optional): Keep the reduced dimension or not, default 1 means keep reduced dimension.
+- **select_last_index** (INT, optional): Whether to select the last index or the first index if the {name} appears in multiple indices, default is False (first index).
+
+## Inputs (1 - 1)
+
+- **data** (T): An input tensor.
+
+## Outputs (1 - 1)
+
+- **reduced** (tensor(int64)): Reduced output tensor with integer data type.
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)
+  Constrain input and output types to all numeric tensors.

--- a/onnx-spec/ops/Asin.md
+++ b/onnx-spec/ops/Asin.md
@@ -1,0 +1,20 @@
+# Asin
+
+Since opset **22**
+
+## Description
+
+Calculates the arcsine (inverse of sine) of the given input tensor, element-wise.
+
+## Inputs (1 - 1)
+
+- **input** (T): Input tensor
+
+## Outputs (1 - 1)
+
+- **output** (T): The arcsine of the input tensor computed element-wise
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain input and output types to float tensors.

--- a/onnx-spec/ops/Asinh.md
+++ b/onnx-spec/ops/Asinh.md
@@ -1,0 +1,20 @@
+# Asinh
+
+Since opset **22**
+
+## Description
+
+Calculates the hyperbolic arcsine of the given input tensor element-wise.
+
+## Inputs (1 - 1)
+
+- **input** (T): Input tensor
+
+## Outputs (1 - 1)
+
+- **output** (T): The hyperbolic arcsine values of the input tensor computed element-wise
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain input and output types to float tensors.

--- a/onnx-spec/ops/Atan.md
+++ b/onnx-spec/ops/Atan.md
@@ -1,0 +1,20 @@
+# Atan
+
+Since opset **22**
+
+## Description
+
+Calculates the arctangent (inverse of tangent) of the given input tensor, element-wise.
+
+## Inputs (1 - 1)
+
+- **input** (T): Input tensor
+
+## Outputs (1 - 1)
+
+- **output** (T): The arctangent of the input tensor computed element-wise
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain input and output types to float tensors.

--- a/onnx-spec/ops/Atanh.md
+++ b/onnx-spec/ops/Atanh.md
@@ -1,0 +1,20 @@
+# Atanh
+
+Since opset **22**
+
+## Description
+
+Calculates the hyperbolic arctangent of the given input tensor element-wise.
+
+## Inputs (1 - 1)
+
+- **input** (T): Input tensor
+
+## Outputs (1 - 1)
+
+- **output** (T): The hyperbolic arctangent values of the input tensor computed element-wise
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain input and output types to float tensors.

--- a/onnx-spec/ops/Attention.md
+++ b/onnx-spec/ops/Attention.md
@@ -1,0 +1,96 @@
+# Attention
+
+Since opset **24**
+
+## Description
+
+Computes scaled dot product attention on query, key and value tensors, using an optional attention mask if passed.
+
+This operator covers self and cross variants of the attention operation based on sequence lengths of K, Q and V.
+
+For self attention, `kv_sequence_length` equals to `q_sequence_length`.
+
+For cross attention, query and key might have different lengths.
+
+This operator also covers the 3 following variants based on the number of heads:
+1) Multi-headed Attention (MHA): Described in the paper https://arxiv.org/pdf/1706.03762, `q_num_heads = kv_num_heads`.
+2) Group-query Attention (GQA): Described in the paper https://arxiv.org/pdf/2305.13245, `q_num_heads > kv_num_heads`, `q_num_heads % kv_num_heads == 0`.
+3) Multi-query Attention (MQA): Described in the paper https://arxiv.org/pdf/1911.02150, `q_num_heads > kv_num_heads`, `kv_num_heads=1`.
+
+Attention bias to be added is calculated based on `attn_mask` input and `is_causal` attribute:
+1) `attn_mask`: A boolean mask where a value of `True` indicates that the element should take part in attention or a float mask of the same type as query, key, value that is added to the attention score.
+2) If `is_causal` is set to `1`, attention scores above the diagonal are masked out, regardless of the `attn_mask` input.
+
+With respect to KV cache update, this operator allows the following two use cases:
+
+1) Cache update happens inside the Attention operator. In this case, the `K` and `V` inputs contain only the incoming
+tokens for the current autoregressive step, and the four optional inputs/outputs past and present key and value are
+all needed. The Attention op performs a Concat operation on the past and incoming key and value to form the present
+key and value, respectively. Note that this only works correctly for the special case where the past key and value
+do not contain padded tokens.
+2) Cache update happens outside the Attention operator (for example, through the `TensorScatter` operator). In this
+case, the `K` and `V` inputs correspond to the entire cache tensor, so the four optional inputs/outputs past and
+present key and value should not be used. An additional input `nonpad_kv_seqlen` of shape (batch_size,) may be
+provided to indicate the number of non-padding tokens in each sample of the batch to save unnecessary computation.
+Here, the kv_sequence dimension of `attn_mask` can be shorter than `K` and `V`, but still needs to be at least as long
+as the maximum value of `nonpad_kv_seqlen`.
+
+Both past and present state key/values are optional. They shall be used together, and not allowed to use only one of them.
+The following pattern is applied to the Q, K and V inputs after appropriate reshaping of K and V inputs based on sequence lengths and num heads provided:
+
+```
+  The following pattern is applied by this operator:
+      Q          K          V
+      |          |          |
+Q*sqrt(scale) K*sqrt(scale) |
+      |          |          |
+      |       Transpose     |
+      |          |          |
+      ---MatMul---          |
+            |               |
+ at_mask---Add              |
+            |               |
+  softcap (if provided)     |
+            |               |
+         Softmax            |
+            |               |
+            -----MatMul------
+                   |
+                   Y
+```
+
+## Attributes
+
+- **is_causal** (INT, optional): If set to `1`, the attention masking is a lower triangular matrix when the mask is a square matrix. The attention masking has the form of the upper left causal bias due to the alignment.
+- **kv_num_heads** (INT, optional): Number of heads of key and value. Must be used with 3D inputs of Q, K and V.
+- **q_num_heads** (INT, optional): Number of heads of query. Must be used with 3D inputs of Q, K and V.
+- **qk_matmul_output_mode** (INT, optional): If set to `0`, qk_matmul_output is the output of qk matmul. If set to `1`, qk_matmul_output includes the addition of the attention mask to the output of qk matmul. If set to `2`, qk_matmul_output is the output after the softcap operation. If set to `3`, qk_matmul_output is the output after the softmax operation. Default value is 0.
+- **scale** (FLOAT, optional): Scaling factor applied to $Q*K^T$. Default value is `1/sqrt(head_size)`. To prevent [numerical overflow](https://tinyurl.com/sudb9s96), scale `Q`, `K` by `sqrt(scale)` before matmul.
+- **softcap** (FLOAT, optional): Softcap value for attention weights. Default value is 0.
+- **softmax_precision** (INT, optional): The floating-point precision used in softmax computation. If softmax precision is not provided, the same precision as the input of softmax (Q and K) is used.
+
+## Inputs (3 - 7)
+
+- **Q** (T1): Query tensor. 4D tensor with shape `(batch_size, q_num_heads, q_sequence_length, head_size)` or 3D tensor with shape `(batch_size, q_sequence_length, q_hidden_size)`. For cases with a 3D input tensor, `q_hidden_size = q_num_heads * head_size`
+- **K** (T1): Key tensor. 4D tensor with shape `(batch_size, kv_num_heads, kv_sequence_length, head_size)` or 3D tensor with shape `(batch_size, kv_sequence_length, k_hidden_size)`. For cases with a 3D input tensor, `k_hidden_size = kv_num_heads * head_size`
+- **V** (T2): Value tensor. 4D tensor with shape `(batch_size, kv_num_heads, kv_sequence_length, v_head_size)` or 3D tensor with shape `(batch_size, kv_sequence_length, v_hidden_size)`. For cases with a 3D input tensor, `v_hidden_size = kv_num_heads * v_head_size`
+- **attn_mask** (U, optional): Attention mask. Shape must be broadcastable to `(batch_size, q_num_heads, q_sequence_length, total_sequence_length)` where `total_sequence_length = past_sequence_length + kv_sequence_length.` The last dimension can also be shorter than `total_sequence_length` and will be padded to `total_sequence_length` with negative infinity. Two types of masks are supported: a boolean mask where a value of `True` indicates that the element should take part in attention, or a float mask of the same type as query, key, value that is added to the attention score.
+- **past_key** (T1, optional): past state cache for key with shape `(batch_size, kv_num_heads, past_sequence_length, head_size)`
+- **past_value** (T2, optional): past state cache for value with shape `(batch_size, kv_num_heads, past_sequence_length, v_head_size)`
+- **nonpad_kv_seqlen** (tensor(int64), optional): A vector of integers of shape `(batch_size,)` that indicates the number of valid (ie, non-padding) tokens in each sample. A padding mask can be derived from this. This should not be used together with `past_key` and `past_value` inputs or `present_key` and `present_value` outputs (See the KV cache use cases in the operator description).
+
+## Outputs (1 - 4)
+
+- **Y** (T1): The output tensor . 4D tensor with shape `(batch_size, q_num_heads, q_sequence_length, v_head_size)` or 3D tensor with shape `(batch_size, q_sequence_length, hidden_size)`. For cases with a 3D input tensor, `hidden_size = q_num_heads * v_head_size`
+- **present_key** (T1, optional): Updated key cache with shape `(batch_size, kv_num_heads, total_sequence_length, head_size)` where `total_sequence_length = past_sequence_length + kv_sequence_length`.
+- **present_value** (T2, optional): Updated value cache with shape `(batch_size, kv_num_heads, total_sequence_length, v_head_size)` where `total_sequence_length = past_sequence_length + kv_sequence_length`.
+- **qk_matmul_output** (T1, optional): The output of QK matmul. 4D tensor with shape `(batch_size, q_num_heads, q_sequence_length, total_sequence_length)` where `total_sequence_length = past_sequence_length + kv_sequence_length`.
+
+## Type Constraints
+
+- **T1**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain Q and K inputs types to float tensors.
+- **T2**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain V input types to float tensors.
+- **U**: tensor(bfloat16), tensor(bool), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)
+  Constrain output 'mask' types to boolean tensors and input types.

--- a/onnx-spec/ops/AveragePool.md
+++ b/onnx-spec/ops/AveragePool.md
@@ -1,0 +1,60 @@
+# AveragePool
+
+Since opset **22**
+
+## Description
+
+AveragePool consumes an input tensor X and applies average pooling across
+ the tensor according to kernel sizes, stride sizes, and pad lengths.
+ average pooling consisting of computing the average on all values of a
+ subset of the input tensor according to the kernel size and downsampling the
+ data into the output tensor Y for further processing. The output spatial shape is calculated differently
+ depending on whether explicit padding is used, where pads is employed, or auto padding is used, where auto_pad is utilized.
+ With explicit padding (https://pytorch.org/docs/stable/generated/torch.nn.MaxPool2d.html?highlight=maxpool#torch.nn.MaxPool2d):
+ ```
+ output_spatial_shape[i] = floor((input_spatial_shape[i] + pad_shape[i] - dilation[i] * (kernel_shape[i] - 1) - 1) / strides_spatial_shape[i] + 1)
+ ```
+ or
+ ```
+ output_spatial_shape[i] = ceil((input_spatial_shape[i] + pad_shape[i] - dilation[i] * (kernel_shape[i] - 1) - 1) / strides_spatial_shape[i] + 1)
+ ```
+ if ceil_mode is enabled. `pad_shape[i]` is the sum of pads along axis `i`. Sliding windows that would start in the right padded region are ignored.
+
+ `auto_pad` is a DEPRECATED attribute. If you are using them currently, the output spatial shape will be following when ceil_mode is enabled:
+ ```
+ VALID: output_spatial_shape[i] = ceil((input_spatial_shape[i] - ((kernel_spatial_shape[i] - 1) * dilations[i] + 1) + 1) / strides_spatial_shape[i])
+ SAME_UPPER or SAME_LOWER: output_spatial_shape[i] = ceil(input_spatial_shape[i] / strides_spatial_shape[i])
+ ```
+ or when ceil_mode is disabled (https://www.tensorflow.org/api_docs/python/tf/keras/layers/AveragePooling2D):
+ ```
+ VALID: output_spatial_shape[i] = floor((input_spatial_shape[i] - ((kernel_spatial_shape[i] - 1) * dilations[i] + 1)) / strides_spatial_shape[i]) + 1
+ SAME_UPPER or SAME_LOWER: output_spatial_shape[i] = floor((input_spatial_shape[i] - 1) / strides_spatial_shape[i]) + 1
+ ```
+ And pad shape will be following if `SAME_UPPER` or `SAME_LOWER`:
+ ```
+ pad_shape[i] = (output_spatial_shape[i] - 1) * strides_spatial_shape[i] + ((kernel_spatial_shape[i] - 1) * dilations[i] + 1) - input_spatial_shape[i]
+ ```
+ The output of each pooling window is divided by the number of elements (exclude pad when attribute count_include_pad is zero).
+
+## Attributes
+
+- **auto_pad** (STRING, optional): auto_pad must be either NOTSET, SAME_UPPER, SAME_LOWER or VALID. Where default value is NOTSET, which means explicit padding is used. SAME_UPPER or SAME_LOWER mean pad the input so that `output_shape[i] = ceil(input_shape[i] / strides[i])` for each axis `i`. The padding is split between the two sides equally or almost equally (depending on whether it is even or odd). In case the padding is an odd number, the extra padding is added at the end for SAME_UPPER and at the beginning for SAME_LOWER.
+- **ceil_mode** (INT, optional): Whether to use ceil or floor (default) to compute the output shape.
+- **count_include_pad** (INT, optional): Whether include pad pixels when calculating values for the edges. Default is 0, doesn't count include pad.
+- **dilations** (INTS, optional): Dilation value along each spatial axis of filter. If not present, the dilation defaults to 1 along each spatial axis.
+- **kernel_shape** (INTS, required): The size of the kernel along each axis.
+- **pads** (INTS, optional): Padding for the beginning and ending along each spatial axis, it can take any value greater than or equal to 0. The value represent the number of pixels added to the beginning and end part of the corresponding axis. `pads` format should be as follow [x1_begin, x2_begin...x1_end, x2_end,...], where xi_begin the number of pixels added at the beginning of axis `i` and xi_end, the number of pixels added at the end of axis `i`. This attribute cannot be used simultaneously with auto_pad attribute. If not present, the padding defaults to 0 along start and end of each spatial axis.
+- **strides** (INTS, optional): Stride along each spatial axis. If not present, the stride defaults to 1 along each spatial axis.
+
+## Inputs (1 - 1)
+
+- **X** (T): Input data tensor from the previous operator; dimensions for image case are (N x C x H x W), where N is the batch size, C is the number of channels, and H and W are the height and the width of the data. For non image case, the dimensions are in the form of (N x C x D1 x D2 ... Dn), where N is the batch size. Optionally, if dimension denotation is in effect, the operation expects the input data tensor to arrive with the dimension denotation of [DATA_BATCH, DATA_CHANNEL, DATA_FEATURE, DATA_FEATURE ...].
+
+## Outputs (1 - 1)
+
+- **Y** (T): Output data tensor from average or max pooling across the input tensor. Dimensions will vary based on various kernel, stride, and pad sizes. Floor value of the dimension is used
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain input and output types to float tensors.

--- a/onnx-spec/ops/BatchNormalization.md
+++ b/onnx-spec/ops/BatchNormalization.md
@@ -1,0 +1,74 @@
+# BatchNormalization
+
+Since opset **15**
+
+## Description
+
+Carries out batch normalization as described in the paper
+https://arxiv.org/abs/1502.03167. Depending on the mode it is being run,
+There are five required inputs 'X', 'scale', 'B', 'input_mean' and
+'input_var'.
+Note that 'input_mean' and 'input_var' are expected to be the estimated
+statistics in inference mode (training_mode=False, default),
+and the running statistics in training mode (training_mode=True).
+There are multiple cases for the number of outputs, which we list below:
+
+* Output case #1: Y, running_mean, running_var (training_mode=True)
+* Output case #2: Y (training_mode=False)
+
+When training_mode=False, extra outputs are invalid.
+The outputs are updated as follows when training_mode=True:
+```
+running_mean = input_mean * momentum + current_mean * (1 - momentum)
+running_var = input_var * momentum + current_var * (1 - momentum)
+
+Y = (X - current_mean) / sqrt(current_var + epsilon) * scale + B
+```
+where:
+```
+current_mean = ReduceMean(X, axis=all_except_channel_index)
+current_var =  ReduceVar(X, axis=all_except_channel_index)
+```
+Notice that `ReduceVar` refers to the population variance, and it equals to
+`sum(sqrd(x_i - x_avg)) / N`
+where `N` is the population size (this formula does not use sample size `N - 1`).
+
+The computation of ReduceMean and ReduceVar uses float to avoid overflow for float16 inputs.
+
+When training_mode=False:
+```
+Y = (X - input_mean) / sqrt(input_var + epsilon) * scale + B
+```
+
+For previous (depreciated) non-spatial cases, implementors are suggested
+to flatten the input shape to (N x C * D1 * D2 * ... * Dn) before a BatchNormalization Op.
+This operator has **optional** inputs/outputs. See [the doc](IR.md) for more details about the representation of optional arguments. An empty string may be used in the place of an actual argument's name to indicate a missing argument. Trailing optional arguments (those not followed by an argument that is present) may also be simply omitted.
+
+## Attributes
+
+- **epsilon** (FLOAT, optional): The epsilon value to use to avoid division by zero.
+- **momentum** (FLOAT, optional): Factor used in computing the running mean and variance.e.g., running_mean = running_mean * momentum + mean * (1 - momentum).
+- **training_mode** (INT, optional): If set to true, it indicates BatchNormalization is being used for training, and outputs 1 and 2 are to be computed.
+
+## Inputs (5 - 5)
+
+- **X** (T): Input data tensor from the previous operator; dimensions are in the form of (N x C x D1 x D2 ... Dn), where N is the batch size, C is the number of channels. Statistics are computed for every channel of C over N and D1 to Dn dimensions. For image data, input dimensions become (N x C x H x W). The op also accepts single dimension input of size N in which case C is assumed to be 1
+- **scale** (T1): Scale tensor of shape (C).
+- **B** (T1): Bias tensor of shape (C).
+- **input_mean** (T2): running (training) or estimated (testing) mean tensor of shape (C).
+- **input_var** (T2): running (training) or estimated (testing) variance tensor of shape (C).
+
+## Outputs (1 - 3)
+
+- **Y** (T): The output tensor of the same shape as X
+- **running_mean** (T2, optional): The running mean after the BatchNormalization operator.
+- **running_var** (T2, optional): The running variance after the BatchNormalization operator. This op uses the population size (N) for calculating variance, and not the sample size N-1.
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain input and output types to float tensors.
+- **T1**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain scale and bias types to float tensors.
+- **T2**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain mean and variance types to float tensors.

--- a/onnx-spec/ops/Bernoulli.md
+++ b/onnx-spec/ops/Bernoulli.md
@@ -1,0 +1,32 @@
+# Bernoulli
+
+Since opset **22**
+
+## Description
+
+Draws binary random numbers (0 or 1) from a Bernoulli distribution. The input tensor should be a tensor
+containing probabilities p (a value in the range [0,1]) to be used for drawing the binary random number,
+where an output of 1 is produced with probability p and an output of 0 is produced with probability (1-p).
+
+This operator is non-deterministic and may not produce the same values in different
+implementations (even if a seed is specified).
+
+## Attributes
+
+- **dtype** (INT, optional): The data type for the elements of the output tensor. if not specified, we will use the data type of the input tensor.
+- **seed** (FLOAT, optional): (Optional) Seed to the random generator, if not specified we will auto generate one.
+
+## Inputs (1 - 1)
+
+- **input** (T1): All values in input have to be in the range:[0, 1].
+
+## Outputs (1 - 1)
+
+- **output** (T2): The returned output tensor only has values 0 or 1, same shape as input tensor.
+
+## Type Constraints
+
+- **T1**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain input types to float tensors.
+- **T2**: tensor(bfloat16), tensor(bool), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)
+  Constrain output types to all numeric tensors and bool tensors.

--- a/onnx-spec/ops/BitShift.md
+++ b/onnx-spec/ops/BitShift.md
@@ -1,0 +1,36 @@
+# BitShift
+
+Since opset **11**
+
+## Description
+
+Bitwise shift operator performs element-wise operation. For each input element, if the
+attribute "direction" is "RIGHT", this operator moves its binary representation toward
+the right side so that the input value is effectively decreased. If the attribute "direction"
+is "LEFT", bits of binary representation moves toward the left side, which results the
+increase of its actual value. The input X is the tensor to be shifted and another input
+Y specifies the amounts of shifting. For example, if "direction" is "Right", X is [1, 4],
+and S is [1, 1], the corresponding output Z would be [0, 2]. If "direction" is "LEFT" with
+X=[1, 2] and S=[1, 2], the corresponding output Y would be [2, 8].
+
+Because this operator supports Numpy-style broadcasting, X's and Y's shapes are
+not necessarily identical.
+This operator supports **multidirectional (i.e., Numpy-style) broadcasting**; for more details please check [the doc](Broadcasting.md).
+
+## Attributes
+
+- **direction** (STRING, required): Direction of moving bits. It can be either "RIGHT" (for right shift) or "LEFT" (for left shift).
+
+## Inputs (2 - 2)
+
+- **X** (T): First operand, input to be shifted.
+- **Y** (T): Second operand, amounts of shift.
+
+## Outputs (1 - 1)
+
+- **Z** (T): Output tensor
+
+## Type Constraints
+
+- **T**: tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)
+  Constrain input and output types to integer tensors.

--- a/onnx-spec/ops/BitwiseAnd.md
+++ b/onnx-spec/ops/BitwiseAnd.md
@@ -1,0 +1,24 @@
+# BitwiseAnd
+
+Since opset **18**
+
+## Description
+
+Returns the tensor resulting from performing the bitwise `and` operation
+elementwise on the input tensors `A` and `B` (with Numpy-style broadcasting support).
+
+This operator supports **multidirectional (i.e., Numpy-style) broadcasting**; for more details please check [the doc](Broadcasting.md).
+
+## Inputs (2 - 2)
+
+- **A** (T): First input operand for the bitwise operator.
+- **B** (T): Second input operand for the bitwise operator.
+
+## Outputs (1 - 1)
+
+- **C** (T): Result tensor.
+
+## Type Constraints
+
+- **T**: tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)
+  Constrain input to integer tensors.

--- a/onnx-spec/ops/BitwiseNot.md
+++ b/onnx-spec/ops/BitwiseNot.md
@@ -1,0 +1,20 @@
+# BitwiseNot
+
+Since opset **18**
+
+## Description
+
+Returns the bitwise not of the input tensor element-wise.
+
+## Inputs (1 - 1)
+
+- **X** (T): Input tensor
+
+## Outputs (1 - 1)
+
+- **Y** (T): Output tensor
+
+## Type Constraints
+
+- **T**: tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)
+  Constrain input/output to integer tensors.

--- a/onnx-spec/ops/BitwiseOr.md
+++ b/onnx-spec/ops/BitwiseOr.md
@@ -1,0 +1,24 @@
+# BitwiseOr
+
+Since opset **18**
+
+## Description
+
+Returns the tensor resulting from performing the bitwise `or` operation
+elementwise on the input tensors `A` and `B` (with Numpy-style broadcasting support).
+
+This operator supports **multidirectional (i.e., Numpy-style) broadcasting**; for more details please check [the doc](Broadcasting.md).
+
+## Inputs (2 - 2)
+
+- **A** (T): First input operand for the bitwise operator.
+- **B** (T): Second input operand for the bitwise operator.
+
+## Outputs (1 - 1)
+
+- **C** (T): Result tensor.
+
+## Type Constraints
+
+- **T**: tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)
+  Constrain input to integer tensors.

--- a/onnx-spec/ops/BitwiseXor.md
+++ b/onnx-spec/ops/BitwiseXor.md
@@ -1,0 +1,24 @@
+# BitwiseXor
+
+Since opset **18**
+
+## Description
+
+Returns the tensor resulting from performing the bitwise `xor` operation
+elementwise on the input tensors `A` and `B` (with Numpy-style broadcasting support).
+
+This operator supports **multidirectional (i.e., Numpy-style) broadcasting**; for more details please check [the doc](Broadcasting.md).
+
+## Inputs (2 - 2)
+
+- **A** (T): First input operand for the bitwise operator.
+- **B** (T): Second input operand for the bitwise operator.
+
+## Outputs (1 - 1)
+
+- **C** (T): Result tensor.
+
+## Type Constraints
+
+- **T**: tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)
+  Constrain input to integer tensors.

--- a/onnx-spec/ops/BlackmanWindow.md
+++ b/onnx-spec/ops/BlackmanWindow.md
@@ -1,0 +1,27 @@
+# BlackmanWindow
+
+Since opset **17**
+
+## Description
+
+Generates a Blackman window as described in the paper https://ieeexplore.ieee.org/document/1455106.
+
+## Attributes
+
+- **output_datatype** (INT, optional): The data type of the output tensor. Strictly must be one of the values from DataType enum in TensorProto whose values correspond to T2. The default value is 1 = FLOAT.
+- **periodic** (INT, optional): If 1, returns a window to be used as periodic function. If 0, return a symmetric window. When 'periodic' is specified, hann computes a window of length size + 1 and returns the first size points. The default value is 1.
+
+## Inputs (1 - 1)
+
+- **size** (T1): A scalar value indicating the length of the window.
+
+## Outputs (1 - 1)
+
+- **output** (T2): A Blackman window with length: size. The output has the shape: [size].
+
+## Type Constraints
+
+- **T1**: tensor(int32), tensor(int64)
+  Constrain the input size to int64_t.
+- **T2**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)
+  Constrain output types to numeric tensors.

--- a/onnx-spec/ops/Cast.md
+++ b/onnx-spec/ops/Cast.md
@@ -1,0 +1,109 @@
+# Cast
+
+Since opset **24**
+
+## Description
+
+The operator casts the elements of a given input tensor to a data type
+specified by the 'to' argument and returns an output tensor of the same size in
+the converted type. The 'to' argument must be one of the data types specified
+in the 'DataType' enum field in the TensorProto message.
+
+Casting from string tensor in plain (e.g., "3.14" and "1000") and scientific numeric representations
+(e.g., "1e-5" and "1E8") to float types is supported. For example, converting string "100.5" to an integer may
+yield result 100. There are some string literals reserved for special floating-point values;
+"+INF" (and "INF"), "-INF", and "NaN" are positive infinity, negative infinity, and not-a-number, respectively.
+Any string which can exactly match "+INF" in a case-insensitive way would be mapped to positive infinite. Similarly,
+this case-insensitive rule is applied to "INF" and "NaN". When casting from numeric tensors
+to string tensors, plain floating-point representation (such as "314.15926") would be used.
+Converting non-numerical-literal string such as "Hello World!" is an undefined behavior. Cases
+of converting string representing floating-point arithmetic value, such as "2.718", to INT is an undefined behavior.
+
+Conversion from a numerical type to any numerical type is always allowed.
+User must be aware of precision loss and value change caused by range difference between two types.
+For example, a 64-bit float 3.1415926459 may be round to a 32-bit float 3.141592. Similarly, converting
+an integer 36 to Boolean may produce 1 because we truncate bits which can't be stored in the targeted type.
+
+In more detail, the conversion among numerical types should follow these rules
+if the destination type is not a float 8 type.
+
+* Casting from floating point to:
+  * floating point: +/- infinity if OOR (out of range).
+  * fixed point: undefined if OOR.
+  * bool: +/- 0.0 to False; all else to True.
+* Casting from fixed point to:
+  * floating point: +/- infinity if OOR. (+ infinity in the case of uint)
+  * fixed point: when OOR, discard higher bits and reinterpret (with respect to two's complement representation for
+    signed types). For example, 200 (int16) -> -56 (int8).
+  * bool: zero to False; nonzero to True.
+* Casting from bool to:
+  * floating point: `{1.0, 0.0}`.
+  * fixed point: `{1, 0}`.
+  * bool: no change.
+
+Float 8 types (E4M3FN, E4M3FNUZ, E5M2, E5M2FNUZ) were introduced to speed up the training of
+deep models. By default the conversion of a float *x* obeys
+to the following rules. `[x]` means the value rounded to
+the target mantissa width.
+
+| x                 | E4M3FN   | E4M3FNUZ | E5M2     | E5M2FNUZ |
+| ----------------- | -------- | -------- | -------- | -------- |
+| 0                 | 0        | 0        | 0        | 0        |
+| -0                | -0       | 0        | -0       | 0        |
+| NaN               | NaN      | NaN      | NaN      | NaN      |
+| Inf               | FLT_MAX  | FLT_MAX  | FLT_MAX  | FLT_MAX  |
+| -Inf              | -FLT_MAX | -FLT_MAX | -FLT_MAX | -FLT_MAX |
+| \[x\] > FLT_MAX   | FLT_MAX  | FLT_MAX  | FLT_MAX  | FLT_MAX  |
+| \[x\] \< -FLT_MAX | -FLT_MAX | -FLT_MAX | -FLT_MAX | -FLT_MAX |
+| else              | RNE      | RNE      | RNE      | RNE      |
+
+The behavior changes if the parameter 'saturate' is set to False.
+The rules then become:
+
+| x                 | E4M3FN | E4M3FNUZ | E5M2 | E5M2FNUZ |
+| ----------------- | ------ | -------- | ---- | -------- |
+| 0                 | 0      | 0        | 0    | 0        |
+| -0                | -0     | 0        | -0   | 0        |
+| NaN               | NaN    | NaN      | NaN  | NaN      |
+| -NaN              | -NaN   | NaN      | -NaN | NaN      |
+| Inf               | NaN    | NaN      | Inf  | NaN      |
+| -Inf              | -NaN   | NaN      | -Inf | NaN      |
+| \[x\] > FLT_MAX   | NaN    | NaN      | Inf  | NaN      |
+| \[x\] \< -FLT_MAX | NaN    | NaN      | -Inf | NaN      |
+| else              | RNE    | RNE      | RNE  | RNE      |
+
+FLOAT8E8M0 type was introduced to enable [Microscaling (MX) formats](https://www.opencompute.org/documents/ocp-microscaling-formats-mx-v1-0-spec-final-pdf).
+When casting to FLOAT8E8M0, the rounding behavior can be specified using the `round_mode` and `saturate` attributes.
+The current CUDA behavior is to round up and saturate. Casting negative values to FLOAT8E8M0 gives undefined behavior.
+The following table describes the casting behavior of special values to FLOAT8E8M0 in the two most common cases.
+
+| x                 | saturate + up | non-saturate + nearest |
+| ----------------- | ------------- | ---------------------  |
+| 0                 | 0             | NaN                    |
+| -0                | Unspecified   | Unspecified            |
+| NaN               | NaN           | NaN                    |
+| Inf               | E8M0_MAX      | NaN                    |
+| x > E8M0_MAX      | E8M0_MAX      | NaN                    |
+| x \< E8M0_MIN     | E8M0_MIN      | NaN                    |
+| x \< 0            | Unspecified   | Unspecified            |
+
+## Attributes
+
+- **round_mode** (STRING, optional): Rounding mode for conversion to float8e8m0. It only applies to casting to float8e8m0 and is `up` by default. `up`: round to nearest value away from zero, `down`: round to nearest value towards zero, `nearest`: round to nearest value and ties round up.
+- **saturate** (INT, optional): The parameter defines how the conversion behaves if an input value is out of range of the destination type. It only applies for float 8 conversion (float8e4m3fn, float8e4m3fnuz, float8e5m2, float8e5m2fnuz, float8e8m0). It is true by default. All cases are fully described in the tables inserted in the operator description.
+- **to** (INT, required): The data type to which the elements of the input tensor are cast. Strictly must be one of the types from DataType enum in TensorProto
+
+## Inputs (1 - 1)
+
+- **input** (T1): Input tensor to be cast.
+
+## Outputs (1 - 1)
+
+- **output** (T2): Output tensor with the same shape as input with type specified by the 'to' argument
+
+## Type Constraints
+
+- **T1**: tensor(bfloat16), tensor(bool), tensor(double), tensor(float), tensor(float16), tensor(float4e2m1), tensor(float8e4m3fn), tensor(float8e4m3fnuz), tensor(float8e5m2), tensor(float8e5m2fnuz), tensor(float8e8m0), tensor(int16), tensor(int32), tensor(int4), tensor(int64), tensor(int8), tensor(string), tensor(uint16), tensor(uint32), tensor(uint4), tensor(uint64), tensor(uint8)
+  Constrain input types. Casting from complex is not supported.
+- **T2**: tensor(bfloat16), tensor(bool), tensor(double), tensor(float), tensor(float16), tensor(float4e2m1), tensor(float8e4m3fn), tensor(float8e4m3fnuz), tensor(float8e5m2), tensor(float8e5m2fnuz), tensor(float8e8m0), tensor(int16), tensor(int32), tensor(int4), tensor(int64), tensor(int8), tensor(string), tensor(uint16), tensor(uint32), tensor(uint4), tensor(uint64), tensor(uint8)
+  Constrain output types. Casting to complex is not supported.

--- a/onnx-spec/ops/CastLike.md
+++ b/onnx-spec/ops/CastLike.md
@@ -1,0 +1,30 @@
+# CastLike
+
+Since opset **24**
+
+## Description
+
+The operator casts the elements of a given input tensor (the first input) to
+the same data type as the elements of the second input tensor.
+See documentation of the Cast operator for further details.
+
+## Attributes
+
+- **round_mode** (STRING, optional): Rounding mode for conversion to float8e8m0. It only applies to casting to float8e8m0 and is `up` by default. `up`: round to nearest value away from zero, `down`: round to nearest value towards zero, `nearest`: round to nearest value and ties round up. Please refer to operator Cast description for further details.
+- **saturate** (INT, optional): The parameter defines how the conversion behaves if an input value is out of range of the destination type. It only applies for float 8 conversion (float8e4m3fn, float8e4m3fnuz, float8e5m2, float8e5m2fnuz, float8e8m0). It is true by default. Please refer to operator Cast description for further details.
+
+## Inputs (2 - 2)
+
+- **input** (T1): Input tensor to be cast.
+- **target_type** (T2): The (first) input tensor will be cast to produce a tensor of the same type as this (second input) tensor.
+
+## Outputs (1 - 1)
+
+- **output** (T2): Output tensor produced by casting the first input tensor to have the same type as the second input tensor.
+
+## Type Constraints
+
+- **T1**: tensor(bfloat16), tensor(bool), tensor(double), tensor(float), tensor(float16), tensor(float4e2m1), tensor(float8e4m3fn), tensor(float8e4m3fnuz), tensor(float8e5m2), tensor(float8e5m2fnuz), tensor(float8e8m0), tensor(int16), tensor(int32), tensor(int4), tensor(int64), tensor(int8), tensor(string), tensor(uint16), tensor(uint32), tensor(uint4), tensor(uint64), tensor(uint8)
+  Constrain input types. Casting from complex is not supported.
+- **T2**: tensor(bfloat16), tensor(bool), tensor(double), tensor(float), tensor(float16), tensor(float4e2m1), tensor(float8e4m3fn), tensor(float8e4m3fnuz), tensor(float8e5m2), tensor(float8e5m2fnuz), tensor(float8e8m0), tensor(int16), tensor(int32), tensor(int4), tensor(int64), tensor(int8), tensor(string), tensor(uint16), tensor(uint32), tensor(uint4), tensor(uint64), tensor(uint8)
+  Constrain output types. Casting to complex is not supported.

--- a/onnx-spec/ops/Ceil.md
+++ b/onnx-spec/ops/Ceil.md
@@ -1,0 +1,22 @@
+# Ceil
+
+Since opset **13**
+
+## Description
+
+Ceil takes one input data (Tensor<T>) and produces one output data
+(Tensor<T>) where the ceil is, y = ceil(x), is applied to
+the tensor elementwise. If x is integral, +0, -0, NaN,  or infinite, x itself is returned.
+
+## Inputs (1 - 1)
+
+- **X** (T): Input tensor
+
+## Outputs (1 - 1)
+
+- **Y** (T): Output tensor
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain input and output types to float tensors.

--- a/onnx-spec/ops/Celu.md
+++ b/onnx-spec/ops/Celu.md
@@ -1,0 +1,30 @@
+# Celu
+
+Since opset **12**
+
+## Description
+
+Continuously Differentiable Exponential Linear Units:
+Perform the linear unit element-wise on the input tensor X
+using formula:
+
+```
+max(0,x) + min(0,alpha*(exp(x/alpha)-1))
+```
+
+## Attributes
+
+- **alpha** (FLOAT, optional): The Alpha value in Celu formula which control the shape of the unit. The default value is 1.0.
+
+## Inputs (1 - 1)
+
+- **X** (T): Input tensor
+
+## Outputs (1 - 1)
+
+- **Y** (T): Output tensor
+
+## Type Constraints
+
+- **T**: tensor(float)
+  Constrain input and output types to float32 tensors.

--- a/onnx-spec/ops/CenterCropPad.md
+++ b/onnx-spec/ops/CenterCropPad.md
@@ -1,0 +1,40 @@
+# CenterCropPad
+
+Since opset **18**
+
+## Description
+
+Center crop or pad an input to given dimensions.
+
+The crop/pad dimensions can be specified for a subset of the `axes`; unspecified dimensions will remain unchanged.
+
+If the input dimensions are larger than the target crop dimensions, a centered cropping window will be extracted
+from the input. The starting value for the cropping window is rounded down, which means that if the difference
+between the input shape and the crop shape is odd, the cropping window will be shifted half a pixel to the left
+of the input center.
+
+If the input dimensions are smaller than the target crop dimensions, the input will be padded equally on both sides
+to center it in the output. In cases where the total number of padding pixels is odd, an additional pixel will be
+added to the right side.
+
+The padding value used is zero.
+
+## Attributes
+
+- **axes** (INTS, optional): If provided, it specifies a subset of axes that 'shape' refer to. If not provided, all axes are assumed [0, 1, ..., r-1], where r = rank(data). Negative value means counting dimensions from the back. Accepted range is [-r, r-1], where r = rank(data). Behavior is undefined if an axis is repeated.
+
+## Inputs (2 - 2)
+
+- **input_data** (T): Input to extract the centered crop from.
+- **shape** (Tind): 1-D tensor representing the cropping window dimensions.
+
+## Outputs (1 - 1)
+
+- **output_data** (T): Output data.
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(bool), tensor(complex128), tensor(complex64), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(string), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)
+  Constrain input and output types to all tensor types.
+- **Tind**: tensor(int32), tensor(int64)
+  Constrain indices to integer types

--- a/onnx-spec/ops/Clip.md
+++ b/onnx-spec/ops/Clip.md
@@ -1,0 +1,26 @@
+# Clip
+
+Since opset **13**
+
+## Description
+
+Clip operator limits the given input within an interval. The interval is
+specified by the inputs 'min' and 'max'. They default to
+numeric_limits::lowest() and numeric_limits::max(), respectively.
+When 'min' is greater than 'max', the clip operator sets all the 'input' values to
+the value of 'max'. Thus, this is equivalent to 'Min(max, Max(input, min))'.
+
+## Inputs (1 - 3)
+
+- **input** (T): Input tensor whose elements to be clipped
+- **min** (T, optional): Minimum value, under which element is replaced by min. It must be a scalar(tensor of empty shape).
+- **max** (T, optional): Maximum value, above which element is replaced by max. It must be a scalar(tensor of empty shape).
+
+## Outputs (1 - 1)
+
+- **output** (T): Output tensor with clipped input elements
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)
+  Constrain input and output types to all numeric tensors.

--- a/onnx-spec/ops/Col2Im.md
+++ b/onnx-spec/ops/Col2Im.md
@@ -1,0 +1,37 @@
+# Col2Im
+
+Since opset **18**
+
+## Description
+
+The operator rearranges column blocks back into a multidimensional image
+
+Col2Im behaves similarly to PyTorch's fold https://pytorch.org/docs/stable/generated/torch.nn.Fold.html,
+but it only supports *batched* multi-dimensional image tensors.
+Another implementation in Python with N-dimension support can be found at https://github.com/f-dangel/unfoldNd/.
+
+NOTE:
+  Although specifying image_shape looks redundant because it could be calculated from
+  convolution formulas, it is required as input for more advanced scenarios as explained
+  at PyTorch's implementation (https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/Col2Im.cpp#L10)
+
+## Attributes
+
+- **dilations** (INTS, optional): 1-dimensional tensor with dilation value along each spatial axis of the image. If not present, the dilation defaults to 1 along each spatial axis of the image.
+- **pads** (INTS, optional): 1-dimensional tensor with padding value for the beginning and ending along each spatial axis, it can take any value greater than or equal to 0. The value represent the number of pixels added to the beginning and end part of the corresponding axis. `pads` format should be as follow [x1_begin, x2_begin...x1_end, x2_end,...], where xi_begin is the number of pixels added at the beginning of axis `i` and xi_end is the number of pixels added at the end of axis `i`. If not present, the padding defaults to 0 along start and end of each spatial axis.
+- **strides** (INTS, optional): 1-dimensional tensor with stride value along each spatial axis. If not present, the stride defaults to 1 along each spatial axis.
+
+## Inputs (3 - 3)
+
+- **input** (T): Input data tensor to be rearranged from column blocks back into an image. This is a 3-dimensional tensor containing [N, C * n-ary-product(block_shape), L], where N is batch dimension, C is image channel dimension and L is number of blocks.The blocks are enumerated in increasing lexicographic-order of their indices.For example, with an image-size 10*20 and block-size 9*18, there would be 2*3 blocks, enumerated in the order block(0, 0), block(0, 1), block(0, 2), block(1, 0), block(1, 1), block(1, 2).
+- **image_shape** (tensor(int64)): The shape of the spatial dimensions of the image after rearranging the column blocks.This is a 1-dimensional tensor with size of at least 2, containing the value [H_img, W_img]  for a 2-D image or [dim_i1, dim_i2, ..., dim_iN] for a N-D image.
+- **block_shape** (tensor(int64)): The shape of the block to apply on the input.This is a 1-dimensional tensor of size of at least 2, containing the value [H_block, W_block]  for a 2-D image or [dim_b1, dim_b2, ..., dim_bN] for a N-D block.This is the block-shape before dilation is applied to it.
+
+## Outputs (1 - 1)
+
+- **output** (T): Output tensor produced by rearranging blocks into an image.
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(bool), tensor(complex128), tensor(complex64), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(string), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)
+  Constrain input and output types to all numeric tensor types.

--- a/onnx-spec/ops/Compress.md
+++ b/onnx-spec/ops/Compress.md
@@ -1,0 +1,29 @@
+# Compress
+
+Since opset **11**
+
+## Description
+
+Selects slices from an input tensor along a given axis where condition evaluates to True for each axis index.
+    In case axis is not provided, input is flattened before elements are selected.
+    Compress behaves like numpy.compress: https://docs.scipy.org/doc/numpy/reference/generated/numpy.compress.html
+
+## Attributes
+
+- **axis** (INT, optional): (Optional) Axis along which to take slices. If not specified, input is flattened before elements being selected. Negative value means counting dimensions from the back. Accepted range is [-r, r-1] where r = rank(input).
+
+## Inputs (2 - 2)
+
+- **input** (T): Tensor of rank r >= 1.
+- **condition** (T1): Rank 1 tensor of booleans to indicate which slices or data elements to be selected. Its length can be less than the input length along the axis or the flattened input size if axis is not specified. In such cases data slices or elements exceeding the condition length are discarded.
+
+## Outputs (1 - 1)
+
+- **output** (T): Tensor of rank r if axis is specified. Otherwise output is a Tensor of rank 1.
+
+## Type Constraints
+
+- **T**: tensor(bool), tensor(complex128), tensor(complex64), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(string), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)
+  Constrain input and output types to all tensor types.
+- **T1**: tensor(bool)
+  Constrain to boolean tensors.

--- a/onnx-spec/ops/Concat.md
+++ b/onnx-spec/ops/Concat.md
@@ -1,0 +1,24 @@
+# Concat
+
+Since opset **13**
+
+## Description
+
+Concatenate a list of tensors into a single tensor. All input tensors must have the same shape, except for the dimension size of the axis to concatenate on.
+
+## Attributes
+
+- **axis** (INT, required): Which axis to concat on. A negative value means counting dimensions from the back. Accepted range is [-r, r-1] where r = rank(inputs)..
+
+## Inputs (1 - 2147483647)
+
+- **inputs** (T, variadic): List of tensors for concatenation
+
+## Outputs (1 - 1)
+
+- **concat_result** (T): Concatenated tensor
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(bool), tensor(complex128), tensor(complex64), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(string), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)
+  Constrain output types to any tensor type.

--- a/onnx-spec/ops/ConcatFromSequence.md
+++ b/onnx-spec/ops/ConcatFromSequence.md
@@ -1,0 +1,30 @@
+# ConcatFromSequence
+
+Since opset **11**
+
+## Description
+
+Concatenate a sequence of tensors into a single tensor.
+All input tensors must have the same shape, except for the dimension size of the axis to concatenate on.
+By default 'new_axis' is 0, the behavior is similar to numpy.concatenate.
+When 'new_axis' is 1, the behavior is similar to numpy.stack.
+
+## Attributes
+
+- **axis** (INT, required): Which axis to concat on. Accepted range in `[-r, r - 1]`, where `r` is the rank of input tensors. When `new_axis` is 1, accepted range is `[-r - 1, r]`.
+- **new_axis** (INT, optional): Insert and concatenate on a new axis or not, default 0 means do not insert new axis.
+
+## Inputs (1 - 1)
+
+- **input_sequence** (S): Sequence of tensors for concatenation
+
+## Outputs (1 - 1)
+
+- **concat_result** (T): Concatenated tensor
+
+## Type Constraints
+
+- **S**: seq(tensor(bool)), seq(tensor(complex128)), seq(tensor(complex64)), seq(tensor(double)), seq(tensor(float)), seq(tensor(float16)), seq(tensor(int16)), seq(tensor(int32)), seq(tensor(int64)), seq(tensor(int8)), seq(tensor(string)), seq(tensor(uint16)), seq(tensor(uint32)), seq(tensor(uint64)), seq(tensor(uint8))
+  Constrain input types to any tensor type.
+- **T**: tensor(bool), tensor(complex128), tensor(complex64), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(string), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)
+  Constrain output types to any tensor type.

--- a/onnx-spec/ops/Constant.md
+++ b/onnx-spec/ops/Constant.md
@@ -1,0 +1,28 @@
+# Constant
+
+Since opset **24**
+
+## Description
+
+This operator produces a constant tensor. Exactly one of the provided attributes, either value, sparse_value,
+or value_* must be specified.
+
+## Attributes
+
+- **sparse_value** (SPARSE_TENSOR, optional): The value for the elements of the output tensor in sparse format.
+- **value** (TENSOR, optional): The value for the elements of the output tensor.
+- **value_float** (FLOAT, optional): The value for the sole element for the scalar, float32, output tensor.
+- **value_floats** (FLOATS, optional): The values for the elements for the 1D, float32, output tensor.
+- **value_int** (INT, optional): The value for the sole element for the scalar, int64, output tensor.
+- **value_ints** (INTS, optional): The values for the elements for the 1D, int64, output tensor.
+- **value_string** (STRING, optional): The value for the sole element for the scalar, UTF-8 string, output tensor.
+- **value_strings** (STRINGS, optional): The values for the elements for the 1D, UTF-8 string, output tensor.
+
+## Outputs (1 - 1)
+
+- **output** (T): Output tensor containing the same value of the provided tensor.
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(bool), tensor(complex128), tensor(complex64), tensor(double), tensor(float), tensor(float16), tensor(float4e2m1), tensor(float8e4m3fn), tensor(float8e4m3fnuz), tensor(float8e5m2), tensor(float8e5m2fnuz), tensor(float8e8m0), tensor(int16), tensor(int32), tensor(int4), tensor(int64), tensor(int8), tensor(string), tensor(uint16), tensor(uint32), tensor(uint4), tensor(uint64), tensor(uint8)
+  Constrain input and output types to all tensor types.

--- a/onnx-spec/ops/ConstantOfShape.md
+++ b/onnx-spec/ops/ConstantOfShape.md
@@ -1,0 +1,26 @@
+# ConstantOfShape
+
+Since opset **24**
+
+## Description
+
+Generate a tensor with given value and shape.
+
+## Attributes
+
+- **value** (TENSOR, optional): (Optional) The value of the output elements.Should be a one-element tensor. If not specified, it defaults to a tensor of value 0 and datatype float32
+
+## Inputs (1 - 1)
+
+- **input** (T1): 1D tensor. The shape of the expected output tensor. If empty tensor is given, the output would be a scalar. All values must be >= 0.
+
+## Outputs (1 - 1)
+
+- **output** (T2): Output tensor of shape specified by 'input'.If attribute 'value' is specified, the value and datatype of the output tensor is taken from 'value'.If attribute 'value' is not specified, the value in the output defaults to 0, and the datatype defaults to float32.
+
+## Type Constraints
+
+- **T1**: tensor(int64)
+  Constrain input types.
+- **T2**: tensor(bfloat16), tensor(bool), tensor(double), tensor(float), tensor(float16), tensor(float4e2m1), tensor(float8e4m3fn), tensor(float8e4m3fnuz), tensor(float8e5m2), tensor(float8e5m2fnuz), tensor(float8e8m0), tensor(int16), tensor(int32), tensor(int4), tensor(int64), tensor(int8), tensor(uint16), tensor(uint32), tensor(uint4), tensor(uint64), tensor(uint8)
+  Constrain output types to be numerics or boolean.

--- a/onnx-spec/ops/Conv.md
+++ b/onnx-spec/ops/Conv.md
@@ -1,0 +1,32 @@
+# Conv
+
+Since opset **22**
+
+## Description
+
+The convolution operator consumes an input tensor and a filter, and
+computes the output.
+
+## Attributes
+
+- **auto_pad** (STRING, optional): auto_pad must be either NOTSET, SAME_UPPER, SAME_LOWER or VALID. Where default value is NOTSET, which means explicit padding is used. SAME_UPPER or SAME_LOWER mean pad the input so that `output_shape[i] = ceil(input_shape[i] / strides[i])` for each axis `i`. The padding is split between the two sides equally or almost equally (depending on whether it is even or odd). In case the padding is an odd number, the extra padding is added at the end for SAME_UPPER and at the beginning for SAME_LOWER.
+- **dilations** (INTS, optional): dilation value along each spatial axis of the filter. If not present, the dilation defaults is 1 along each spatial axis.
+- **group** (INT, optional): number of groups input channels and output channels are divided into.
+- **kernel_shape** (INTS, optional): The shape of the convolution kernel. If not present, should be inferred from input W.
+- **pads** (INTS, optional): Padding for the beginning and ending along each spatial axis, it can take any value greater than or equal to 0. The value represent the number of pixels added to the beginning and end part of the corresponding axis. `pads` format should be as follow [x1_begin, x2_begin...x1_end, x2_end,...], where xi_begin the number of pixels added at the beginning of axis `i` and xi_end, the number of pixels added at the end of axis `i`. This attribute cannot be used simultaneously with auto_pad attribute. If not present, the padding defaults to 0 along start and end of each spatial axis.
+- **strides** (INTS, optional): Stride along each spatial axis. If not present, the stride defaults is 1 along each spatial axis.
+
+## Inputs (2 - 3)
+
+- **X** (T): Input data tensor from previous layer; has size (N x C x H x W), where N is the batch size, C is the number of channels, and H and W are the height and width. Note that this is for the 2D image. Otherwise the size is (N x C x D1 x D2 ... x Dn). Optionally, if dimension denotation is in effect, the operation expects input data tensor to arrive with the dimension denotation of [DATA_BATCH, DATA_CHANNEL, DATA_FEATURE, DATA_FEATURE ...].
+- **W** (T): The weight tensor that will be used in the convolutions; has size (M x C/group x kH x kW), where C is the number of channels, and kH and kW are the height and width of the kernel, and M is the number of feature maps. For more than 2 dimensions, the kernel shape will be (M x C/group x k1 x k2 x ... x kn), where (k1 x k2 x ... kn) is the dimension of the kernel. Optionally, if dimension denotation is in effect, the operation expects the weight tensor to arrive with the dimension denotation of [FILTER_OUT_CHANNEL, FILTER_IN_CHANNEL, FILTER_SPATIAL, FILTER_SPATIAL ...]. Assuming zero based indices for the shape array, X.shape[1] == (W.shape[1] * group) == C and W.shape[0] mod G == 0. Or in other words FILTER_IN_CHANNEL multiplied by the number of groups should be equal to DATA_CHANNEL and the number of feature maps M should be a multiple of the number of groups G.
+- **B** (T, optional): Optional 1D bias to be added to the convolution, has size of M.
+
+## Outputs (1 - 1)
+
+- **Y** (T): Output data tensor that contains the result of the convolution. The output dimensions are functions of the kernel size, stride size, and pad lengths.
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain input and output types to float tensors.

--- a/onnx-spec/ops/ConvInteger.md
+++ b/onnx-spec/ops/ConvInteger.md
@@ -1,0 +1,37 @@
+# ConvInteger
+
+Since opset **10**
+
+## Description
+
+The integer convolution operator consumes an input tensor, its zero-point, a filter, and its zero-point,
+and computes the output. The production MUST never overflow. The accumulation may overflow if and only if in 32 bits.
+
+## Attributes
+
+- **auto_pad** (STRING, optional): auto_pad must be either NOTSET, SAME_UPPER, SAME_LOWER or VALID. Where default value is NOTSET, which means explicit padding is used. SAME_UPPER or SAME_LOWER mean pad the input so that `output_shape[i] = ceil(input_shape[i] / strides[i])` for each axis `i`. The padding is split between the two sides equally or almost equally (depending on whether it is even or odd). In case the padding is an odd number, the extra padding is added at the end for SAME_UPPER and at the beginning for SAME_LOWER.
+- **dilations** (INTS, optional): dilation value along each spatial axis of the filter. If not present, the dilation defaults to 1 along each axis.
+- **group** (INT, optional): number of groups input channels and output channels are divided into. default is 1.
+- **kernel_shape** (INTS, optional): The shape of the convolution kernel. If not present, should be inferred from input 'w'.
+- **pads** (INTS, optional): Padding for the beginning and ending along each spatial axis, it can take any value greater than or equal to 0.The value represent the number of pixels added to the beginning and end part of the corresponding axis.`pads` format should be as follow [x1_begin, x2_begin...x1_end, x2_end,...], where xi_begin the number ofpixels added at the beginning of axis `i` and xi_end, the number of pixels added at the end of axis `i`.This attribute cannot be used simultaneously with auto_pad attribute. If not present, the padding defaultsto 0 along start and end of each spatial axis.
+- **strides** (INTS, optional): Stride along each spatial axis. If not present, the stride defaults to 1 along each axis.
+
+## Inputs (2 - 4)
+
+- **x** (T1): Input data tensor from previous layer; has size (N x C x H x W), where N is the batch size, C is the number of channels, and H and W are the height and width. Note that this is for the 2D image. Otherwise the size is (N x C x D1 x D2 ... x Dn). Optionally, if dimension denotation is in effect, the operation expects input data tensor to arrive with the dimension denotation of [DATA_BATCH, DATA_CHANNEL, DATA_FEATURE, DATA_FEATURE ...].
+- **w** (T2): The weight tensor that will be used in the convolutions; has size (M x C/group x kH x kW), where C is the number of channels, and kH and kW are the height and width of the kernel, and M is the number of feature maps. For more than 2 dimensions, the kernel shape will be (M x C/group x k1 x k2 x ... x kn), where (k1 x k2 x ... kn) is the dimension of the kernel. Optionally, if dimension denotation is in effect, the operation expects the weight tensor to arrive with the dimension denotation of [FILTER_OUT_CHANNEL, FILTER_IN_CHANNEL, FILTER_SPATIAL, FILTER_SPATIAL ...]. X.shape[1] == (W.shape[1] * group) == C (assuming zero based indices for the shape array). Or in other words FILTER_IN_CHANNEL should be equal to DATA_CHANNEL.
+- **x_zero_point** (T1, optional): Zero point tensor for input 'x'. It's optional and default value is 0. It's a scalar, which means a per-tensor/layer quantization.
+- **w_zero_point** (T2, optional): Zero point tensor for input 'w'. It's optional and default value is 0.  It could be a scalar or a 1-D tensor, which means a per-tensor/layer or per output channel quantization. If it's a 1-D tensor, its number of elements should be equal to the number of output channels (M)
+
+## Outputs (1 - 1)
+
+- **y** (T3): Output data tensor that contains the result of the convolution. The output dimensions are functions of the kernel size, stride size, and pad lengths.
+
+## Type Constraints
+
+- **T1**: tensor(int8), tensor(uint8)
+  Constrain input x and its zero point data type to 8-bit integer tensor.
+- **T2**: tensor(int8), tensor(uint8)
+  Constrain input w and its zero point data type to 8-bit integer tensor.
+- **T3**: tensor(int32)
+  Constrain output y data type to 32-bit integer tensor.

--- a/onnx-spec/ops/ConvTranspose.md
+++ b/onnx-spec/ops/ConvTranspose.md
@@ -1,0 +1,44 @@
+# ConvTranspose
+
+Since opset **22**
+
+## Description
+
+The convolution transpose operator consumes an input tensor and a filter,
+and computes the output.
+
+If the pads parameter is provided the shape of the output is calculated via the following equation:
+
+  output_shape[i] = stride[i] * (input_size[i] - 1) + output_padding[i] + ((kernel_shape[i] - 1) * dilations[i] + 1) - pads[start_i] - pads[end_i]
+
+output_shape can also be explicitly specified in which case pads values are auto generated using these equations:
+
+  total_padding[i] = stride[i] * (input_size[i] - 1) + output_padding[i] + ((kernel_shape[i] - 1) * dilations[i] + 1) - output_shape[i]
+  If (auto_pads == SAME_UPPER): pads[start_i] = total_padding[i]/2; pads[end_i] = total_padding[i] - (total_padding[i]/2)
+  Else: pads[start_i] = total_padding[i] - (total_padding[i]/2); pads[end_i] = (total_padding[i]/2).
+
+## Attributes
+
+- **auto_pad** (STRING, optional): auto_pad must be either NOTSET, SAME_UPPER, SAME_LOWER or VALID. Where default value is NOTSET, which means explicit padding is used. SAME_UPPER or SAME_LOWER mean pad the input so that `output_shape[i] = input_shape[i] * strides[i]` for each axis `i`. The padding is split between the two sides equally or almost equally (depending on whether it is even or odd). In case the padding is an odd number, the extra padding is added at the end for SAME_UPPER and at the beginning for SAME_LOWER.
+- **dilations** (INTS, optional): dilation value along each spatial axis of the filter. If not present, the dilation defaults to 1 along each spatial axis.
+- **group** (INT, optional): number of groups input channels and output channels are divided into.
+- **kernel_shape** (INTS, optional): The shape of the convolution kernel. If not present, should be inferred from input W.
+- **output_padding** (INTS, optional): Additional elements added to the side with higher coordinate indices in the output. Each padding value in "output_padding" must be less than the corresponding stride/dilation dimension. By default, this attribute is a zero vector. Note that this attribute doesn't directly affect the computed output values. It only controls the selection of the computed values, so changing this attribute only adds or removes output elements. If "output_shape" is explicitly provided, "output_padding" does not contribute additional size to "output_shape" but participates in the computation of the needed padding amount. This is also called adjs or adjustment in some frameworks.
+- **output_shape** (INTS, optional): The shape of the output can be explicitly set which will cause pads values to be auto generated. If output_shape is specified pads values are ignored. See doc for details for equations to generate pads. Note that the output_shape attribute value should not include dimensions for batch size and channels, which are automatically inferred.
+- **pads** (INTS, optional): Padding for the beginning and ending along each spatial axis, it can take any value greater than or equal to 0. The value represent the number of pixels added to the beginning and end part of the corresponding axis. `pads` format should be as follow [x1_begin, x2_begin...x1_end, x2_end,...], where xi_begin the number of pixels added at the beginning of axis `i` and xi_end, the number of pixels added at the end of axis `i`. This attribute cannot be used simultaneously with auto_pad attribute. If not present, the padding defaults to 0 along start and end of each spatial axis.
+- **strides** (INTS, optional): Stride along each spatial axis. If not present, the stride defaults to 1 along each spatial axis.
+
+## Inputs (2 - 3)
+
+- **X** (T): Input data tensor from previous layer; has size (N x C x H x W), where N is the batch size, C is the number of channels, and H and W are the height and width. Note that this is for the 2D image. Otherwise the size is (N x C x D1 x D2 ... x Dn)
+- **W** (T): The weight tensor that will be used in the convolutions; has size (C x M/group x kH x kW), where C is the number of channels, and kH and kW are the height and width of the kernel, and M is the number of feature maps. For more than 2 dimensions, the weight shape will be (C x M/group x k1 x k2 x ... x kn), where (k1 x k2 x ... x kn) is the dimension of the kernel. The number of channels in the output should be equal to W.shape[1] * group (assuming zero based indices of the shape array)
+- **B** (T, optional): Optional 1D bias to be added to the convolution, has size of M.
+
+## Outputs (1 - 1)
+
+- **Y** (T): Output data tensor that contains the result of the convolution. The output dimensions are functions of the kernel size, stride size, pad lengths and group count. The number of channels in the output should be equal to W.shape[1] * group (assuming zero based indices of the shape array)
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain input and output types to float tensors.

--- a/onnx-spec/ops/Cos.md
+++ b/onnx-spec/ops/Cos.md
@@ -1,0 +1,20 @@
+# Cos
+
+Since opset **22**
+
+## Description
+
+Calculates the cosine of the given input tensor, element-wise.
+
+## Inputs (1 - 1)
+
+- **input** (T): Input tensor
+
+## Outputs (1 - 1)
+
+- **output** (T): The cosine of the input tensor computed element-wise
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain input and output types to float tensors.

--- a/onnx-spec/ops/Cosh.md
+++ b/onnx-spec/ops/Cosh.md
@@ -1,0 +1,20 @@
+# Cosh
+
+Since opset **22**
+
+## Description
+
+Calculates the hyperbolic cosine of the given input tensor element-wise.
+
+## Inputs (1 - 1)
+
+- **input** (T): Input tensor
+
+## Outputs (1 - 1)
+
+- **output** (T): The hyperbolic cosine values of the input tensor computed element-wise
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain input and output types to float tensors.

--- a/onnx-spec/ops/CumSum.md
+++ b/onnx-spec/ops/CumSum.md
@@ -1,0 +1,46 @@
+# CumSum
+
+Since opset **14**
+
+## Description
+
+Performs cumulative sum of the input elements along the given axis.
+By default, it will do the sum inclusively meaning the first element is copied as is.
+Through an `exclusive` attribute, this behavior can change to exclude the first element.
+It can also perform summation in the opposite direction of the axis. For that, set `reverse` attribute to 1.
+
+Example:
+```
+input_x = [1, 2, 3]
+axis=0
+output = [1, 3, 6]
+exclusive=1
+output = [0, 1, 3]
+exclusive=0
+reverse=1
+output = [6, 5, 3]
+exclusive=1
+reverse=1
+output = [5, 3, 0]
+```
+
+## Attributes
+
+- **exclusive** (INT, optional): If set to 1 will return exclusive sum in which the top element is not included. In other terms, if set to 1, the j-th output element would be the sum of the first (j-1) elements. Otherwise, it would be the sum of the first j elements.
+- **reverse** (INT, optional): If set to 1 will perform the sums in reverse direction.
+
+## Inputs (2 - 2)
+
+- **x** (T): An input tensor that is to be processed.
+- **axis** (T2): A 0-D tensor. Must be in the range [-rank(x), rank(x)-1]. Negative value means counting dimensions from the back.
+
+## Outputs (1 - 1)
+
+- **y** (T): Output tensor of the same type as 'x' with cumulative sums of the x's elements
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16), tensor(int32), tensor(int64), tensor(uint32), tensor(uint64)
+  Constrain input and output types to high-precision numeric tensors.
+- **T2**: tensor(int32), tensor(int64)
+  axis tensor can be int32 or int64 only

--- a/onnx-spec/ops/DFT.md
+++ b/onnx-spec/ops/DFT.md
@@ -1,0 +1,45 @@
+# DFT
+
+Since opset **20**
+
+## Description
+
+Computes the discrete Fourier Transform (DFT) of the input.
+
+Assuming the input has shape `[M, N]`, where `N` is the dimension over which the
+DFT is computed and `M` denotes the conceptual "all other dimensions,"
+the DFT `y[m, k]` of shape `[M, N]` is defined as
+
+$$y[m, k] = \sum_{n=0}^{N-1} e^{-2 \pi j \frac{k n}{N} } x[m, n] ,$$
+
+and the inverse transform is defined as
+
+$$x[m, n] = \frac{1}{N} \sum_{k=0}^{N-1} e^{2 \pi j \frac{k n}{N} } y[m, k] ,$$
+
+where $j$ is the imaginary unit.
+
+The actual shape of the output is specified in the "output" section.
+
+Reference: https://docs.scipy.org/doc/scipy/tutorial/fft.html
+
+## Attributes
+
+- **inverse** (INT, optional): Whether to perform the inverse discrete Fourier Transform. Default is 0, which corresponds to `false`.
+- **onesided** (INT, optional): If `onesided` is `1` and input is real, only values for `k` in `[0, 1, 2, ..., floor(n_fft/2) + 1]` are returned because the real-to-complex Fourier transform satisfies the conjugate symmetry, i.e., `X[m, k] = X[m, n_fft-k]*`, where `m` denotes "all other dimensions" DFT was not applied on. If the input tensor is complex, onesided output is not possible. Value can be `0` or `1`. Default is `0`.
+
+## Inputs (1 - 3)
+
+- **input** (T1): For real input, the following shape is expected: `[signal_dim0][signal_dim1][signal_dim2]...[signal_dimN][1]`. For complex input, the following shape is expected: `[signal_dim0][signal_dim1][signal_dim2]...[signal_dimN][2]`. The final dimension represents the real and imaginary parts of the value in that order.
+- **dft_length** (T2, optional): The length of the signal as a scalar. If greater than the axis dimension, the signal will be zero-padded up to `dft_length`. If less than the axis dimension, only the first `dft_length` values will be used as the signal.
+- **axis** (tensor(int64), optional): The axis as a scalar on which to perform the DFT. Default is `-2` (last signal axis). Negative value means counting dimensions from the back. Accepted range is $[-r, -2] \cup [0, r-2]$ where `r = rank(input)`. The last dimension is for representing complex numbers and thus is an invalid axis.
+
+## Outputs (1 - 1)
+
+- **output** (T1): The Fourier Transform of the input vector. If `onesided` is `0`, the following shape is expected: `[signal_dim0][signal_dim1][signal_dim2]...[signal_dimN][2]`. If `axis=0` and `onesided` is `1`, the following shape is expected: `[floor(signal_dim0/2)+1][signal_dim1][signal_dim2]...[signal_dimN][2]`. If `axis=1` and `onesided` is `1`, the following shape is expected: `[signal_dim0][floor(signal_dim1/2)+1][signal_dim2]...[signal_dimN][2]`. If `axis=N` and `onesided` is `1`, the following shape is expected: `[signal_dim0][signal_dim1][signal_dim2]...[floor(signal_dimN/2)+1][2]`. The `signal_dim` at the specified `axis` is equal to the `dft_length`.
+
+## Type Constraints
+
+- **T1**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain input and output types to float tensors.
+- **T2**: tensor(int32), tensor(int64)
+  Constrain scalar length types to integers.

--- a/onnx-spec/ops/DeformConv.md
+++ b/onnx-spec/ops/DeformConv.md
@@ -1,0 +1,34 @@
+# DeformConv
+
+Since opset **22**
+
+## Description
+
+Performs deformable convolution as described in https://arxiv.org/abs/1703.06211 and https://arxiv.org/abs/1811.11168.
+This operator specification supports the general N-D case. Note that most common use cases have 2D or 3D data.
+
+## Attributes
+
+- **dilations** (INTS, optional): Dilation value along each spatial axis of the kernel. Default is 1 along each axis.
+- **group** (INT, optional): Number of groups the input and output channels, C and oC, are divided into. C and oC must both be divisible by group. Default is 1.
+- **kernel_shape** (INTS, optional): Shape of the convolution kernel. If not present, it is inferred from the shape of input W.
+- **offset_group** (INT, optional): Number of groups of offset. C must be divisible by offset_group. Default is 1.
+- **pads** (INTS, optional): Padding for the beginning and end along each spatial axis. The values represent the number of pixels added to the beginning and end of the corresponding axis and can take any nonnegative value. The format should be as follows: [x1_begin, x2_begin, ..., x1_end, x2_end, ...], where xi_begin is the number of pixels added at the beginning of axis `i` and xi_end is the number of pixels added at the end of axis `i`. Default is 0 along each axis.
+- **strides** (INTS, optional): Stride along each spatial axis. Default is 1 along each axis.
+
+## Inputs (3 - 5)
+
+- **X** (T): Input data tensor. For 2D image data, it has shape (N, C, H, W) where N is the batch size, C is the number of input channels, and H and W are the height and width. In general, the shape is (N, C, D1, D2, ... , Dn) for n-dimensional data, where D1 to Dn are the spatial dimension sizes. Most common use cases have n = 2 or 3.
+- **W** (T): Weight tensor that will be used in the convolutions. It has shape (oC, C/group, kH, kW), where oC is the number of output channels and kH and kW are the kernel height and width. For more than 2 dimensions, it has shape (oC, C/group, k1, k2, ... , kn).
+- **offset** (T): Offset tensor denoting the offset for the sampling locations in the convolution kernel. It has shape (N, offset_group * kH * kW * 2, oH, oW) for 2D data or (N, offset_group * k1 * k2 * ... * kn * n, o1, o2, ... , on) for nD data. Use linear interpolationfor fractional offset values. Sampling locations outside of the padded input tensor gives zero.
+- **B** (T, optional): Optional 1D bias of length oC to be added to the convolution. Default is a tensor of zeros.
+- **mask** (T, optional): The mask tensor to be applied to each position in the convolution kernel. It has shape (N, offset_group * kH * kW, oH, oW) for 2D data or (N, offset_group * k1 * k2 * ... * kn * n, o1, o2, ... , on) for nD data. Default is a tensor of ones.
+
+## Outputs (1 - 1)
+
+- **Y** (T): Output data tensor that contains the result of convolution. It has shape (N, oC, oH, oW) for 2D data or (N, oC, o1, o2, ..., on) for nD data
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain input and output types to float tensors.

--- a/onnx-spec/ops/DepthToSpace.md
+++ b/onnx-spec/ops/DepthToSpace.md
@@ -1,0 +1,47 @@
+# DepthToSpace
+
+Since opset **13**
+
+## Description
+
+DepthToSpace rearranges (permutes) data from depth into blocks of spatial data.
+This is the reverse transformation of SpaceToDepth. More specifically, this op outputs a copy of
+the input tensor where values from the depth dimension are moved in spatial blocks to the height
+and width dimensions. By default, `mode` = `DCR`.
+In the DCR mode, elements along the depth dimension from the input tensor are rearranged in the
+following order: depth, column, and then row. The output y is computed from the input x as below:
+
+```
+b, c, h, w = x.shape
+tmp = np.reshape(x, [b, blocksize, blocksize, c // (blocksize**2), h, w])
+tmp = np.transpose(tmp, [0, 3, 4, 1, 5, 2])
+y = np.reshape(tmp, [b, c // (blocksize**2), h * blocksize, w * blocksize])
+```
+
+In the CRD mode, elements along the depth dimension from the input tensor are rearranged in the
+following order: column, row, and the depth. The output y is computed from the input x as below:
+
+```
+b, c, h, w = x.shape
+tmp = np.reshape(x, [b, c // (blocksize ** 2), blocksize, blocksize, h, w])
+tmp = np.transpose(tmp, [0, 1, 4, 2, 5, 3])
+y = np.reshape(tmp, [b, c // (blocksize ** 2), h * blocksize, w * blocksize])
+```
+
+## Attributes
+
+- **blocksize** (INT, required): Blocks of [blocksize, blocksize] are moved.
+- **mode** (STRING, optional): DCR (default) for depth-column-row order re-arrangement. Use CRD for column-row-depth order.
+
+## Inputs (1 - 1)
+
+- **input** (T): Input tensor of [N,C,H,W], where N is the batch axis, C is the channel or depth, H is the height and W is the width.
+
+## Outputs (1 - 1)
+
+- **output** (T): Output tensor of [N, C/(blocksize * blocksize), H * blocksize, W * blocksize].
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(bool), tensor(complex128), tensor(complex64), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(string), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)
+  Constrain input and output types to all tensor types.

--- a/onnx-spec/ops/DequantizeLinear.md
+++ b/onnx-spec/ops/DequantizeLinear.md
@@ -1,0 +1,42 @@
+# DequantizeLinear
+
+Since opset **24**
+
+## Description
+
+The linear dequantization operator. It consumes a quantized tensor, a scale, and a zero point to compute the
+full-precision tensor. The dequantization formula is `y = (x - x_zero_point) * x_scale`. `x_scale` and `x_zero_point`
+must have the same shape, determining the quantization's granularity: a scalar for per-tensor/per-layer quantization,
+a 1-D tensor for per-axis quantization, or have a rank identical to the input for blocked quantization.
+See QuantizeLinear for details on quantization granularity.
+
+`x_zero_point` and `x` must have the same type. `x` and `y` must have the same shape. In the case of dequantizing
+`int32`, there's no zero point (zero point is supposed to be 0).
+`zero-point` is usually not used in the case of float8 and 4-bit types quantization, but the dequantization formula remains the same
+for consistency. The output type is determined by the attribute `output_dtype`. If `output_dtype` is not supplied then the output type
+is the same as `x_scale`. The output type also determines the precision of the multiplication operation.
+
+## Attributes
+
+- **axis** (INT, optional): (Optional) The axis of the dequantizing dimension of the input tensor. Used for per-axis and blocked quantization. Negative value means counting dimensions from the back. Accepted range is `[-r, r-1]` where `r = rank(input)`.
+- **block_size** (INT, optional): (Optional) The size of the quantization block (number of times every scale is replicated). Used only for blocked quantization. The block size is a positive integer. Given `x` shape `(D0, ..., Di, ..., Dn)`, `y_scale` shape `(S0, ... Si, ...Sn)` and `axis=i`, the accepted range is `[ceil(Di/Si), ceil(Di/(Si-1))-1]`
+- **output_dtype** (INT, optional): (Optional) The output data type. If not supplied, the output data type is inferred from `x_scale` data type (`T2`)
+
+## Inputs (2 - 3)
+
+- **x** (T1): N-D quantized input tensor to be de-quantized.
+- **x_scale** (T2): Scale for input `x`. For per-tensor/layer dequantization the scale is a scalar, for per per-axis dequantization it is a 1-D Tensor and for blocked dequantization it has the same shape as the input, except for one dimension in which blocking is performed.
+- **x_zero_point** (T1, optional): Zero point for input `x`. Shape must match x_scale. It's optional. Zero point is 0 when it's not specified.
+
+## Outputs (1 - 1)
+
+- **y** (T3): N-D full precision output tensor. It has the same shape as input `x`. The data type is specified by the `output_dtype` attribute or, in its absence, the type of `x_scale`.
+
+## Type Constraints
+
+- **T1**: tensor(float4e2m1), tensor(float8e4m3fn), tensor(float8e4m3fnuz), tensor(float8e5m2), tensor(float8e5m2fnuz), tensor(int16), tensor(int32), tensor(int4), tensor(int8), tensor(uint16), tensor(uint4), tensor(uint8)
+  The type of the inputs 'x_zero_point' and 'x'.
+- **T2**: tensor(bfloat16), tensor(float), tensor(float16), tensor(float8e8m0)
+  The type of the input 'x_scale'.
+- **T3**: tensor(bfloat16), tensor(float), tensor(float16)
+  The type of the output 'y'.

--- a/onnx-spec/ops/Det.md
+++ b/onnx-spec/ops/Det.md
@@ -1,0 +1,24 @@
+# Det
+
+Since opset **22**
+
+## Description
+
+Det calculates determinant of a square matrix or batches of square matrices.
+Det takes one input tensor of shape `[*, M, M]`, where `*` is zero or more batch dimensions,
+and the inner-most 2 dimensions form square matrices.
+The output is a tensor of shape `[*]`, containing the determinants of all input submatrices.
+e.g., When the input is 2-D, the output is a scalar(shape is empty: `[]`).
+
+## Inputs (1 - 1)
+
+- **X** (T): Input tensor
+
+## Outputs (1 - 1)
+
+- **Y** (T): Output tensor
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain input and output types to floating-point tensors.

--- a/onnx-spec/ops/Div.md
+++ b/onnx-spec/ops/Div.md
@@ -1,0 +1,25 @@
+# Div
+
+Since opset **14**
+
+## Description
+
+Performs element-wise binary division (with Numpy-style broadcasting support).
+
+This operator supports **multidirectional (i.e., Numpy-style) broadcasting**; for more details please check [the doc](Broadcasting.md).
+
+(Opset 14 change): Extend supported types to include uint8, int8, uint16, and int16.
+
+## Inputs (2 - 2)
+
+- **A** (T): First operand.
+- **B** (T): Second operand.
+
+## Outputs (1 - 1)
+
+- **C** (T): Result, has same element type as two inputs
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)
+  Constrain input and output types to all numeric tensors.

--- a/onnx-spec/ops/Dropout.md
+++ b/onnx-spec/ops/Dropout.md
@@ -1,0 +1,42 @@
+# Dropout
+
+Since opset **22**
+
+## Description
+
+Dropout takes an input floating-point tensor, an optional input ratio (floating-point scalar) and an optional input training_mode (boolean scalar). It produces two tensor outputs,
+output (floating-point tensor) and mask (optional `Tensor<bool>`). If `training_mode` is true then the output Y will be a random dropout;
+Note that this Dropout scales the masked input data by the following equation, so to convert the trained model into inference mode,
+the user can simply not pass `training_mode` input or set it to false.
+```
+output = scale * data * mask,
+```
+where
+```
+scale = 1. / (1. - ratio).
+```
+This operator has **optional** inputs/outputs. See [the doc](IR.md) for more details about the representation of optional arguments. An empty string may be used in the place of an actual argument's name to indicate a missing argument. Trailing optional arguments (those not followed by an argument that is present) may also be simply omitted.
+
+## Attributes
+
+- **seed** (INT, optional): (Optional) Seed to the random generator, if not specified we will auto generate one.
+
+## Inputs (1 - 3)
+
+- **data** (T): The input data as Tensor.
+- **ratio** (T1, optional): The ratio of random dropout, with value in [0, 1). If set to 0, the output would be a simple copy of the input. If it's non-zero, output will be a random dropout of the scaled input, which is typically the case during training. It is an optional value, if not specified it will default to 0.5.
+- **training_mode** (T2, optional): If set to true then it indicates dropout is being used for training. It is an optional value hence unless specified explicitly, it is false. If it is false, ratio is ignored and the operation mimics inference mode where nothing will be dropped from the input data and if mask is requested as output it will contain all ones.
+
+## Outputs (1 - 2)
+
+- **output** (T): The output.
+- **mask** (T2, optional): The output mask.
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16), tensor(float8e4m3fn), tensor(float8e4m3fnuz), tensor(float8e5m2), tensor(float8e5m2fnuz)
+  Constrain input and output types to float tensors.
+- **T1**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16), tensor(float8e4m3fn), tensor(float8e4m3fnuz), tensor(float8e5m2), tensor(float8e5m2fnuz)
+  Constrain input 'ratio' types to float tensors.
+- **T2**: tensor(bool)
+  Constrain output 'mask' types to boolean tensors.

--- a/onnx-spec/ops/DynamicQuantizeLinear.md
+++ b/onnx-spec/ops/DynamicQuantizeLinear.md
@@ -1,0 +1,50 @@
+# DynamicQuantizeLinear
+
+Since opset **11**
+
+## Description
+
+A Function to fuse calculation for Scale, Zero Point and FP32->8Bit conversion of FP32 Input data.
+Outputs Scale, ZeroPoint and Quantized Input for a given FP32 Input.
+Scale is calculated as:
+```
+y_scale = (maximum(0, max(x)) - minimum(0, min(x))) / (qmax - qmin)
+```
+
+* where qmax and qmin are max and min values for quantization range i.e. [0, 255] in case of uint8
+* data range is adjusted to include 0.
+
+Zero point is calculated as:
+```
+intermediate_zero_point = qmin - min(x)/y_scale
+y_zero_point = cast(round(saturate(itermediate_zero_point)))
+```
+
+* where qmax and qmin are max and min values for quantization range .i.e [0, 255] in case of uint8
+* for saturation, it saturates to [0, 255] if it's uint8, or [-127, 127] if it's int8. Right now only uint8 is supported.
+* rounding to nearest ties to even.
+
+Data quantization formula is:
+```
+y = saturate (round (x / y_scale) + y_zero_point)
+```
+
+* for saturation, it saturates to [0, 255] if it's uint8, or [-127, 127] if it's int8. Right now only uint8 is supported.
+* rounding to nearest ties to even.
+
+## Inputs (1 - 1)
+
+- **x** (T1): Input tensor
+
+## Outputs (3 - 3)
+
+- **y** (T2): Quantized output tensor
+- **y_scale** (tensor(float)): Output scale. It's a scalar, which means a per-tensor/layer quantization.
+- **y_zero_point** (T2): Output zero point. It's a scalar, which means a per-tensor/layer quantization.
+
+## Type Constraints
+
+- **T1**: tensor(float)
+  Constrain 'x' to float tensor.
+- **T2**: tensor(uint8)
+  Constrain 'y_zero_point' and 'y' to 8-bit unsigned integer tensor.

--- a/onnx-spec/ops/Einsum.md
+++ b/onnx-spec/ops/Einsum.md
@@ -1,0 +1,48 @@
+# Einsum
+
+Since opset **12**
+
+## Description
+
+An einsum of the form `term1, term2 -> output-term` produces an output tensor using the following equation
+
+```
+output[output-term] = reduce-sum( input1[term1] * input2[term2] )
+```
+
+where the reduce-sum performs a summation over all the indices occurring in the input terms (term1, term2)
+that do not occur in the output-term.
+
+The Einsum operator evaluates algebraic tensor operations on a sequence of tensors, using the Einstein summation
+convention. The equation string contains a comma-separated sequence of lower case letters. Each term corresponds to
+an operand tensor, and the characters within the terms correspond to operands dimensions.
+
+This sequence may be followed by "->" to separate the left and right hand side of the equation.
+If the equation contains "->" followed by the right-hand side, the explicit (not classical) form of the Einstein
+summation is performed, and the right-hand side indices indicate output tensor dimensions. In other cases,
+output indices are (implicitly) set to the alphabetically sorted sequence of indices appearing exactly once in the
+equation.
+
+When a dimension character is repeated in the left-hand side, it represents summation along the dimension.
+
+The equation may contain ellipsis ("...") to enable broadcasting. Ellipsis must indicate a fixed number of dimensions.
+Specifically, every occurrence of ellipsis in the equation must represent the same number of dimensions.
+The right-hand side may contain exactly one ellipsis. In implicit mode, the ellipsis dimensions are set to the
+beginning of the output. The equation string may contain space (U+0020) character.
+
+## Attributes
+
+- **equation** (STRING, required): Einsum expression string.
+
+## Inputs (1 - 2147483647)
+
+- **Inputs** (T, variadic): Operands
+
+## Outputs (1 - 1)
+
+- **Output** (T): Output tensor
+
+## Type Constraints
+
+- **T**: tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)
+  Constrain input and output types to all numerical tensor types.

--- a/onnx-spec/ops/Elu.md
+++ b/onnx-spec/ops/Elu.md
@@ -1,0 +1,26 @@
+# Elu
+
+Since opset **22**
+
+## Description
+
+Elu takes one input data (Tensor<T>) and produces one output data
+(Tensor<T>) where the function `f(x) = alpha * (exp(x) - 1.) for x <
+0`, `f(x) = x for x >= 0`., is applied to the tensor elementwise.
+
+## Attributes
+
+- **alpha** (FLOAT, optional): Coefficient of ELU.
+
+## Inputs (1 - 1)
+
+- **X** (T): Input tensor
+
+## Outputs (1 - 1)
+
+- **Y** (T): Output tensor
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain input and output types to float tensors.

--- a/onnx-spec/ops/Equal.md
+++ b/onnx-spec/ops/Equal.md
@@ -1,0 +1,26 @@
+# Equal
+
+Since opset **19**
+
+## Description
+
+Returns the tensor resulted from performing the `equal` logical operation
+elementwise on the input tensors `A` and `B` (with Numpy-style broadcasting support).
+
+This operator supports **multidirectional (i.e., Numpy-style) broadcasting**; for more details please check [the doc](Broadcasting.md).
+
+## Inputs (2 - 2)
+
+- **A** (T): First input operand for the logical operator.
+- **B** (T): Second input operand for the logical operator.
+
+## Outputs (1 - 1)
+
+- **C** (T1): Result tensor.
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(bool), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(string), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)
+  Constrain input types to all (non-complex) tensors.
+- **T1**: tensor(bool)
+  Constrain output to boolean tensor.

--- a/onnx-spec/ops/Erf.md
+++ b/onnx-spec/ops/Erf.md
@@ -1,0 +1,20 @@
+# Erf
+
+Since opset **13**
+
+## Description
+
+Computes the error function of the given input tensor element-wise.
+
+## Inputs (1 - 1)
+
+- **input** (T): Input tensor
+
+## Outputs (1 - 1)
+
+- **output** (T): The error function of the input tensor computed element-wise. It has the same shape and type of the input.
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)
+  Constrain input and output types to all numeric tensors.

--- a/onnx-spec/ops/Exp.md
+++ b/onnx-spec/ops/Exp.md
@@ -1,0 +1,20 @@
+# Exp
+
+Since opset **13**
+
+## Description
+
+Calculates the exponential of the given input tensor, element-wise.
+
+## Inputs (1 - 1)
+
+- **input** (T): Input tensor
+
+## Outputs (1 - 1)
+
+- **output** (T): The exponential of the input tensor computed element-wise
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain input and output types to float tensors.

--- a/onnx-spec/ops/Expand.md
+++ b/onnx-spec/ops/Expand.md
@@ -1,0 +1,28 @@
+# Expand
+
+Since opset **13**
+
+## Description
+
+Broadcast the input tensor following the given shape and the broadcast rule.
+The broadcast rule is similar to numpy.array(input) * numpy.ones(shape):
+Dimensions are right alignment;
+Two corresponding dimensions must have the same value, or one of them is equal to 1.
+Also, this operator is similar to numpy.broadcast_to(input, shape),
+but the major difference is numpy.broadcast_to() does not allow shape to be smaller than input.size().
+It is possible that the output.shape is not equal to shape, when some dimensions in shape is equal to 1,
+or the shape.ndim < input.shape.ndim.
+
+## Inputs (2 - 2)
+
+- **input** (T): Input tensor
+- **shape** (tensor(int64)): A 1-D tensor indicates the shape you want to expand to, following the broadcast rule
+
+## Outputs (1 - 1)
+
+- **output** (T): Output tensor
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(bool), tensor(complex128), tensor(complex64), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(string), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)
+  Constrain input and output types to all tensors.

--- a/onnx-spec/ops/EyeLike.md
+++ b/onnx-spec/ops/EyeLike.md
@@ -1,0 +1,33 @@
+# EyeLike
+
+Since opset **22**
+
+## Description
+
+Generate a 2D tensor (matrix) with ones on the diagonal and zeros everywhere else. Only 2D
+tensors are supported, i.e. input T1 must be of rank 2. The shape of the output tensor is the
+same as the input tensor. The data type can be specified by the 'dtype' argument. If
+'dtype' is not specified, then the type of input tensor is used. By default, the main diagonal
+is populated with ones, but attribute 'k' can be used to populate upper or lower diagonals.
+The 'dtype' argument must be one of the data types specified in the 'DataType' enum field in the
+TensorProto message and be valid as an output type.
+
+## Attributes
+
+- **dtype** (INT, optional): (Optional) The data type for the elements of the output tensor. If not specified, the data type of the input tensor T1 is used.
+- **k** (INT, optional): (Optional) Index of the diagonal to be populated with ones. Default is 0. If T2 is the output, this op sets T2[i, i+k] = 1. k = 0 populates the main diagonal, k > 0 populates an upper diagonal,  and k < 0 populates a lower diagonal.
+
+## Inputs (1 - 1)
+
+- **input** (T1): 2D input tensor to copy shape, and optionally, type information from.
+
+## Outputs (1 - 1)
+
+- **output** (T2): Output tensor, same shape as input tensor T1.
+
+## Type Constraints
+
+- **T1**: tensor(bfloat16), tensor(bool), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)
+  Constrain input types. Strings and complex are not supported.
+- **T2**: tensor(bfloat16), tensor(bool), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)
+  Constrain output types. Strings and complex are not supported.

--- a/onnx-spec/ops/Flatten.md
+++ b/onnx-spec/ops/Flatten.md
@@ -1,0 +1,26 @@
+# Flatten
+
+Since opset **24**
+
+## Description
+
+Flattens the input tensor into a 2D matrix. If input tensor has shape
+(d_0, d_1, ... d_n) then the output will have shape
+(d_0 X d_1 ... d_(axis-1), d_axis X d_(axis+1) ... X dn).
+
+## Attributes
+
+- **axis** (INT, optional): Indicate up to which input dimensions (exclusive) should be flattened to the outer dimension of the output. The value for axis must be in the range [-r, r], where r is the rank of the input tensor. Negative value means counting dimensions from the back. When axis = 0, the shape of the output tensor is (1, (d_0 X d_1 ... d_n), where the shape of the input tensor is (d_0, d_1, ... d_n).
+
+## Inputs (1 - 1)
+
+- **input** (T): A tensor of rank >= axis.
+
+## Outputs (1 - 1)
+
+- **output** (T): A 2D tensor with the contents of the input tensor, with input dimensions up to axis flattened to the outer dimension of the output and remaining input dimensions flattened into the inner dimension of the output.
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(bool), tensor(complex128), tensor(complex64), tensor(double), tensor(float), tensor(float16), tensor(float4e2m1), tensor(float8e4m3fn), tensor(float8e4m3fnuz), tensor(float8e5m2), tensor(float8e5m2fnuz), tensor(float8e8m0), tensor(int16), tensor(int32), tensor(int4), tensor(int64), tensor(int8), tensor(string), tensor(uint16), tensor(uint32), tensor(uint4), tensor(uint64), tensor(uint8)
+  Constrain input and output to all tensor types up to IRv12.

--- a/onnx-spec/ops/Floor.md
+++ b/onnx-spec/ops/Floor.md
@@ -1,0 +1,22 @@
+# Floor
+
+Since opset **13**
+
+## Description
+
+Floor takes one input data (Tensor<T>) and produces one output data
+(Tensor<T>) where the floor is, y = floor(x), is applied to
+the tensor elementwise. If x is integral, +0, -0, NaN,  or infinite, x itself is returned.
+
+## Inputs (1 - 1)
+
+- **X** (T): Input tensor
+
+## Outputs (1 - 1)
+
+- **Y** (T): Output tensor
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain input and output types to float tensors.

--- a/onnx-spec/ops/GRU.md
+++ b/onnx-spec/ops/GRU.md
@@ -1,0 +1,85 @@
+# GRU
+
+Since opset **22**
+
+## Description
+
+Computes an one-layer GRU. This operator is usually supported via some custom
+implementation such as CuDNN.
+
+Notations:
+
+* `X` - input tensor
+* `z` - update gate
+* `r` - reset gate
+* `h` - hidden gate
+* `t` - time step (t-1 means previous time step)
+* `W[zrh]` - W parameter weight matrix for update, reset, and hidden gates
+* `R[zrh]` - R recurrence weight matrix for update, reset, and hidden gates
+* `Wb[zrh]` - W bias vectors for update, reset, and hidden gates
+* `Rb[zrh]` - R bias vectors for update, reset, and hidden gates
+* `WB[zrh]` - W parameter weight matrix for backward update, reset, and hidden gates
+* `RB[zrh]` - R recurrence weight matrix for backward update, reset, and hidden gates
+* `WBb[zrh]` - W bias vectors for backward update, reset, and hidden gates
+* `RBb[zrh]` - R bias vectors for backward update, reset, and hidden gates
+* `H` - Hidden state
+* `num_directions` - 2 if direction == bidirectional else 1
+
+Activation functions:
+
+* Relu(x)                - max(0, x)
+* Tanh(x)                - (1 - e^{-2x})/(1 + e^{-2x})
+* Sigmoid(x)             - 1/(1 + e^{-x})
+
+NOTE:
+  Below are optional
+
+* Affine(x)              - alpha * x + beta
+* LeakyRelu(x)           - x if x >= 0 else alpha * x
+* ThresholdedRelu(x)     - x if x >= alpha else 0
+* ScaledTanh(x)          - alpha * Tanh(beta * x)
+* HardSigmoid(x)         - min(max(alpha * x + beta, 0), 1)
+* Elu(x)                 - x if x >= 0 else alpha * (e^x - 1)
+* Softsign(x)            - x/(1 + |x|)
+* Softplus(x)            - log(1 + e^x)
+
+Equations (Default: f=Sigmoid, g=Tanh):
+
+* zt = f(Xt*(Wz^T) + Ht-1*(Rz^T) + Wbz + Rbz)
+* rt = f(Xt*(Wr^T) + Ht-1*(Rr^T) + Wbr + Rbr)
+* ht = g(Xt*(Wh^T) + (rt (.) Ht-1)*(Rh^T) + Rbh + Wbh) # default, when linear_before_reset = 0
+* ht = g(Xt*(Wh^T) + (rt (.) (Ht-1*(Rh^T) + Rbh)) + Wbh) # when linear_before_reset != 0
+* Ht = (1 - zt) (.) ht + zt (.) Ht-1
+This operator has **optional** inputs/outputs. See [the doc](IR.md) for more details about the representation of optional arguments. An empty string may be used in the place of an actual argument's name to indicate a missing argument. Trailing optional arguments (those not followed by an argument that is present) may also be simply omitted.
+
+## Attributes
+
+- **activation_alpha** (FLOATS, optional): Optional scaling values used by some activation functions. The values are consumed in the order of activation functions, for example (f, g, h) in LSTM. Default values are the same as of corresponding ONNX operators.For example with LeakyRelu, the default alpha is 0.01.
+- **activation_beta** (FLOATS, optional): Optional scaling values used by some activation functions. The values are consumed in the order of activation functions, for example (f, g, h) in LSTM. Default values are the same as of corresponding ONNX operators.
+- **activations** (STRINGS, optional): A list of 2 (or 4 if bidirectional) activation functions for update, reset, and hidden gates. The activation functions must be one of the activation functions specified above. Optional: See the equations for default if not specified.
+- **clip** (FLOAT, optional): Cell clip threshold. Clipping bounds the elements of a tensor in the range of [-threshold, +threshold] and is applied to the input of activations. No clip if not specified.
+- **direction** (STRING, optional): Specify if the RNN is forward, reverse, or bidirectional. Must be one of forward (default), reverse, or bidirectional.
+- **hidden_size** (INT, optional): Number of neurons in the hidden layer
+- **layout** (INT, optional): The shape format of inputs X, initial_h and outputs Y, Y_h. If 0, the following shapes are expected: X.shape = [seq_length, batch_size, input_size], Y.shape = [seq_length, num_directions, batch_size, hidden_size], initial_h.shape = Y_h.shape = [num_directions, batch_size, hidden_size]. If 1, the following shapes are expected: X.shape = [batch_size, seq_length, input_size], Y.shape = [batch_size, seq_length, num_directions, hidden_size], initial_h.shape = Y_h.shape = [batch_size, num_directions, hidden_size].
+- **linear_before_reset** (INT, optional): When computing the output of the hidden gate, apply the linear transformation before multiplying by the output of the reset gate.
+
+## Inputs (3 - 6)
+
+- **X** (T): The input sequences packed (and potentially padded) into one 3-D tensor with the shape of `[seq_length, batch_size, input_size]`.
+- **W** (T): The weight tensor for the gates. Concatenation of `W[zrh]` and `WB[zrh]` (if bidirectional) along dimension 0. This tensor has shape `[num_directions, 3*hidden_size, input_size]`.
+- **R** (T): The recurrence weight tensor. Concatenation of `R[zrh]` and `RB[zrh]` (if bidirectional) along dimension 0. This tensor has shape `[num_directions, 3*hidden_size, hidden_size]`.
+- **B** (T, optional): The bias tensor for the gates. Concatenation of `[Wb[zrh], Rb[zrh]]` and `[WBb[zrh], RBb[zrh]]` (if bidirectional) along dimension 0. This tensor has shape `[num_directions, 6*hidden_size]`. Optional: If not specified - assumed to be 0
+- **sequence_lens** (T1, optional): Optional tensor specifying lengths of the sequences in a batch. If not specified - assumed all sequences in the batch to have length `seq_length`. It has shape `[batch_size]`.
+- **initial_h** (T, optional): Optional initial value of the hidden. If not specified - assumed to be 0. It has shape `[num_directions, batch_size, hidden_size]`.
+
+## Outputs (0 - 2)
+
+- **Y** (T, optional): A tensor that concats all the intermediate output values of the hidden. It has shape `[seq_length, num_directions, batch_size, hidden_size]`.
+- **Y_h** (T, optional): The last output value of the hidden. It has shape `[num_directions, batch_size, hidden_size]`.
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain input and output types to float tensors.
+- **T1**: tensor(int32)
+  Constrain seq_lens to integer tensor.

--- a/onnx-spec/ops/Gather.md
+++ b/onnx-spec/ops/Gather.md
@@ -1,0 +1,89 @@
+# Gather
+
+Since opset **13**
+
+## Description
+
+Given `data` tensor of rank r >= 1, and `indices` tensor of rank q, gather
+entries of the axis dimension of `data` (by default outer-most one as axis=0) indexed by `indices`, and concatenates
+them in an output tensor of rank q + (r - 1).
+
+It is an indexing operation that indexes into the input `data` along a single (specified) axis.
+Each entry in `indices` produces a `r-1` dimensional slice of the input tensor.
+The entire operation produces, conceptually, a `q`-dimensional tensor of `r-1` dimensional slices,
+which is arranged into a `q + (r-1)`-dimensional tensor, with the `q` dimensions taking the
+place of the original `axis` that is being indexed into.
+
+The following few examples illustrate how `Gather` works for specific shapes of `data`,
+`indices`, and given value of `axis`:
+| data shape | indices shape | axis | output shape | output equation |
+| --- | --- | --- | --- | --- |
+| (P, Q) | ( )  (a scalar)   | 0 | (Q)       | output[q] = data[indices, q] |
+| (P, Q, R) | ( )  (a scalar)   | 1 | (P, R)       | output[p, r] = data[p, indices, r] |
+| (P, Q) | (R, S) | 0 | (R, S, Q) | output[r, s, q] = data[ [indices[r, s], q] |
+| (P, Q) | (R, S) | 1 | (P, R, S) | output[p, r, s] = data[ p, indices[r, s]] |
+
+More generally, if `axis = 0`, let `k = indices[i_{0}, ..., i_{q-1}]`
+then `output[i_{0}, ..., i_{q-1}, j_{0}, ..., j_{r-2}] = input[k , j_{0}, ..., j_{r-2}]`:
+
+```
+data = [
+    [1.0, 1.2],
+    [2.3, 3.4],
+    [4.5, 5.7],
+]
+indices = [
+    [0, 1],
+    [1, 2],
+]
+output = [
+    [
+        [1.0, 1.2],
+        [2.3, 3.4],
+    ],
+    [
+        [2.3, 3.4],
+        [4.5, 5.7],
+    ],
+]
+```
+
+If `axis = 1`, let `k = indices[i_{0}, ..., i_{q-1}]`
+then `output[j_{0}, i_{0}, ..., i_{q-1}, j_{1}, ..., j_{r-2}] = input[j_{0}, k, j_{1}, ..., j_{r-2}]`:
+
+```
+data = [
+    [1.0, 1.2, 1.9],
+    [2.3, 3.4, 3.9],
+    [4.5, 5.7, 5.9],
+]
+indices = [
+    [0, 2],
+]
+axis = 1,
+output = [
+        [[1.0, 1.9]],
+        [[2.3, 3.9]],
+        [[4.5, 5.9]],
+]
+```
+
+## Attributes
+
+- **axis** (INT, optional): Which axis to gather on. Negative value means counting dimensions from the back. Accepted range is [-r, r-1] where r = rank(data).
+
+## Inputs (2 - 2)
+
+- **data** (T): Tensor of rank r >= 1.
+- **indices** (Tind): Tensor of int32/int64 indices, of any rank q. All index values are expected to be within bounds [-s, s-1] along axis of size s. It is an error if any of the index values are out of bounds.
+
+## Outputs (1 - 1)
+
+- **output** (T): Tensor of rank q + (r - 1).
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(bool), tensor(complex128), tensor(complex64), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(string), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)
+  Constrain input and output types to any tensor type.
+- **Tind**: tensor(int32), tensor(int64)
+  Constrain indices to integer types

--- a/onnx-spec/ops/GatherElements.md
+++ b/onnx-spec/ops/GatherElements.md
@@ -1,0 +1,77 @@
+# GatherElements
+
+Since opset **13**
+
+## Description
+
+GatherElements takes two inputs `data` and `indices` of the same rank r >= 1
+and an optional attribute `axis` that identifies an axis of `data`
+(by default, the outer-most axis, that is axis 0). It is an indexing operation
+that produces its output by indexing into the input data tensor at index
+positions determined by elements of the `indices` tensor.
+Its output shape is the same as the shape of `indices` and consists of one value
+(gathered from the `data`) for each element in `indices`.
+
+For instance, in the 3-D case (r = 3), the output produced is determined
+by the following equations:
+```
+out[i][j][k] = input[index[i][j][k]][j][k] if axis = 0,
+out[i][j][k] = input[i][index[i][j][k]][k] if axis = 1,
+out[i][j][k] = input[i][j][index[i][j][k]] if axis = 2,
+```
+
+This operator is also the inverse of ScatterElements. It is similar to Torch's gather operation.
+
+Example 1:
+```
+data = [
+    [1, 2],
+    [3, 4],
+]
+indices = [
+    [0, 0],
+    [1, 0],
+]
+axis = 1
+output = [
+    [1, 1],
+    [4, 3],
+]
+```
+Example 2:
+```
+data = [
+    [1, 2, 3],
+    [4, 5, 6],
+    [7, 8, 9],
+]
+indices = [
+    [1, 2, 0],
+    [2, 0, 0],
+]
+axis = 0
+output = [
+    [4, 8, 3],
+    [7, 2, 3],
+]
+```
+
+## Attributes
+
+- **axis** (INT, optional): Which axis to gather on. Negative value means counting dimensions from the back. Accepted range is [-r, r-1] where r = rank(data).
+
+## Inputs (2 - 2)
+
+- **data** (T): Tensor of rank r >= 1.
+- **indices** (Tind): Tensor of int32/int64 indices, with the same rank r as the input. All index values are expected to be within bounds [-s, s-1] along axis of size s. It is an error if any of the index values are out of bounds.
+
+## Outputs (1 - 1)
+
+- **output** (T): Tensor of the same shape as indices.
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(bool), tensor(complex128), tensor(complex64), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(string), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)
+  Constrain input and output types to any tensor type.
+- **Tind**: tensor(int32), tensor(int64)
+  Constrain indices to integer types

--- a/onnx-spec/ops/GatherND.md
+++ b/onnx-spec/ops/GatherND.md
@@ -1,0 +1,108 @@
+# GatherND
+
+Since opset **13**
+
+## Description
+
+Given `data` tensor of rank `r` >= 1, `indices` tensor of rank `q` >= 1, and `batch_dims` integer `b`, this operator gathers
+slices of `data` into an output tensor of rank `q + r - indices_shape[-1] - 1 - b`.
+
+`indices` is an q-dimensional integer tensor, best thought of as a `(q-1)`-dimensional tensor of index-tuples into `data`,
+where each element defines a slice of `data`
+
+`batch_dims` (denoted as `b`) is an integer indicating the number of batch dimensions, i.e the leading `b` number of dimensions of
+`data` tensor and `indices` are representing the batches, and the gather starts from the `b+1` dimension.
+
+Some salient points about the inputs' rank and shape:
+
+1) r >= 1 and q >= 1 are to be honored. There is no dependency condition to be met between ranks `r` and `q`
+
+2) The first `b` dimensions of the shape of `indices` tensor and `data` tensor must be equal.
+
+3) b < min(q, r) is to be honored.
+
+4) The `indices_shape[-1]` should have a value between 1 (inclusive) and rank `r-b` (inclusive)
+
+5) All values in `indices` are expected to be within bounds [-s, s-1] along axis of size `s` (i.e.) `-data_shape[i] <= indices[...,i] <= data_shape[i] - 1`.
+   It is an error if any of the index values are out of bounds.
+
+The output is computed as follows:
+
+The output tensor is obtained by mapping each index-tuple in the `indices` tensor to the corresponding slice of the input `data`.
+
+1) If `indices_shape[-1] > r-b` => error condition
+
+2) If `indices_shape[-1] == r-b`, since the rank of `indices` is `q`, `indices` can be thought of as `N` `(q-b-1)`-dimensional tensors
+   containing 1-D tensors of dimension `r-b`, where `N` is an integer equals to the product of 1 and all the elements in the batch dimensions
+   of the indices_shape. Let us think of each such `r-b` ranked tensor as `indices_slice`. Each *scalar value* corresponding to `data[0:b-1,indices_slice]`
+   is filled into the corresponding location of the `(q-b-1)`-dimensional tensor to form the `output` tensor (Example 1 below)
+
+3) If `indices_shape[-1] < r-b`, since the rank of `indices` is `q`, `indices` can be thought of as `N` `(q-b-1)`-dimensional tensor
+   containing 1-D tensors of dimension `< r-b`. Let us think of each such tensors as `indices_slice`. Each *tensor slice* corresponding
+   to `data[0:b-1, indices_slice , :]` is filled into the corresponding location of the `(q-b-1)`-dimensional tensor
+   to form the `output` tensor (Examples 2, 3, 4 and 5 below)
+
+This operator is the inverse of `ScatterND`.
+
+**Example 1**
+
+```
+batch_dims = 0
+data    = [[0,1],[2,3]]   # data_shape    = [2, 2]
+indices = [[0,0],[1,1]]   # indices_shape = [2, 2]
+output  = [0,3]           # output_shape  = [2]
+```
+
+**Example 2**
+
+```
+batch_dims = 0
+data    = [[0,1],[2,3]]  # data_shape    = [2, 2]
+indices = [[1],[0]]      # indices_shape = [2, 1]
+output  = [[2,3],[0,1]]  # output_shape  = [2, 2]
+```
+
+**Example 3**
+
+```
+batch_dims = 0
+data    = [[[0,1],[2,3]],[[4,5],[6,7]]] # data_shape    = [2, 2, 2]
+indices = [[0,1],[1,0]]                 # indices_shape = [2, 2]
+output  = [[2,3],[4,5]]                 # output_shape  = [2, 2]
+```
+
+**Example 4**
+
+```
+batch_dims = 0
+data    = [[[0,1],[2,3]],[[4,5],[6,7]]] # data_shape    = [2, 2, 2]
+indices = [[[0,1]],[[1,0]]]             # indices_shape = [2, 1, 2]
+output  = [[[2,3]],[[4,5]]]             # output_shape  = [2, 1, 2]
+```
+
+**Example 5**
+
+```
+batch_dims = 1
+data    = [[[0,1],[2,3]],[[4,5],[6,7]]] # data_shape    = [2, 2, 2]
+indices = [[1],[0]]                     # indices_shape = [2, 1]
+output  = [[2,3],[4,5]]                 # output_shape  = [2, 2]
+```
+
+## Attributes
+
+- **batch_dims** (INT, optional): The number of batch dimensions. The gather of indexing starts from dimension of data[batch_dims:]
+
+## Inputs (2 - 2)
+
+- **data** (T): Tensor of rank r >= 1.
+- **indices** (tensor(int64)): Tensor of rank q >= 1. All index values are expected to be within bounds [-s, s-1] along axis of size s. It is an error if any of the index values are out of bounds.
+
+## Outputs (1 - 1)
+
+- **output** (T): Tensor of rank q + r - indices_shape[-1] - 1.
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(bool), tensor(complex128), tensor(complex64), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(string), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)
+  Constrain input and output types to any tensor type.

--- a/onnx-spec/ops/Gelu.md
+++ b/onnx-spec/ops/Gelu.md
@@ -1,0 +1,29 @@
+# Gelu
+
+Since opset **20**
+
+## Description
+
+Gelu takes one input data (Tensor<T>) and produces one
+output data (Tensor<T>) where the gaussian error linear units function,
+$y = 0.5 * x * (1 + erf(x/sqrt(2)))$ is applied to the tensor elementwise.
+If the attribute "approximate" is set to "tanh", the function estimation,
+$y = 0.5 * x * (1 + Tanh(sqrt(2/\pi) * (x + 0.044715 * x^3)))$ is used and applied
+to the tensor elementwise.
+
+## Attributes
+
+- **approximate** (STRING, optional): Gelu approximation algorithm: `"tanh"`, `"none"`(default).`"none"`: do not use approximation.`"tanh"`: use tanh approximation.
+
+## Inputs (1 - 1)
+
+- **X** (T): Input tensor
+
+## Outputs (1 - 1)
+
+- **Y** (T): Output tensor
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain input and output types to float tensors.

--- a/onnx-spec/ops/Gemm.md
+++ b/onnx-spec/ops/Gemm.md
@@ -1,0 +1,40 @@
+# Gemm
+
+Since opset **13**
+
+## Description
+
+General Matrix multiplication:
+https://en.wikipedia.org/wiki/Basic_Linear_Algebra_Subprograms#Level_3
+
+* A' = transpose(A) if transA else A
+* B' = transpose(B) if transB else B
+
+Compute Y = alpha * A' * B' + beta * C, where input tensor A has shape (M, K) or (K, M),
+input tensor B has shape (K, N) or (N, K), input tensor C is broadcastable to shape (M, N),
+and output tensor Y has shape (M, N). A will be transposed before doing the
+computation if attribute transA is non-zero, same for B and transB.
+This operator supports **unidirectional broadcasting** (tensor C should be unidirectional broadcastable to tensor A * B); for more details please check [the doc](Broadcasting.md).
+This operator has **optional** inputs/outputs. See [the doc](IR.md) for more details about the representation of optional arguments. An empty string may be used in the place of an actual argument's name to indicate a missing argument. Trailing optional arguments (those not followed by an argument that is present) may also be simply omitted.
+
+## Attributes
+
+- **alpha** (FLOAT, optional): Scalar multiplier for the product of input tensors A * B.
+- **beta** (FLOAT, optional): Scalar multiplier for input tensor C.
+- **transA** (INT, optional): Whether A should be transposed
+- **transB** (INT, optional): Whether B should be transposed
+
+## Inputs (2 - 3)
+
+- **A** (T): Input tensor A. The shape of A should be (M, K) if transA is 0, or (K, M) if transA is non-zero.
+- **B** (T): Input tensor B. The shape of B should be (K, N) if transB is 0, or (N, K) if transB is non-zero.
+- **C** (T, optional): Optional input tensor C. If not specified, the computation is done as if C is a scalar 0. The shape of C should be unidirectional broadcastable to (M, N).
+
+## Outputs (1 - 1)
+
+- **Y** (T): Output tensor of shape (M, N).
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16), tensor(int32), tensor(int64), tensor(uint32), tensor(uint64)
+  Constrain input and output types to float/int tensors.

--- a/onnx-spec/ops/GlobalAveragePool.md
+++ b/onnx-spec/ops/GlobalAveragePool.md
@@ -1,0 +1,22 @@
+# GlobalAveragePool
+
+Since opset **22**
+
+## Description
+
+GlobalAveragePool consumes an input tensor X and applies average pooling across
+ the values in the same channel. This is equivalent to AveragePool with kernel size
+ equal to the spatial dimension of input tensor.
+
+## Inputs (1 - 1)
+
+- **X** (T): Input data tensor from the previous operator; dimensions for image case are (N x C x H x W), where N is the batch size, C is the number of channels, and H and W are the height and the width of the data. For non image case, the dimensions are in the form of (N x C x D1 x D2 ... Dn), where N is the batch size.
+
+## Outputs (1 - 1)
+
+- **Y** (T): Output data tensor from pooling across the input tensor. The output tensor has the same rank as the input. The first two dimensions of output shape are the same as the input (N x C), while the other dimensions are all 1.
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain input and output types to float tensors.

--- a/onnx-spec/ops/GlobalLpPool.md
+++ b/onnx-spec/ops/GlobalLpPool.md
@@ -1,0 +1,26 @@
+# GlobalLpPool
+
+Since opset **22**
+
+## Description
+
+GlobalLpPool consumes an input tensor X and applies lp pool pooling across
+ the values in the same channel. This is equivalent to LpPool with kernel size
+ equal to the spatial dimension of input tensor.
+
+## Attributes
+
+- **p** (INT, optional): p value of the Lp norm used to pool over the input data.
+
+## Inputs (1 - 1)
+
+- **X** (T): Input data tensor from the previous operator; dimensions for image case are (N x C x H x W), where N is the batch size, C is the number of channels, and H and W are the height and the width of the data. For non image case, the dimensions are in the form of (N x C x D1 x D2 ... Dn), where N is the batch size.
+
+## Outputs (1 - 1)
+
+- **Y** (T): Output data tensor from pooling across the input tensor. The output tensor has the same rank as the input. The first two dimensions of output shape are the same as the input (N x C), while the other dimensions are all 1.
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain input and output types to float tensors.

--- a/onnx-spec/ops/GlobalMaxPool.md
+++ b/onnx-spec/ops/GlobalMaxPool.md
@@ -1,0 +1,22 @@
+# GlobalMaxPool
+
+Since opset **22**
+
+## Description
+
+GlobalMaxPool consumes an input tensor X and applies max pooling across
+ the values in the same channel. This is equivalent to MaxPool with kernel size
+ equal to the spatial dimension of input tensor.
+
+## Inputs (1 - 1)
+
+- **X** (T): Input data tensor from the previous operator; dimensions for image case are (N x C x H x W), where N is the batch size, C is the number of channels, and H and W are the height and the width of the data. For non image case, the dimensions are in the form of (N x C x D1 x D2 ... Dn), where N is the batch size.
+
+## Outputs (1 - 1)
+
+- **Y** (T): Output data tensor from pooling across the input tensor. The output tensor has the same rank as the input. The first two dimensions of output shape are the same as the input (N x C), while the other dimensions are all 1.
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain input and output types to float tensors.

--- a/onnx-spec/ops/Greater.md
+++ b/onnx-spec/ops/Greater.md
@@ -1,0 +1,26 @@
+# Greater
+
+Since opset **13**
+
+## Description
+
+Returns the tensor resulted from performing the `greater` logical operation
+elementwise on the input tensors `A` and `B` (with Numpy-style broadcasting support).
+
+This operator supports **multidirectional (i.e., Numpy-style) broadcasting**; for more details please check [the doc](Broadcasting.md).
+
+## Inputs (2 - 2)
+
+- **A** (T): First input operand for the logical operator.
+- **B** (T): Second input operand for the logical operator.
+
+## Outputs (1 - 1)
+
+- **C** (T1): Result tensor.
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)
+  Constrain input types to all numeric tensors.
+- **T1**: tensor(bool)
+  Constrain output to boolean tensor.

--- a/onnx-spec/ops/GreaterOrEqual.md
+++ b/onnx-spec/ops/GreaterOrEqual.md
@@ -1,0 +1,26 @@
+# GreaterOrEqual
+
+Since opset **16**
+
+## Description
+
+Returns the tensor resulted from performing the `greater_equal` logical operation
+elementwise on the input tensors `A` and `B` (with Numpy-style broadcasting support).
+
+This operator supports **multidirectional (i.e., Numpy-style) broadcasting**; for more details please check [the doc](Broadcasting.md).
+
+## Inputs (2 - 2)
+
+- **A** (T): First input operand for the logical operator.
+- **B** (T): Second input operand for the logical operator.
+
+## Outputs (1 - 1)
+
+- **C** (T1): Result tensor.
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)
+  Constrain input types to all numeric tensors.
+- **T1**: tensor(bool)
+  Constrain output to boolean tensor.

--- a/onnx-spec/ops/GridSample.md
+++ b/onnx-spec/ops/GridSample.md
@@ -1,0 +1,46 @@
+# GridSample
+
+Since opset **22**
+
+## Description
+
+Given an input `X` and a flow-field `grid`, computes the output `Y` using `X` values and pixel locations from the `grid`.
+For spatial input `X` with shape (N, C, H, W), the `grid` will have shape (N, H_out, W_out, 2),
+the output `Y` will have shape (N, C, H_out, W_out). For volumetric input `X` with shape (N, C, D, H, W),
+the `grid` will have shape (N, D_out, H_out, W_out, 3), the output `Y` will have shape (N, C, D_out, H_out, W_out).
+More generally, for an input `X` of rank r+2 with shape (N, C, d1, d2, ..., dr),
+the `grid` will have shape (N, D1_out, D2_out, ..., Dr_out, r), the output `Y` will have shape (N, C, D1_out, D2_out, ..., Dr_out).
+
+The tensor `X` contains values at centers of square pixels (voxels, etc) locations such as (n, c, d1_in, d2_in, ..., dr_in).
+The (n, d1_out, d2_out, ..., dr_out, :) values from the tensor `grid` are the normalized positions for interpolating the values
+at the (n, c, d1_out, d2_out, ..., dr_out) locations from the output tensor `Y` using a specified interpolation method (the mode)
+and a padding mode (for `grid` positions falling outside the 2-dimensional image).
+
+For example, the values in `grid[n, h_out, w_out, :]` are size-2 vectors specifying normalized positions in the 2-dimensional space of `X`.
+They are used to interpolate output values of `Y[n, c, h_out, w_out]`.
+
+The GridSample operator is often used in doing grid generator and sampler in the
+[Spatial Transformer Networks](https://arxiv.org/abs/1506.02025).
+See also in [torch.nn.functional.grid_sample](https://pytorch.org/docs/stable/generated/torch.nn.functional.grid_sample.html).
+
+## Attributes
+
+- **align_corners** (INT, optional): If align_corners=1, the extrema (-1 and 1) are considered as referring to the center points of the input's corner pixels (voxels, etc.). If align_corners=0, they are instead considered as referring to the corner points of the input's corner pixels (voxels, etc.), making the sampling more resolution agnostic.
+- **mode** (STRING, optional): Three interpolation modes: linear (default), nearest and cubic. The "linear" mode includes linear and N-linear interpolation modes depending on the number of spatial dimensions of the input tensor (i.e. linear for 1 spatial dimension, bilinear for 2 spatial dimensions, etc.). The "cubic" mode also includes N-cubic interpolation modes following the same rules. The "nearest" mode rounds to the nearest even index when the sampling point falls halfway between two indices.
+- **padding_mode** (STRING, optional): Support padding modes for outside grid values: `zeros`(default), `border`, `reflection`. zeros: use 0 for out-of-bound grid locations, border: use border values for out-of-bound grid locations, reflection: use values at locations reflected by the border for out-of-bound grid locations. If index 0 represents the margin pixel, the reflected value at index -1 will be the same as the value at index 1. For location far away from the border, it will keep being reflected until becoming in bound. If pixel location x = -3.5 reflects by border -1 and becomes x' = 1.5, then reflects by border 1 and becomes x'' = 0.5.
+
+## Inputs (2 - 2)
+
+- **X** (T1): Input tensor of rank r+2 that has shape (N, C, D1, D2, ..., Dr), where N is the batch size, C is the number of channels, D1, D2, ..., Dr are the spatial dimensions.
+- **grid** (T2): Input offset of shape (N, D1_out, D2_out, ..., Dr_out, r), where D1_out, D2_out, ..., Dr_out are the spatial dimensions of the grid and output, and r is the number of spatial dimensions. Grid specifies the sampling locations normalized by the input spatial dimensions. Therefore, it should have most values in the range of [-1, 1]. If the grid has values outside the range of [-1, 1], the corresponding outputs will be handled as defined by padding_mode. Following computer vision convention, the coordinates in the length-r location vector are listed from the innermost tensor dimension to the outermost, the opposite of regular tensor indexing.
+
+## Outputs (1 - 1)
+
+- **Y** (T1): Output tensor of rank r+2 that has shape (N, C, D1_out, D2_out, ..., Dr_out) of the sampled values. For integer input types, intermediate values are computed as floating point and cast to integer at the end.
+
+## Type Constraints
+
+- **T1**: tensor(bfloat16), tensor(bool), tensor(complex128), tensor(complex64), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(string), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)
+  Constrain input `X` and output `Y` types to all tensor types.
+- **T2**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain grid types to float tensors.

--- a/onnx-spec/ops/GroupNormalization.md
+++ b/onnx-spec/ops/GroupNormalization.md
@@ -1,0 +1,50 @@
+# GroupNormalization
+
+Since opset **21**
+
+## Description
+
+A GroupNormalization function. Carries out group normalization as described in
+the paper https://arxiv.org/abs/1803.08494
+
+This operator transforms input according to
+```
+y = scale * (x - mean) / sqrt(variance + epsilon) + bias,
+```
+where the mean and variance are computed per instance per group of channels, and
+`scale` and `bias` should be specified for each channel. The number of
+groups `num_groups` should be divisible by the number of channels so that there are
+an equal number of channels per group.
+
+The overall computation has two stages: the first stage normalizes the elements to
+have zero mean and unit variance for each instance in each group, and the second
+stage scales and shifts the results of the first stage. The floating-point precision
+used in the first stage is determined by the `stash_type` attribute. For example,
+if `stash_type` is 1, the operator casts all input variables to 32-bit float,
+performs the computation, and finally casts the normalized results back to the
+original type of `X`. The second stage does not depend on `stash_type`.
+
+When the number of groups is the same as the number of channels, this operator is
+equivalent to InstanceNormalization. When there is only one group, this operator
+is equivalent to LayerNormalization.
+
+## Attributes
+
+- **epsilon** (FLOAT, optional): The epsilon value to use to avoid division by zero.
+- **num_groups** (INT, required): The number of groups of channels. It should be a divisor of the number of channels `C`.
+- **stash_type** (INT, optional): The floating-point precision used in stage one of the computation.
+
+## Inputs (3 - 3)
+
+- **X** (T): Input data tensor. Dimensions for image cases are `(N x C x H x W)`, where `N` is the batch size, `C` is the number of channels, and `H` and `W` are the height and width of the data. Statistics are computed for every group of channels over `C`, `H`, and `W`. For non-image cases, the dimensions are in the form of `(N x C x D1 x D2 ... Dn)`.
+- **scale** (T): Scale tensor of shape `(C)`.
+- **bias** (T): Bias tensor of shape `(C)`.
+
+## Outputs (1 - 1)
+
+- **Y** (T): The output tensor of the same shape as `X`.
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain input and output types to float tensors.

--- a/onnx-spec/ops/HammingWindow.md
+++ b/onnx-spec/ops/HammingWindow.md
@@ -1,0 +1,27 @@
+# HammingWindow
+
+Since opset **17**
+
+## Description
+
+Generates a Hamming window as described in the paper https://ieeexplore.ieee.org/document/1455106.
+
+## Attributes
+
+- **output_datatype** (INT, optional): The data type of the output tensor. Strictly must be one of the values from DataType enum in TensorProto whose values correspond to T2. The default value is 1 = FLOAT.
+- **periodic** (INT, optional): If 1, returns a window to be used as periodic function. If 0, return a symmetric window. When 'periodic' is specified, hann computes a window of length size + 1 and returns the first size points. The default value is 1.
+
+## Inputs (1 - 1)
+
+- **size** (T1): A scalar value indicating the length of the window.
+
+## Outputs (1 - 1)
+
+- **output** (T2): A Hamming window with length: size. The output has the shape: [size].
+
+## Type Constraints
+
+- **T1**: tensor(int32), tensor(int64)
+  Constrain the input size to int64_t.
+- **T2**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)
+  Constrain output types to numeric tensors.

--- a/onnx-spec/ops/HannWindow.md
+++ b/onnx-spec/ops/HannWindow.md
@@ -1,0 +1,27 @@
+# HannWindow
+
+Since opset **17**
+
+## Description
+
+Generates a Hann window as described in the paper https://ieeexplore.ieee.org/document/1455106.
+
+## Attributes
+
+- **output_datatype** (INT, optional): The data type of the output tensor. Strictly must be one of the values from DataType enum in TensorProto whose values correspond to T2. The default value is 1 = FLOAT.
+- **periodic** (INT, optional): If 1, returns a window to be used as periodic function. If 0, return a symmetric window. When 'periodic' is specified, hann computes a window of length size + 1 and returns the first size points. The default value is 1.
+
+## Inputs (1 - 1)
+
+- **size** (T1): A scalar value indicating the length of the window.
+
+## Outputs (1 - 1)
+
+- **output** (T2): A Hann window with length: size. The output has the shape: [size].
+
+## Type Constraints
+
+- **T1**: tensor(int32), tensor(int64)
+  Constrain the input size to int64_t.
+- **T2**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)
+  Constrain output types to numeric tensors.

--- a/onnx-spec/ops/HardSigmoid.md
+++ b/onnx-spec/ops/HardSigmoid.md
@@ -1,0 +1,27 @@
+# HardSigmoid
+
+Since opset **22**
+
+## Description
+
+HardSigmoid takes one input data (Tensor<T>) and produces one output data
+(Tensor<T>) where the HardSigmoid function, y = max(0, min(1, alpha * x + beta)),
+is applied to the tensor elementwise.
+
+## Attributes
+
+- **alpha** (FLOAT, optional): Value of alpha.
+- **beta** (FLOAT, optional): Value of beta.
+
+## Inputs (1 - 1)
+
+- **X** (T): Input tensor
+
+## Outputs (1 - 1)
+
+- **Y** (T): Output tensor
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain input and output types to float tensors.

--- a/onnx-spec/ops/HardSwish.md
+++ b/onnx-spec/ops/HardSwish.md
@@ -1,0 +1,22 @@
+# HardSwish
+
+Since opset **22**
+
+## Description
+
+HardSwish takes one input data (Tensor<T>) and produces one output data (Tensor<T>) where
+the HardSwish function, y = x * max(0, min(1, alpha * x + beta)) = x * HardSigmoid<alpha, beta>(x),
+where alpha = 1/6 and beta = 0.5, is applied to the tensor elementwise.
+
+## Inputs (1 - 1)
+
+- **X** (T): Input tensor
+
+## Outputs (1 - 1)
+
+- **Y** (T): Output tensor
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain input and output types to float tensors.

--- a/onnx-spec/ops/Hardmax.md
+++ b/onnx-spec/ops/Hardmax.md
@@ -1,0 +1,30 @@
+# Hardmax
+
+Since opset **13**
+
+## Description
+
+The operator computes the hardmax values for the given input:
+
+ Hardmax(element in input, axis) = 1 if the element is the first maximum value along the specified axis, 0 otherwise
+
+The "axis" attribute indicates the dimension along which Hardmax
+will be performed. The output tensor has the same shape
+and contains the Hardmax values of the corresponding input.
+
+## Attributes
+
+- **axis** (INT, optional): Describes the dimension Hardmax will be performed on.
+
+## Inputs (1 - 1)
+
+- **input** (T): The input tensor of rank >= axis.
+
+## Outputs (1 - 1)
+
+- **output** (T): The output values with the same shape as the input tensor.
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain input and output types to float tensors.

--- a/onnx-spec/ops/Identity.md
+++ b/onnx-spec/ops/Identity.md
@@ -1,0 +1,20 @@
+# Identity
+
+Since opset **24**
+
+## Description
+
+Identity operator
+
+## Inputs (1 - 1)
+
+- **input** (V): Input tensor
+
+## Outputs (1 - 1)
+
+- **output** (V): Tensor to copy input into.
+
+## Type Constraints
+
+- **V**: optional(seq(tensor(bool))), optional(seq(tensor(complex128))), optional(seq(tensor(complex64))), optional(seq(tensor(double))), optional(seq(tensor(float))), optional(seq(tensor(float16))), optional(seq(tensor(int16))), optional(seq(tensor(int32))), optional(seq(tensor(int64))), optional(seq(tensor(int8))), optional(seq(tensor(string))), optional(seq(tensor(uint16))), optional(seq(tensor(uint32))), optional(seq(tensor(uint64))), optional(seq(tensor(uint8))), optional(tensor(bool)), optional(tensor(complex128)), optional(tensor(complex64)), optional(tensor(double)), optional(tensor(float)), optional(tensor(float16)), optional(tensor(int16)), optional(tensor(int32)), optional(tensor(int64)), optional(tensor(int8)), optional(tensor(string)), optional(tensor(uint16)), optional(tensor(uint32)), optional(tensor(uint64)), optional(tensor(uint8)), seq(tensor(bool)), seq(tensor(complex128)), seq(tensor(complex64)), seq(tensor(double)), seq(tensor(float)), seq(tensor(float16)), seq(tensor(int16)), seq(tensor(int32)), seq(tensor(int64)), seq(tensor(int8)), seq(tensor(string)), seq(tensor(uint16)), seq(tensor(uint32)), seq(tensor(uint64)), seq(tensor(uint8)), tensor(bfloat16), tensor(bool), tensor(complex128), tensor(complex64), tensor(double), tensor(float), tensor(float16), tensor(float4e2m1), tensor(float8e4m3fn), tensor(float8e4m3fnuz), tensor(float8e5m2), tensor(float8e5m2fnuz), tensor(float8e8m0), tensor(int16), tensor(int32), tensor(int4), tensor(int64), tensor(int8), tensor(string), tensor(uint16), tensor(uint32), tensor(uint4), tensor(uint64), tensor(uint8)
+  Constrain input and output types to all tensor, sequence, and optional types.

--- a/onnx-spec/ops/If.md
+++ b/onnx-spec/ops/If.md
@@ -1,0 +1,27 @@
+# If
+
+Since opset **24**
+
+## Description
+
+If conditional
+
+## Attributes
+
+- **else_branch** (GRAPH, required): Graph to run if condition is false. Has N outputs: values you wish to be live-out to the enclosing scope. The number of outputs must match the number of outputs in the then_branch.
+- **then_branch** (GRAPH, required): Graph to run if condition is true. Has N outputs: values you wish to be live-out to the enclosing scope. The number of outputs must match the number of outputs in the else_branch.
+
+## Inputs (1 - 1)
+
+- **cond** (B): Condition for the if. The tensor must contain a single element.
+
+## Outputs (1 - 2147483647)
+
+- **outputs** (V, variadic): Values that are live-out to the enclosing scope. The return values in the `then_branch` and `else_branch` must be of the same data type. The `then_branch` and `else_branch` may produce tensors with the same element type and different shapes. If corresponding outputs from the then-branch and the else-branch have static shapes S1 and S2, then the shape of the corresponding output variable of the if-node (if present) must be compatible with both S1 and S2 as it represents the union of both possible shapes.For example, if in a model file, the first output of `then_branch` is typed float tensor with shape [2] and the first output of `else_branch` is another float tensor with shape [3], If's first output should have (a) no shape set, or (b) a shape of rank 1 with neither `dim_value` nor `dim_param` set, or (c) a shape of rank 1 with a unique `dim_param`. In contrast, the first output cannot have the shape [2] since [2] and [3] are not compatible.
+
+## Type Constraints
+
+- **V**: optional(seq(tensor(bfloat16))), optional(seq(tensor(bool))), optional(seq(tensor(complex128))), optional(seq(tensor(complex64))), optional(seq(tensor(double))), optional(seq(tensor(float))), optional(seq(tensor(float16))), optional(seq(tensor(int16))), optional(seq(tensor(int32))), optional(seq(tensor(int64))), optional(seq(tensor(int8))), optional(seq(tensor(string))), optional(seq(tensor(uint16))), optional(seq(tensor(uint32))), optional(seq(tensor(uint64))), optional(seq(tensor(uint8))), optional(tensor(bfloat16)), optional(tensor(bool)), optional(tensor(complex128)), optional(tensor(complex64)), optional(tensor(double)), optional(tensor(float)), optional(tensor(float16)), optional(tensor(float4e2m1)), optional(tensor(float8e4m3fn)), optional(tensor(float8e4m3fnuz)), optional(tensor(float8e5m2)), optional(tensor(float8e5m2fnuz)), optional(tensor(float8e8m0)), optional(tensor(int16)), optional(tensor(int32)), optional(tensor(int4)), optional(tensor(int64)), optional(tensor(int8)), optional(tensor(string)), optional(tensor(uint16)), optional(tensor(uint32)), optional(tensor(uint4)), optional(tensor(uint64)), optional(tensor(uint8)), seq(tensor(bfloat16)), seq(tensor(bool)), seq(tensor(complex128)), seq(tensor(complex64)), seq(tensor(double)), seq(tensor(float)), seq(tensor(float16)), seq(tensor(float4e2m1)), seq(tensor(float8e4m3fn)), seq(tensor(float8e4m3fnuz)), seq(tensor(float8e5m2)), seq(tensor(float8e5m2fnuz)), seq(tensor(float8e8m0)), seq(tensor(int16)), seq(tensor(int32)), seq(tensor(int4)), seq(tensor(int64)), seq(tensor(int8)), seq(tensor(string)), seq(tensor(uint16)), seq(tensor(uint32)), seq(tensor(uint4)), seq(tensor(uint64)), seq(tensor(uint8)), tensor(bfloat16), tensor(bool), tensor(complex128), tensor(complex64), tensor(double), tensor(float), tensor(float16), tensor(float4e2m1), tensor(float8e4m3fn), tensor(float8e4m3fnuz), tensor(float8e5m2), tensor(float8e5m2fnuz), tensor(float8e8m0), tensor(int16), tensor(int32), tensor(int4), tensor(int64), tensor(int8), tensor(string), tensor(uint16), tensor(uint32), tensor(uint4), tensor(uint64), tensor(uint8)
+  All Tensor, Sequence(Tensor), Optional(Tensor), and Optional(Sequence(Tensor)) types up to IRv11.
+- **B**: tensor(bool)
+  Only bool

--- a/onnx-spec/ops/ImageDecoder.md
+++ b/onnx-spec/ops/ImageDecoder.md
@@ -1,0 +1,48 @@
+# ImageDecoder
+
+Since opset **20**
+
+## Description
+
+Loads and decodes and image from a file. If it can't decode for any reason (e.g. corrupted encoded
+stream, invalid format, it will return an empty matrix).
+The following image formats are supported:
+* BMP
+* JPEG (note: Lossless JPEG support is optional)
+* JPEG2000
+* TIFF
+* PNG
+* WebP
+* Portable image format (PBM, PGM, PPM, PXM, PNM)
+Decoded images follow a channel-last layout: (Height, Width, Channels).
+**JPEG chroma upsampling method:**
+When upsampling the chroma components by a factor of 2, the pixels are linearly interpolated so that the
+centers of the output pixels are 1/4 and 3/4 of the way between input pixel centers.
+When rounding, 0.5 is rounded down and up at alternative pixels locations to prevent bias towards
+larger values (ordered dither pattern).
+Considering adjacent input pixels A, B, and C, B is upsampled to pixels B0 and B1 so that
+```
+B0 = round_half_down((1/4) * A + (3/4) * B)
+B1 = round_half_up((3/4) * B + (1/4) * C)
+```
+This method,  is the default chroma upsampling method in the well-established libjpeg-turbo library,
+also referred as "smooth" or "fancy" upsampling.
+
+## Attributes
+
+- **pixel_format** (STRING, optional): Pixel format. Can be one of "RGB", "BGR", or "Grayscale".
+
+## Inputs (1 - 1)
+
+- **encoded_stream** (T1): Encoded stream
+
+## Outputs (1 - 1)
+
+- **image** (T2): Decoded image
+
+## Type Constraints
+
+- **T1**: tensor(uint8)
+  Constrain input types to 8-bit unsigned integer tensor.
+- **T2**: tensor(uint8)
+  Constrain output types to 8-bit unsigned integer tensor.

--- a/onnx-spec/ops/InstanceNormalization.md
+++ b/onnx-spec/ops/InstanceNormalization.md
@@ -1,0 +1,30 @@
+# InstanceNormalization
+
+Since opset **22**
+
+## Description
+
+Carries out instance normalization as described in the paper
+https://arxiv.org/abs/1607.08022.
+
+y = scale * (x - mean) / sqrt(variance + epsilon) + B,
+where mean and variance are computed per instance per channel.
+
+## Attributes
+
+- **epsilon** (FLOAT, optional): The epsilon value to use to avoid division by zero.
+
+## Inputs (3 - 3)
+
+- **input** (T): Input data tensor from the previous operator; dimensions for image case are (N x C x H x W), where N is the batch size, C is the number of channels, and H and W are the height and the width of the data. For non image case, the dimensions are in the form of (N x C x D1 x D2 ... Dn), where N is the batch size.
+- **scale** (T): The input 1-dimensional scale tensor of size C.
+- **B** (T): The input 1-dimensional bias tensor of size C.
+
+## Outputs (1 - 1)
+
+- **output** (T): The output tensor of the same shape as input.
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain input and output types to float tensors.

--- a/onnx-spec/ops/IsInf.md
+++ b/onnx-spec/ops/IsInf.md
@@ -1,0 +1,27 @@
+# IsInf
+
+Since opset **20**
+
+## Description
+
+Map infinity to true and other values to false.
+
+## Attributes
+
+- **detect_negative** (INT, optional): (Optional) Whether map negative infinity to true. Default to 1 so that negative infinity induces true. Set this attribute to 0 if negative infinity should be mapped to false.
+- **detect_positive** (INT, optional): (Optional) Whether map positive infinity to true. Default to 1 so that positive infinity induces true. Set this attribute to 0 if positive infinity should be mapped to false.
+
+## Inputs (1 - 1)
+
+- **X** (T1): input
+
+## Outputs (1 - 1)
+
+- **Y** (T2): output
+
+## Type Constraints
+
+- **T1**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16), tensor(float8e4m3fn), tensor(float8e4m3fnuz), tensor(float8e5m2), tensor(float8e5m2fnuz)
+  Constrain input types to float tensors.
+- **T2**: tensor(bool)
+  Constrain output types to boolean tensors.

--- a/onnx-spec/ops/IsNaN.md
+++ b/onnx-spec/ops/IsNaN.md
@@ -1,0 +1,22 @@
+# IsNaN
+
+Since opset **20**
+
+## Description
+
+Returns which elements of the input are NaN.
+
+## Inputs (1 - 1)
+
+- **X** (T1): input
+
+## Outputs (1 - 1)
+
+- **Y** (T2): output
+
+## Type Constraints
+
+- **T1**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16), tensor(float8e4m3fn), tensor(float8e4m3fnuz), tensor(float8e5m2), tensor(float8e5m2fnuz)
+  Constrain input types to float tensors.
+- **T2**: tensor(bool)
+  Constrain output types to boolean tensors.

--- a/onnx-spec/ops/LRN.md
+++ b/onnx-spec/ops/LRN.md
@@ -1,0 +1,36 @@
+# LRN
+
+Since opset **13**
+
+## Description
+
+Local Response Normalization proposed in the [AlexNet paper](https://papers.nips.cc/paper/4824-imagenet-classification-with-deep-convolutional-neural-networks.pdf).
+It normalizes over local input regions.
+The local region is defined across the channels. For an element `X[n, c, d1, ..., dk]` in a tensor
+of shape `(N x C x D1 x D2, ..., Dk)`, its region is
+`{X[n, i, d1, ..., dk] | max(0, c - floor((size - 1) / 2)) <= i <= min(C - 1, c + ceil((size - 1) / 2))}`.
+
+`square_sum[n, c, d1, ..., dk] = sum(X[n, i, d1, ..., dk] ^ 2)`,
+where `max(0, c - floor((size - 1) / 2)) <= i <= min(C - 1, c + ceil((size - 1) / 2))`.
+
+`Y[n, c, d1, ..., dk] = X[n, c, d1, ..., dk] / (bias + alpha / size * square_sum[n, c, d1, ..., dk] ) ^ beta`
+
+## Attributes
+
+- **alpha** (FLOAT, optional): Scaling parameter.
+- **beta** (FLOAT, optional): The exponent.
+- **bias** (FLOAT, optional)
+- **size** (INT, required): The number of channels to sum over
+
+## Inputs (1 - 1)
+
+- **X** (T): Input data tensor from the previous operator; dimensions for image case are (N x C x H x W), where N is the batch size, C is the number of channels, and H and W are the height and the width of the data. For non image case, the dimensions are in the form of (N x C x D1 x D2 ... Dn), where N is the batch size. Optionally, if dimension denotation is in effect, the operation expects the input data tensor to arrive with the dimension denotation of [DATA_BATCH, DATA_CHANNEL, DATA_FEATURE, DATA_FEATURE ...].
+
+## Outputs (1 - 1)
+
+- **Y** (T): Output tensor, which has the shape and type as input tensor
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain input and output  types to float tensors.

--- a/onnx-spec/ops/LSTM.md
+++ b/onnx-spec/ops/LSTM.md
@@ -1,0 +1,91 @@
+# LSTM
+
+Since opset **22**
+
+## Description
+
+Computes an one-layer LSTM. This operator is usually supported via some
+custom implementation such as CuDNN.
+
+Notations:
+
+* `X` - input tensor
+* `i` - input gate
+* `o` - output gate
+* `f` - forget gate
+* `c` - cell gate
+* `t` - time step (t-1 means previous time step)
+* `W[iofc]` - W parameter weight matrix for input, output, forget, and cell gates
+* `R[iofc]` - R recurrence weight matrix for input, output, forget, and cell gates
+* `Wb[iofc]` - W bias vectors for input, output, forget, and cell gates
+* `Rb[iofc]` - R bias vectors for input, output, forget, and cell gates
+* `P[iof]`  - P peephole weight vector for input, output, and forget gates
+* `WB[iofc]` - W parameter weight matrix for backward input, output, forget, and cell gates
+* `RB[iofc]` - R recurrence weight matrix for backward input, output, forget, and cell gates
+* `WBb[iofc]` - W bias vectors for backward input, output, forget, and cell gates
+* `RBb[iofc]` - R bias vectors for backward input, output, forget, and cell gates
+* `PB[iof]`  - P peephole weight vector for backward input, output, and forget gates
+* `H` - Hidden state
+* `num_directions` - 2 if direction == bidirectional else 1
+
+Activation functions:
+
+* Relu(x)                - max(0, x)
+* Tanh(x)                - (1 - e^{-2x})/(1 + e^{-2x})
+* Sigmoid(x)             - 1/(1 + e^{-x})
+
+NOTE: Below are optional
+
+* Affine(x)              - alpha*x + beta
+* LeakyRelu(x)           - x if x >= 0 else alpha * x
+* ThresholdedRelu(x)     - x if x >= alpha else 0
+* ScaledTanh(x)          - alpha*Tanh(beta*x)
+* HardSigmoid(x)         - min(max(alpha*x + beta, 0), 1)
+* Elu(x)                 - x if x >= 0 else alpha*(e^x - 1)
+* Softsign(x)            - x/(1 + |x|)
+* Softplus(x)            - log(1 + e^x)
+
+Equations (Default: f=Sigmoid, g=Tanh, h=Tanh):
+
+* it = f(Xt*(Wi^T) + Ht-1*(Ri^T) + Pi (.) Ct-1 + Wbi + Rbi)
+* ft = f(Xt*(Wf^T) + Ht-1*(Rf^T) + Pf (.) Ct-1 + Wbf + Rbf)
+* ct = g(Xt*(Wc^T) + Ht-1*(Rc^T) + Wbc + Rbc)
+* Ct = ft (.) Ct-1 + it (.) ct
+* ot = f(Xt*(Wo^T) + Ht-1*(Ro^T) + Po (.) Ct + Wbo + Rbo)
+* Ht = ot (.) h(Ct)
+This operator has **optional** inputs/outputs. See [the doc](IR.md) for more details about the representation of optional arguments. An empty string may be used in the place of an actual argument's name to indicate a missing argument. Trailing optional arguments (those not followed by an argument that is present) may also be simply omitted.
+
+## Attributes
+
+- **activation_alpha** (FLOATS, optional): Optional scaling values used by some activation functions. The values are consumed in the order of activation functions, for example (f, g, h) in LSTM. Default values are the same as of corresponding ONNX operators.For example with LeakyRelu, the default alpha is 0.01.
+- **activation_beta** (FLOATS, optional): Optional scaling values used by some activation functions. The values are consumed in the order of activation functions, for example (f, g, h) in LSTM. Default values are the same as of corresponding ONNX operators.
+- **activations** (STRINGS, optional): A list of 3 (or 6 if bidirectional) activation functions for input, output, forget, cell, and hidden. The activation functions must be one of the activation functions specified above. Optional: See the equations for default if not specified.
+- **clip** (FLOAT, optional): Cell clip threshold. Clipping bounds the elements of a tensor in the range of [-threshold, +threshold] and is applied to the input of activations. No clip if not specified.
+- **direction** (STRING, optional): Specify if the RNN is forward, reverse, or bidirectional. Must be one of forward (default), reverse, or bidirectional.
+- **hidden_size** (INT, optional): Number of neurons in the hidden layer
+- **input_forget** (INT, optional): Couple the input and forget gates if 1.
+- **layout** (INT, optional): The shape format of inputs X, initial_h, initial_c and outputs Y, Y_h, Y_c. If 0, the following shapes are expected: X.shape = [seq_length, batch_size, input_size], Y.shape = [seq_length, num_directions, batch_size, hidden_size], initial_h.shape = Y_h.shape = initial_c.shape = Y_c.shape = [num_directions, batch_size, hidden_size]. If 1, the following shapes are expected: X.shape = [batch_size, seq_length, input_size], Y.shape = [batch_size, seq_length, num_directions, hidden_size], initial_h.shape = Y_h.shape = initial_c.shape = Y_c.shape = [batch_size, num_directions, hidden_size].
+
+## Inputs (3 - 8)
+
+- **X** (T): The input sequences packed (and potentially padded) into one 3-D tensor with the shape of `[seq_length, batch_size, input_size]`.
+- **W** (T): The weight tensor for the gates. Concatenation of `W[iofc]` and `WB[iofc]` (if bidirectional) along dimension 0. The tensor has shape `[num_directions, 4*hidden_size, input_size]`.
+- **R** (T): The recurrence weight tensor. Concatenation of `R[iofc]` and `RB[iofc]` (if bidirectional) along dimension 0. This tensor has shape `[num_directions, 4*hidden_size, hidden_size]`.
+- **B** (T, optional): The bias tensor for input gate. Concatenation of `[Wb[iofc], Rb[iofc]]`, and `[WBb[iofc], RBb[iofc]]` (if bidirectional) along dimension 0. This tensor has shape `[num_directions, 8*hidden_size]`. Optional: If not specified - assumed to be 0.
+- **sequence_lens** (T1, optional): Optional tensor specifying lengths of the sequences in a batch. If not specified - assumed all sequences in the batch to have length `seq_length`. It has shape `[batch_size]`.
+- **initial_h** (T, optional): Optional initial value of the hidden. If not specified - assumed to be 0. It has shape `[num_directions, batch_size, hidden_size]`.
+- **initial_c** (T, optional): Optional initial value of the cell. If not specified - assumed to be 0. It has shape `[num_directions, batch_size, hidden_size]`.
+- **P** (T, optional): The weight tensor for peepholes. Concatenation of `P[iof]` and `PB[iof]` (if bidirectional) along dimension 0. It has shape `[num_directions, 3*hidde_size]`. Optional: If not specified - assumed to be 0.
+
+## Outputs (0 - 3)
+
+- **Y** (T, optional): A tensor that concats all the intermediate output values of the hidden. It has shape `[seq_length, num_directions, batch_size, hidden_size]`.
+- **Y_h** (T, optional): The last output value of the hidden. It has shape `[num_directions, batch_size, hidden_size]`.
+- **Y_c** (T, optional): The last output value of the cell. It has shape `[num_directions, batch_size, hidden_size]`.
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain input and output types to float tensors.
+- **T1**: tensor(int32)
+  Constrain seq_lens to integer tensor.

--- a/onnx-spec/ops/LayerNormalization.md
+++ b/onnx-spec/ops/LayerNormalization.md
@@ -1,0 +1,72 @@
+# LayerNormalization
+
+Since opset **17**
+
+## Description
+
+This is layer normalization defined in ONNX as function.
+      The overall computation can be split into two stages.
+      The first stage is standardization, which makes the
+      normalized elements have zero mean and unit variances.
+      The computation required by standardization can be
+      described by the following equations.
+      ```
+      Mean = ReduceMean<axes=normalized_axes>(X)
+      D = Sub(X, Mean)
+      DD = Mul(D, D)
+      Var = ReduceMean<axes=normalized_axes>(DD)
+      VarEps = Add(Var, epsilon)
+      StdDev = Sqrt(VarEps)
+      InvStdDev = Reciprocal(StdDev)
+      Normalized = Mul(D, InvStdDev)
+      ```
+      where `normalized_axes` is `[axis, ..., rank of X - 1]`.
+      The variables `Var` and `StdDev` stand for variance and
+      standard deviation, respectively. The second output is
+      `Mean` and the last one is `InvStdDev`.
+      Depending on `stash_type` attribute, the actual computation
+      must happen in different floating-point precision.
+      For example, if `stash_type` is 1, this operator casts
+      all input variables to 32-bit float, perform the computation, and
+      finally cast `Normalized` back to the original type of `X`.
+      The second stage then scales and shifts the outcome of the
+      first stage using
+      ```
+      NormalizedScaled = Mul(Normalized, Scale)
+      Y = Add(NormalizedScaled, B)
+      ```
+      The second stage doesn't depends on `stash_type`.
+      All equations are in [this syntax](https://github.com/onnx/onnx/blob/main/docs/Syntax.md).
+      The same variable (i.e., input, output, and attribute) uses
+      the same name in the equations above and this operator's definition.
+      Let `d[i]` indicate the i-th dimension of `X`.
+      If `X`'s shape is `[d[0], ..., d[axis-1], d[axis], ..., d[rank-1]]`,
+      the shape of `Mean` and `InvStdDev` is `[d[0], ..., d[axis-1], 1, ..., 1]`.
+      `Y` and `X` have the same shape. This operator supports unidirectional broadcasting
+      (tensors `Scale` and `B` should be unidirectional broadcastable to tensor `X`);
+      for more details please check [the doc](Broadcasting.md).
+
+## Attributes
+
+- **axis** (INT, optional): The first normalization dimension. If rank(X) is r, axis' allowed range is [-r, r). Negative value means counting dimensions from the back.
+- **epsilon** (FLOAT, optional): The epsilon value to use to avoid division by zero.
+- **stash_type** (INT, optional): Type of Mean and InvStdDev. This also specifies stage one's computation precision.
+
+## Inputs (2 - 3)
+
+- **X** (T): Tensor to be normalized.
+- **Scale** (T): Scale tensor.
+- **B** (T, optional): Bias tensor.
+
+## Outputs (1 - 3)
+
+- **Y** (T): Normalized tensor.
+- **Mean** (U, optional): Saved mean used during training to speed up gradient computation
+- **InvStdDev** (U, optional): Saved inverse standard deviation used during training to speed up gradient computation.
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain input types and output Y type to float tensors.
+- **U**: tensor(bfloat16), tensor(float)
+  Type of Mean and InvStdDev tensors.

--- a/onnx-spec/ops/LeakyRelu.md
+++ b/onnx-spec/ops/LeakyRelu.md
@@ -1,0 +1,26 @@
+# LeakyRelu
+
+Since opset **16**
+
+## Description
+
+LeakyRelu takes input data (Tensor<T>) and an argument alpha, and produces one
+output data (Tensor<T>) where the function `f(x) = alpha * x for x < 0`,
+`f(x) = x for x >= 0`, is applied to the data tensor elementwise.
+
+## Attributes
+
+- **alpha** (FLOAT, optional): Coefficient of leakage.
+
+## Inputs (1 - 1)
+
+- **X** (T): Input tensor
+
+## Outputs (1 - 1)
+
+- **Y** (T): Output tensor
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain input and output types to float tensors.

--- a/onnx-spec/ops/Less.md
+++ b/onnx-spec/ops/Less.md
@@ -1,0 +1,26 @@
+# Less
+
+Since opset **13**
+
+## Description
+
+Returns the tensor resulted from performing the `less` logical operation
+elementwise on the input tensors `A` and `B` (with Numpy-style broadcasting support).
+
+This operator supports **multidirectional (i.e., Numpy-style) broadcasting**; for more details please check [the doc](Broadcasting.md).
+
+## Inputs (2 - 2)
+
+- **A** (T): First input operand for the logical operator.
+- **B** (T): Second input operand for the logical operator.
+
+## Outputs (1 - 1)
+
+- **C** (T1): Result tensor.
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)
+  Constrain input types to all numeric tensors.
+- **T1**: tensor(bool)
+  Constrain output to boolean tensor.

--- a/onnx-spec/ops/LessOrEqual.md
+++ b/onnx-spec/ops/LessOrEqual.md
@@ -1,0 +1,26 @@
+# LessOrEqual
+
+Since opset **16**
+
+## Description
+
+Returns the tensor resulted from performing the `less_equal` logical operation
+elementwise on the input tensors `A` and `B` (with Numpy-style broadcasting support).
+
+This operator supports **multidirectional (i.e., Numpy-style) broadcasting**; for more details please check [the doc](Broadcasting.md).
+
+## Inputs (2 - 2)
+
+- **A** (T): First input operand for the logical operator.
+- **B** (T): Second input operand for the logical operator.
+
+## Outputs (1 - 1)
+
+- **C** (T1): Result tensor.
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)
+  Constrain input types to all numeric tensors.
+- **T1**: tensor(bool)
+  Constrain output to boolean tensor.

--- a/onnx-spec/ops/Log.md
+++ b/onnx-spec/ops/Log.md
@@ -1,0 +1,20 @@
+# Log
+
+Since opset **13**
+
+## Description
+
+Calculates the natural log of the given input tensor, element-wise.
+
+## Inputs (1 - 1)
+
+- **input** (T): Input tensor
+
+## Outputs (1 - 1)
+
+- **output** (T): The natural log of the input tensor computed element-wise
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain input and output types to float tensors.

--- a/onnx-spec/ops/LogSoftmax.md
+++ b/onnx-spec/ops/LogSoftmax.md
@@ -1,0 +1,30 @@
+# LogSoftmax
+
+Since opset **13**
+
+## Description
+
+The operator computes the log of softmax values for the given input:
+
+ LogSoftmax(input, axis) = Log(Softmax(input, axis=axis))
+
+The "axis" attribute indicates the dimension along which LogSoftmax
+will be performed. The output tensor has the same shape
+and contains the LogSoftmax values of the corresponding input.
+
+## Attributes
+
+- **axis** (INT, optional): Describes the dimension LogSoftmax will be performed on.
+
+## Inputs (1 - 1)
+
+- **input** (T): The input tensor of rank >= axis.
+
+## Outputs (1 - 1)
+
+- **output** (T): The output values with the same shape as the input tensor.
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain input and output types to float tensors.

--- a/onnx-spec/ops/Loop.md
+++ b/onnx-spec/ops/Loop.md
@@ -1,0 +1,164 @@
+# Loop
+
+Since opset **24**
+
+## Description
+
+Generic Looping construct. This loop has multiple termination conditions:
+
+1) Trip count. Iteration count specified at runtime. Set by
+   specifying the input M. Optional. Set to empty string to omit.
+   Note that a static trip count (specified at graph construction time) can be
+   specified by passing in a constant node for input M.
+2) Loop termination condition. This is an input to the op that determines
+   whether to run the first iteration and also a loop-carried dependency for
+   the body graph. The body graph must yield a value for the condition variable,
+   whether this input is provided or not.
+
+This table summarizes the operating modes of this operator with equivalent
+C-style code:
+
+Operator inputs defined as (max_trip_count, condition_var).
+
+* input ("", ""):
+        for (int i=0; ; ++i) {
+          cond = ... // Note this value is ignored, but is required in the body
+        }
+
+* input ("", cond) // Note this is analogous to a while loop
+        bool cond = ...;
+        for (int i=0; cond; ++i) {
+          cond = ...;
+        }
+
+* input ("", 1) // Note this is analogous to a do-while loop
+        bool cond = true
+        for (int i=0; cond; ++i) {
+          cond = ...;
+        }
+
+* input (trip_count, "") // Note this is analogous to a for loop
+        int trip_count = ...
+        for (int i=0; i < trip_count; ++i) {
+          cond = ...; // ignored
+        }
+
+* input (trip_count, cond)
+        int trip_count = ...;
+        bool cond = ...;
+        for (int i=0; i < trip_count && cond; ++i) {
+          cond = ...;
+        }
+
+
+*Sample usage - cond as well as trip count*
+
+    graph predict-net {
+      %a = Constant[value = <Scalar Tensor [3]>]()
+      %b = Constant[value = <Scalar Tensor [6]>]()
+      %keepgoing = Constant[value = <Scalar Tensor [1]>]()
+      %max_trip_count = Constant[value = <Scalar Tensor [10]>]()
+      %keepgoing_out, %b_out, %user_defined_vals = Loop[body = <graph body-net>](%max_trip_count, %keepgoing, %b)
+      return
+    }
+
+    graph body-net (
+      %i[INT32, scalar]           // iteration number
+      %keepgoing_in[BOOL, scalar] // incoming loop-termination-condition; not used
+      %b_in[INT32, scalar]        // incoming value of loop-carried-dependency b
+    ) {
+      %my_local = Add(%a, %b_in)
+      %b_out = Sub(%a, %b_in) // outgoing value of loop-carried-dependency b
+      %keepgoing_out = Greater(%my_local, %b_out) // outgoing loop-termination-condition
+      %user_defined_val = Add(%b_in, %b_in) // scan-output value to be accumulated
+      return %keepgoing_out, %b_out, %user_defined_val
+    }
+
+*Sample equivalent C code*
+
+    {
+      /* User-defined code (enclosing scope) */
+      int a = 3, b = 6;
+      bool keepgoing = true; // Analogous to input cond
+      /* End user-defined code */
+
+      /* Implicitly-defined code */
+      const int max_trip_count = 10; // Analogous to input M
+      int user_defined_vals[]; // Imagine this is resizable
+      /* End implicitly-defined code */
+      /* initialize loop-carried variables and scan-output variables */
+      bool keepgoing_out = keepgoing
+      int b_out = b
+
+      for (int i=0; i < max_trip_count && keepgoing_out; ++i) {
+        /* Implicitly-defined code: bind actual parameter values
+           to formal parameter variables of loop-body */
+        bool keepgoing_in = keepgoing_out;
+        bool b_in = b_out;
+
+        /* User-defined code (loop body) */
+        int my_local = a + b_in; // Reading value "a" from the enclosing scope is fine
+        b_out = a - b_in;
+        keepgoing_out = my_local > b_out;
+        user_defined_val = b_in + b_in; // b_in and b_out are different variables
+        /* End user-defined code */
+
+        /* Implicitly defined-code */
+        user_defined_vals[i] = user_defined_val // accumulate scan-output values
+      }
+      // int t = my_local; // Can't do this. my_local is not accessible here.
+
+      // The values below are bound to the output variables of the loop and therefore accessible
+      // b_out; user_defined_vals; keepgoing_out;
+    }
+
+There are several things of note in this code snippet:
+
+1) Values from the enclosing scope (i.e. variable "a" here) are in scope and can
+   be referenced in the inputs of the loop.
+2) Any values computed in the loop body that needs to be used in a subsequent
+   iteration or after the loop are modelled using a pair of variables in the loop-body,
+   consisting of an input variable (eg., b_in) and an output variable (eg., b_out).
+   These are referred to as loop-carried dependences. The loop operation node
+   supplies the input value of the input variable for the first iteration, and
+   returns the output value of the output variable produced by the final
+   iteration.
+3) Scan_output variables are used to implicitly concatenate values computed across
+   all the iterations. In the above example, the value of user_defined_val computed
+   over all iterations are concatenated and returned as the value of user_defined_vals
+   after the loop.
+4) Values created in the body cannot be accessed in the enclosing scope,
+   except using the mechanism described above.
+
+Note that the semantics of this op support "diagonal" or "wavefront" execution.
+(See Step 3 here for an example:
+https://devblogs.nvidia.com/optimizing-recurrent-neural-networks-cudnn-5/).
+Frontends should emit multi-layer RNNs as a series of While operators (with
+time being the inner looping dimension), with each successive layer consuming
+the scan_outputs from the previous layer, possibly going through several
+point-wise operators (e.g. dropout, residual connections, linear layer).
+
+The input/output of subgraph (produced by loop node) matching is based on order instead of name. The implementation will figure out the names based on this order.
+
+## Attributes
+
+- **body** (GRAPH, required): The graph run each iteration. It has 2+N inputs: (iteration_num, condition, loop carried dependencies...). It has 1+N+K outputs: (condition, loop carried dependencies..., scan_outputs...). Each scan_output is created by concatenating the value of the specified output value at the end of each iteration of the loop. It is an error if the dimensions or data type of these scan_outputs change across loop iterations.
+
+## Inputs (2 - 2147483647)
+
+- **M** (I, optional): A maximum trip-count for the loop specified at runtime. Optional. Pass empty string to skip.
+- **cond** (B, optional): A boolean termination condition. Optional. Pass empty string to skip.
+- **v_initial** (V, variadic): The initial values of any loop-carried dependencies (values that change across loop iterations)
+
+## Outputs (1 - 2147483647)
+
+- **v_final_and_scan_outputs** (V, variadic): Final N loop carried dependency values then K scan_outputs. Scan outputs must be Tensors.
+
+## Type Constraints
+
+- **V**: optional(seq(tensor(bfloat16))), optional(seq(tensor(bool))), optional(seq(tensor(complex128))), optional(seq(tensor(complex64))), optional(seq(tensor(double))), optional(seq(tensor(float))), optional(seq(tensor(float16))), optional(seq(tensor(int16))), optional(seq(tensor(int32))), optional(seq(tensor(int64))), optional(seq(tensor(int8))), optional(seq(tensor(string))), optional(seq(tensor(uint16))), optional(seq(tensor(uint32))), optional(seq(tensor(uint64))), optional(seq(tensor(uint8))), optional(tensor(bfloat16)), optional(tensor(bool)), optional(tensor(complex128)), optional(tensor(complex64)), optional(tensor(double)), optional(tensor(float)), optional(tensor(float16)), optional(tensor(float4e2m1)), optional(tensor(float8e4m3fn)), optional(tensor(float8e4m3fnuz)), optional(tensor(float8e5m2)), optional(tensor(float8e5m2fnuz)), optional(tensor(float8e8m0)), optional(tensor(int16)), optional(tensor(int32)), optional(tensor(int4)), optional(tensor(int64)), optional(tensor(int8)), optional(tensor(string)), optional(tensor(uint16)), optional(tensor(uint32)), optional(tensor(uint4)), optional(tensor(uint64)), optional(tensor(uint8)), seq(tensor(bfloat16)), seq(tensor(bool)), seq(tensor(complex128)), seq(tensor(complex64)), seq(tensor(double)), seq(tensor(float)), seq(tensor(float16)), seq(tensor(float4e2m1)), seq(tensor(float8e4m3fn)), seq(tensor(float8e4m3fnuz)), seq(tensor(float8e5m2)), seq(tensor(float8e5m2fnuz)), seq(tensor(float8e8m0)), seq(tensor(int16)), seq(tensor(int32)), seq(tensor(int4)), seq(tensor(int64)), seq(tensor(int8)), seq(tensor(string)), seq(tensor(uint16)), seq(tensor(uint32)), seq(tensor(uint4)), seq(tensor(uint64)), seq(tensor(uint8)), tensor(bfloat16), tensor(bool), tensor(complex128), tensor(complex64), tensor(double), tensor(float), tensor(float16), tensor(float4e2m1), tensor(float8e4m3fn), tensor(float8e4m3fnuz), tensor(float8e5m2), tensor(float8e5m2fnuz), tensor(float8e8m0), tensor(int16), tensor(int32), tensor(int4), tensor(int64), tensor(int8), tensor(string), tensor(uint16), tensor(uint32), tensor(uint4), tensor(uint64), tensor(uint8)
+  All Tensor, Sequence(Tensor), Optional(Tensor), and Optional(Sequence(Tensor)) types up to IRv11.
+- **I**: tensor(int64)
+  tensor of int64, which should be a scalar.
+- **B**: tensor(bool)
+  tensor of bool, which should be a scalar.

--- a/onnx-spec/ops/LpNormalization.md
+++ b/onnx-spec/ops/LpNormalization.md
@@ -1,0 +1,25 @@
+# LpNormalization
+
+Since opset **22**
+
+## Description
+
+Given a matrix, apply Lp-normalization along the provided axis.
+
+## Attributes
+
+- **axis** (INT, optional): The axis on which to apply normalization, -1 mean last axis.
+- **p** (INT, optional): The order of the normalization, only 1 or 2 are supported.
+
+## Inputs (1 - 1)
+
+- **input** (T): Input matrix
+
+## Outputs (1 - 1)
+
+- **output** (T): Matrix after normalization
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain input and output types to float tensors.

--- a/onnx-spec/ops/LpPool.md
+++ b/onnx-spec/ops/LpPool.md
@@ -1,0 +1,52 @@
+# LpPool
+
+Since opset **22**
+
+## Description
+
+LpPool consumes an input tensor X and applies Lp pooling across
+ the tensor according to kernel sizes, stride sizes, and pad lengths.
+ Lp pooling consisting of computing the Lp norm on all values of a subset
+ of the input tensor according to the kernel size and downsampling the
+ data into the output tensor Y for further processing. The output spatial shape will be following:
+ ```
+ output_spatial_shape[i] = floor((input_spatial_shape[i] + pad_shape[i] - {kernelSpatialShape}) / strides_spatial_shape[i] + 1)
+ ```
+ or
+ ```
+ output_spatial_shape[i] = ceil((input_spatial_shape[i] + pad_shape[i] - {kernelSpatialShape}) / strides_spatial_shape[i] + 1)
+ ```
+ if ceil_mode is enabled `pad_shape[i]` is the sum of pads along axis `i`.
+
+ `auto_pad` is a DEPRECATED attribute. If you are using them currently, the output spatial shape will be following:
+ ```
+ VALID: output_spatial_shape[i] = ceil((input_spatial_shape[i] - {kernelSpatialShape} + 1) / strides_spatial_shape[i])
+ SAME_UPPER or SAME_LOWER: output_spatial_shape[i] = ceil(input_spatial_shape[i] / strides_spatial_shape[i])
+ ```
+ And pad shape will be following if `SAME_UPPER` or `SAME_LOWER`:
+ ```
+ pad_shape[i] = (output_spatial_shape[i] - 1) * strides_spatial_shape[i] + {kernelSpatialShape} - input_spatial_shape[i]
+ ```
+
+## Attributes
+
+- **auto_pad** (STRING, optional): auto_pad must be either NOTSET, SAME_UPPER, SAME_LOWER or VALID. Where default value is NOTSET, which means explicit padding is used. SAME_UPPER or SAME_LOWER mean pad the input so that `output_shape[i] = ceil(input_shape[i] / strides[i])` for each axis `i`. The padding is split between the two sides equally or almost equally (depending on whether it is even or odd). In case the padding is an odd number, the extra padding is added at the end for SAME_UPPER and at the beginning for SAME_LOWER.
+- **ceil_mode** (INT, optional): Whether to use ceil or floor (default) to compute the output shape.
+- **dilations** (INTS, optional): dilation value along each spatial axis of the filter. If not present, the dilation defaults is 1 along each spatial axis.
+- **kernel_shape** (INTS, required): The size of the kernel along each axis.
+- **p** (INT, optional): p value of the Lp norm used to pool over the input data.
+- **pads** (INTS, optional): Padding for the beginning and ending along each spatial axis, it can take any value greater than or equal to 0. The value represent the number of pixels added to the beginning and end part of the corresponding axis. `pads` format should be as follow [x1_begin, x2_begin...x1_end, x2_end,...], where xi_begin the number of pixels added at the beginning of axis `i` and xi_end, the number of pixels added at the end of axis `i`. This attribute cannot be used simultaneously with auto_pad attribute. If not present, the padding defaults to 0 along start and end of each spatial axis.
+- **strides** (INTS, optional): Stride along each spatial axis. If not present, the stride defaults to 1 along each spatial axis.
+
+## Inputs (1 - 1)
+
+- **X** (T): Input data tensor from the previous operator; dimensions for image case are (N x C x H x W), where N is the batch size, C is the number of channels, and H and W are the height and the width of the data. For non image case, the dimensions are in the form of (N x C x D1 x D2 ... Dn), where N is the batch size.
+
+## Outputs (1 - 1)
+
+- **Y** (T): Output data tensor from Lp pooling across the input tensor. Dimensions will vary based on various kernel, stride, and pad sizes.
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain input and output types to float tensors.

--- a/onnx-spec/ops/MatMul.md
+++ b/onnx-spec/ops/MatMul.md
@@ -1,0 +1,21 @@
+# MatMul
+
+Since opset **13**
+
+## Description
+
+Matrix product that behaves like [numpy.matmul](https://numpy.org/doc/stable/reference/generated/numpy.matmul.html).
+
+## Inputs (2 - 2)
+
+- **A** (T): N-dimensional matrix A
+- **B** (T): N-dimensional matrix B
+
+## Outputs (1 - 1)
+
+- **Y** (T): Matrix multiply results from A * B
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16), tensor(int32), tensor(int64), tensor(uint32), tensor(uint64)
+  Constrain input and output types to float/int tensors.

--- a/onnx-spec/ops/MatMulInteger.md
+++ b/onnx-spec/ops/MatMulInteger.md
@@ -1,0 +1,28 @@
+# MatMulInteger
+
+Since opset **10**
+
+## Description
+
+Matrix product that behaves like [numpy.matmul](https://numpy.org/doc/stable/reference/generated/numpy.matmul.html).
+The production MUST never overflow. The accumulation may overflow if and only if in 32 bits.
+
+## Inputs (2 - 4)
+
+- **A** (T1): N-dimensional matrix A
+- **B** (T2): N-dimensional matrix B
+- **a_zero_point** (T1, optional): Zero point tensor for input 'A'. It's optional and default value is 0. It could be a scalar or N-D tensor. Scalar refers to per tensor quantization whereas N-D refers to per row quantization. If the input is 2D of shape [M, K] then zero point tensor may be an M element vector [zp_1, zp_2, ..., zp_M]. If the input is N-D tensor with shape [D1, D2, M, K] then zero point tensor may have shape [D1, D2, M, 1].
+- **b_zero_point** (T2, optional): Zero point tensor for input 'B'. It's optional and default value is 0. It could be a scalar or a N-D tensor, Scalar refers to per tensor quantization whereas N-D refers to per col quantization. If the input is 2D of shape [K, N] then zero point tensor may be an N element vector [zp_1, zp_2, ..., zp_N]. If the input is N-D tensor with shape [D1, D2, K, N] then zero point tensor may have shape [D1, D2, 1, N].
+
+## Outputs (1 - 1)
+
+- **Y** (T3): Matrix multiply results from A * B
+
+## Type Constraints
+
+- **T1**: tensor(int8), tensor(uint8)
+  Constrain input A data type to 8-bit integer tensor.
+- **T2**: tensor(int8), tensor(uint8)
+  Constrain input B data type to 8-bit integer tensor.
+- **T3**: tensor(int32)
+  Constrain output Y data type as 32-bit integer tensor.

--- a/onnx-spec/ops/Max.md
+++ b/onnx-spec/ops/Max.md
@@ -1,0 +1,22 @@
+# Max
+
+Since opset **13**
+
+## Description
+
+Element-wise max of each of the input tensors (with Numpy-style broadcasting support).
+All inputs and outputs must have the same data type.
+This operator supports **multidirectional (i.e., Numpy-style) broadcasting**; for more details please check [the doc](Broadcasting.md).
+
+## Inputs (1 - 2147483647)
+
+- **data_0** (T, variadic): List of tensors for max.
+
+## Outputs (1 - 1)
+
+- **max** (T): Output tensor.
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)
+  Constrain input and output types to numeric tensors.

--- a/onnx-spec/ops/MaxPool.md
+++ b/onnx-spec/ops/MaxPool.md
@@ -1,0 +1,63 @@
+# MaxPool
+
+Since opset **22**
+
+## Description
+
+MaxPool consumes an input tensor X and applies max pooling across
+ the tensor according to kernel sizes, stride sizes, and pad lengths.
+ max pooling consisting of computing the max on all values of a
+ subset of the input tensor according to the kernel size and downsampling the
+ data into the output tensor Y for further processing. The output spatial shape is calculated differently
+ depending on whether explicit padding is used, where pads is employed, or auto padding is used, where auto_pad is utilized.
+ With explicit padding (https://pytorch.org/docs/stable/generated/torch.nn.MaxPool2d.html?highlight=maxpool#torch.nn.MaxPool2d):
+ ```
+ output_spatial_shape[i] = floor((input_spatial_shape[i] + pad_shape[i] - dilation[i] * (kernel_shape[i] - 1) - 1) / strides_spatial_shape[i] + 1)
+ ```
+ or
+ ```
+ output_spatial_shape[i] = ceil((input_spatial_shape[i] + pad_shape[i] - dilation[i] * (kernel_shape[i] - 1) - 1) / strides_spatial_shape[i] + 1)
+ ```
+ if ceil_mode is enabled. `pad_shape[i]` is the sum of pads along axis `i`. Sliding windows that would start in the right padded region are ignored.
+
+ `auto_pad` is a DEPRECATED attribute. If you are using them currently, the output spatial shape will be following when ceil_mode is enabled:
+ ```
+ VALID: output_spatial_shape[i] = ceil((input_spatial_shape[i] - ((kernel_spatial_shape[i] - 1) * dilations[i] + 1) + 1) / strides_spatial_shape[i])
+ SAME_UPPER or SAME_LOWER: output_spatial_shape[i] = ceil(input_spatial_shape[i] / strides_spatial_shape[i])
+ ```
+ or when ceil_mode is disabled (https://www.tensorflow.org/api_docs/python/tf/keras/layers/AveragePooling2D):
+ ```
+ VALID: output_spatial_shape[i] = floor((input_spatial_shape[i] - ((kernel_spatial_shape[i] - 1) * dilations[i] + 1)) / strides_spatial_shape[i]) + 1
+ SAME_UPPER or SAME_LOWER: output_spatial_shape[i] = floor((input_spatial_shape[i] - 1) / strides_spatial_shape[i]) + 1
+ ```
+ And pad shape will be following if `SAME_UPPER` or `SAME_LOWER`:
+ ```
+ pad_shape[i] = (output_spatial_shape[i] - 1) * strides_spatial_shape[i] + ((kernel_spatial_shape[i] - 1) * dilations[i] + 1) - input_spatial_shape[i]
+ ```
+ The output of each pooling window is maximum number of elements exclude pad.
+
+## Attributes
+
+- **auto_pad** (STRING, optional): auto_pad must be either NOTSET, SAME_UPPER, SAME_LOWER or VALID. Where default value is NOTSET, which means explicit padding is used. SAME_UPPER or SAME_LOWER mean pad the input so that `output_shape[i] = ceil(input_shape[i] / strides[i])` for each axis `i`. The padding is split between the two sides equally or almost equally (depending on whether it is even or odd). In case the padding is an odd number, the extra padding is added at the end for SAME_UPPER and at the beginning for SAME_LOWER.
+- **ceil_mode** (INT, optional): Whether to use ceil or floor (default) to compute the output shape.
+- **dilations** (INTS, optional): Dilation value along each spatial axis of filter. If not present, the dilation defaults to 1 along each spatial axis.
+- **kernel_shape** (INTS, required): The size of the kernel along each axis.
+- **pads** (INTS, optional): Padding for the beginning and ending along each spatial axis, it can take any value greater than or equal to 0. The value represent the number of pixels added to the beginning and end part of the corresponding axis. `pads` format should be as follow [x1_begin, x2_begin...x1_end, x2_end,...], where xi_begin the number of pixels added at the beginning of axis `i` and xi_end, the number of pixels added at the end of axis `i`. This attribute cannot be used simultaneously with auto_pad attribute. If not present, the padding defaults to 0 along start and end of each spatial axis.
+- **storage_order** (INT, optional): The storage order of the tensor. 0 is row major, and 1 is column major. This attribute is used only to convert an n-tuple index value into a single integer value for producing the second output.
+- **strides** (INTS, optional): Stride along each spatial axis. If not present, the stride defaults to 1 along each spatial axis.
+
+## Inputs (1 - 1)
+
+- **X** (T): Input data tensor from the previous operator; dimensions for image case are (N x C x H x W), where N is the batch size, C is the number of channels, and H and W are the height and the width of the data. For non image case, the dimensions are in the form of (N x C x D1 x D2 ... Dn), where N is the batch size. Optionally, if dimension denotation is in effect, the operation expects the input data tensor to arrive with the dimension denotation of [DATA_BATCH, DATA_CHANNEL, DATA_FEATURE, DATA_FEATURE ...].
+
+## Outputs (1 - 2)
+
+- **Y** (T): Output data tensor from average or max pooling across the input tensor. Dimensions will vary based on various kernel, stride, and pad sizes. Floor value of the dimension is used
+- **Indices** (I, optional): Indices tensor from max pooling across the input tensor. The dimensions of indices are the same as output tensor. The values in indices of are the indices of the selected values during pooling. The indices are computed as flatten 1-D tensor, and the indices do not consider padding. So the values in indices are in [0, N x C x D1 x ... x Dn).
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16), tensor(int8), tensor(uint8)
+  Constrain input and output types to float and 8 bit tensors.
+- **I**: tensor(int64)
+  Constrain index tensor to int64

--- a/onnx-spec/ops/MaxRoiPool.md
+++ b/onnx-spec/ops/MaxRoiPool.md
@@ -1,0 +1,28 @@
+# MaxRoiPool
+
+Since opset **22**
+
+## Description
+
+ROI max pool consumes an input tensor X and region of interests (RoIs) to
+ apply max pooling across each RoI, to produce output 4-D tensor of shape
+ (num_rois, channels, pooled_shape[0], pooled_shape[1]).
+
+## Attributes
+
+- **pooled_shape** (INTS, required): ROI pool output shape (height, width).
+- **spatial_scale** (FLOAT, optional): Multiplicative spatial scale factor to translate ROI coordinates from their input scale to the scale used when pooling.
+
+## Inputs (2 - 2)
+
+- **X** (T): Input data tensor from the previous operator; dimensions for image case are (N x C x H x W), where N is the batch size, C is the number of channels, and H and W are the height and the width of the data.
+- **rois** (T): RoIs (Regions of Interest) to pool over. Should be a 2-D tensor of shape (num_rois, 5) given as [[batch_id, x1, y1, x2, y2], ...].
+
+## Outputs (1 - 1)
+
+- **Y** (T): RoI pooled output 4-D tensor of shape (num_rois, channels, pooled_shape[0], pooled_shape[1]).
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain input and output types to float tensors.

--- a/onnx-spec/ops/MaxUnpool.md
+++ b/onnx-spec/ops/MaxUnpool.md
@@ -1,0 +1,47 @@
+# MaxUnpool
+
+Since opset **22**
+
+## Description
+
+MaxUnpool essentially computes the partial inverse of the MaxPool op.
+ The input information to this op is typically the output information from a MaxPool op. The first
+ input tensor X is the tensor that needs to be unpooled, which is typically the pooled tensor (first output)
+ from MaxPool. The second input tensor, I, contains the indices to the (locally maximal) elements corresponding
+ to the elements in the first input tensor X. Input tensor I is typically the second output of the MaxPool op.
+ The third (optional) input is a tensor that specifies the output size of the unpooling operation.
+
+MaxUnpool is intended to do 'partial' inverse of the MaxPool op. 'Partial' because all the non-maximal
+ values from the original input to MaxPool are set to zero in the output of the MaxUnpool op. Pooling
+ the result of an unpooling operation should give back the original input to the unpooling op.
+
+MaxUnpool can produce the same output size for several input sizes, which makes unpooling op ambiguous.
+ The third input argument, output_size, is meant to disambiguate the op and produce output tensor of
+ known/predictable size.
+
+In addition to the inputs, MaxUnpool takes three attributes, namely kernel_shape, strides, and pads,
+ which define the exact unpooling op. The attributes typically have the same values as the corresponding
+ pooling op that the unpooling op is trying to invert.
+
+## Attributes
+
+- **kernel_shape** (INTS, required): The size of the kernel along each axis.
+- **pads** (INTS, optional): Padding for the beginning and ending along each spatial axis, it can take any value greater than or equal to 0. The value represent the number of pixels added to the beginning and end part of the corresponding axis. `pads` format should be as follow [x1_begin, x2_begin...x1_end, x2_end,...], where xi_begin the number of pixels added at the beginning of axis `i` and xi_end, the number of pixels added at the end of axis `i`. This attribute cannot be used simultaneously with auto_pad attribute. If not present, the padding defaults to 0 along start and end of each spatial axis.
+- **strides** (INTS, optional): Stride along each spatial axis. If not present, the stride defaults to 1 along each spatial axis.
+
+## Inputs (2 - 3)
+
+- **X** (T1): Input data tensor that has to be unpooled. This tensor is typically the first output of the MaxPool op.Dimensions for image case are (N x C x H x W), where N is the batch size, C is the number of channels, and H and W are the height and the width of the data. For non-image case, the dimensions are in the form of (N x C x D1 x D2 ... Dn), where N is the batch size. Optionally, if dimension denotation is in effect, the operation expects the input data tensor to arrive with the dimension denotation of [DATA_BATCH, DATA_CHANNEL, DATA_FEATURE, DATA_FEATURE ...].
+- **I** (T2): Input data tensor containing the indices corresponding to elements in the first input tensor X.This tensor is typically the second output of the MaxPool op.Dimensions must be the same as input tensor X. The indices are linear, i.e. computed considering the tensor as flattened 1-D tensor, assuming row-major storage. Also, the linear indices should not consider padding. So the values in indices are in the range [0, N x C x D1 x ... x Dn).
+- **output_shape** (T2, optional): The shape of the output can be explicitly set which will cause pads values to be auto generated. If 'output_shape' is specified, 'pads' values are ignored.
+
+## Outputs (1 - 1)
+
+- **output** (T1): Output data tensor that contains the result of the unpooling.
+
+## Type Constraints
+
+- **T1**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain input and output types to float tensors.
+- **T2**: tensor(int64)
+  Constrain index tensor to int64

--- a/onnx-spec/ops/Mean.md
+++ b/onnx-spec/ops/Mean.md
@@ -1,0 +1,22 @@
+# Mean
+
+Since opset **13**
+
+## Description
+
+Element-wise mean of each of the input tensors (with Numpy-style broadcasting support).
+All inputs and outputs must have the same data type.
+This operator supports **multidirectional (i.e., Numpy-style) broadcasting**; for more details please check [the doc](Broadcasting.md).
+
+## Inputs (1 - 2147483647)
+
+- **data_0** (T, variadic): List of tensors for mean.
+
+## Outputs (1 - 1)
+
+- **mean** (T): Output tensor.
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain input and output types to float tensors.

--- a/onnx-spec/ops/MeanVarianceNormalization.md
+++ b/onnx-spec/ops/MeanVarianceNormalization.md
@@ -1,0 +1,25 @@
+# MeanVarianceNormalization
+
+Since opset **13**
+
+## Description
+
+A MeanVarianceNormalization Function: Perform mean variance normalization
+      on the input tensor X using formula: `(X-EX)/sqrt(E(X-EX)^2)`
+
+## Attributes
+
+- **axes** (INTS, optional): A list of integers, along which to reduce. The default is to calculate along axes [0,2,3] for calculating mean and variance along each channel. Two variables with the same C-coordinate are associated with the same mean and variance.
+
+## Inputs (1 - 1)
+
+- **X** (T): Input tensor
+
+## Outputs (1 - 1)
+
+- **Y** (T): Output tensor
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain input and output types to all numeric tensors.

--- a/onnx-spec/ops/MelWeightMatrix.md
+++ b/onnx-spec/ops/MelWeightMatrix.md
@@ -1,0 +1,39 @@
+# MelWeightMatrix
+
+Since opset **17**
+
+## Description
+
+Generate a MelWeightMatrix that can be used to re-weight a Tensor containing a linearly sampled frequency spectra (from DFT or STFT) into num_mel_bins frequency information based on the [lower_edge_hertz, upper_edge_hertz] range on the mel scale.
+This function defines the mel scale in terms of a frequency in hertz according to the following formula:
+
+    mel(f) = 2595 * log10(1 + f/700)
+
+In the returned matrix, all the triangles (filterbanks) have a peak value of 1.0.
+
+The returned MelWeightMatrix can be used to right-multiply a spectrogram S of shape [frames, num_spectrogram_bins] of linear scale spectrum values (e.g. STFT magnitudes) to generate a "mel spectrogram" M of shape [frames, num_mel_bins].
+
+## Attributes
+
+- **output_datatype** (INT, optional): The data type of the output tensor. Strictly must be one of the values from DataType enum in TensorProto whose values correspond to T3. The default value is 1 = FLOAT.
+
+## Inputs (5 - 5)
+
+- **num_mel_bins** (T1): The number of bands in the mel spectrum.
+- **dft_length** (T1): The size of the original DFT. The size of the original DFT is used to infer the size of the onesided DFT, which is understood to be floor(dft_length/2) + 1, i.e. the spectrogram only contains the nonredundant DFT bins.
+- **sample_rate** (T1): Samples per second of the input signal used to create the spectrogram. Used to figure out the frequencies corresponding to each spectrogram bin, which dictates how they are mapped into the mel scale.
+- **lower_edge_hertz** (T2): Lower bound on the frequencies to be included in the mel spectrum. This corresponds to the lower edge of the lowest triangular band.
+- **upper_edge_hertz** (T2): The desired top edge of the highest frequency band.
+
+## Outputs (1 - 1)
+
+- **output** (T3): The Mel Weight Matrix. The output has the shape: [floor(dft_length/2) + 1][num_mel_bins].
+
+## Type Constraints
+
+- **T1**: tensor(int32), tensor(int64)
+  Constrain to integer tensors.
+- **T2**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain to float tensors
+- **T3**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)
+  Constrain to any numerical types.

--- a/onnx-spec/ops/Min.md
+++ b/onnx-spec/ops/Min.md
@@ -1,0 +1,22 @@
+# Min
+
+Since opset **13**
+
+## Description
+
+Element-wise min of each of the input tensors (with Numpy-style broadcasting support).
+All inputs and outputs must have the same data type.
+This operator supports **multidirectional (i.e., Numpy-style) broadcasting**; for more details please check [the doc](Broadcasting.md).
+
+## Inputs (1 - 2147483647)
+
+- **data_0** (T, variadic): List of tensors for min.
+
+## Outputs (1 - 1)
+
+- **min** (T): Output tensor.
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)
+  Constrain input and output types to numeric tensors.

--- a/onnx-spec/ops/Mish.md
+++ b/onnx-spec/ops/Mish.md
@@ -1,0 +1,26 @@
+# Mish
+
+Since opset **22**
+
+## Description
+
+Mish: A Self Regularized Non-Monotonic Neural Activation Function.
+
+Perform the linear unit element-wise on the input tensor X using formula:
+
+```
+mish(x) = x * tanh(softplus(x)) = x * tanh(ln(1 + e^{x}))
+```
+
+## Inputs (1 - 1)
+
+- **X** (T): Input tensor
+
+## Outputs (1 - 1)
+
+- **Y** (T): Output tensor
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain input X and output types to float tensors.

--- a/onnx-spec/ops/Mod.md
+++ b/onnx-spec/ops/Mod.md
@@ -1,0 +1,41 @@
+# Mod
+
+Since opset **13**
+
+## Description
+
+Performs an element-wise binary modulo operation.
+The semantics and supported data types depend on the value of the `fmod` attribute which must be `0` (default), or `1`.
+
+If the `fmod` attribute is set to `0`, `T` is constrained to integer data types and the semantics follow that of the Python `%`-operator.
+The sign of the result is that of the divisor.
+
+If `fmod` is set to `1`, the behavior of this operator follows that of the `fmod` function in C and `T` is constrained to floating point data types.
+The result of this operator is the remainder of the division operation `x / y` where `x` and `y` are respective elements of `A` and `B`. The result is exactly the value `x - n * y`, where `n` is `x / y` with its fractional part truncated.
+The returned value has the same sign as `x` (except if `x` is `-0`) and is less or equal to `|y|` in magnitude.
+The following special cases apply when `fmod` is set to `1`:
+- If `x` is `-0` and `y` is greater than zero, either `+0` or `-0` may be returned.
+- If `x` is `±∞` and `y` is not `NaN`, `NaN` is returned.
+- If `y` is `±0` and `x` is not `NaN`, `NaN` should be returned.
+- If `y` is `±∞` and `x` is finite, `x` is returned.
+- If either argument is `NaN`, `NaN` is returned.
+
+This operator supports **multidirectional (i.e., NumPy-style) broadcasting**; for more details please check [the doc](Broadcasting.md).
+
+## Attributes
+
+- **fmod** (INT, optional): Whether the operator should behave like fmod (default=0 meaning it will do integer mods); Set this to 1 to force fmod treatment
+
+## Inputs (2 - 2)
+
+- **A** (T): Dividend tensor
+- **B** (T): Divisor tensor
+
+## Outputs (1 - 1)
+
+- **C** (T): Remainder tensor
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)
+  Constrain input and output types to high-precision numeric tensors.

--- a/onnx-spec/ops/Mul.md
+++ b/onnx-spec/ops/Mul.md
@@ -1,0 +1,25 @@
+# Mul
+
+Since opset **14**
+
+## Description
+
+Performs element-wise binary multiplication (with Numpy-style broadcasting support).
+
+This operator supports **multidirectional (i.e., Numpy-style) broadcasting**; for more details please check [the doc](Broadcasting.md).
+
+(Opset 14 change): Extend supported types to include uint8, int8, uint16, and int16.
+
+## Inputs (2 - 2)
+
+- **A** (T): First operand.
+- **B** (T): Second operand.
+
+## Outputs (1 - 1)
+
+- **C** (T): Result, has same element type as two inputs
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)
+  Constrain input and output types to all numeric tensors.

--- a/onnx-spec/ops/Multinomial.md
+++ b/onnx-spec/ops/Multinomial.md
@@ -1,0 +1,29 @@
+# Multinomial
+
+Since opset **22**
+
+## Description
+
+Generate a tensor of samples from a multinomial distribution according to the probabilities
+of each of the possible outcomes.
+
+## Attributes
+
+- **dtype** (INT, optional): (Optional) The data type for the elements of the output tensor, if not specified, we will use int32.
+- **sample_size** (INT, optional): Number of times to sample.
+- **seed** (FLOAT, optional): (Optional) Seed to the random generator, if not specified we will auto generate one.
+
+## Inputs (1 - 1)
+
+- **input** (T1): Input tensor with shape [batch_size, class_size], where class_size is the number of all possible outcomes. Each value along the axis zero represents the unnormalized log-probability of each corresponding outcome in a batch.
+
+## Outputs (1 - 1)
+
+- **output** (T2): Output tensor with shape [batch_size, sample_size], where sample_size is the number of times to sample. Each value along the axis zero represents the outcome of the corresponding sample in a batch.
+
+## Type Constraints
+
+- **T1**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain input types to float tensors.
+- **T2**: tensor(int32), tensor(int64)
+  Constrain output types to integral tensors.

--- a/onnx-spec/ops/Neg.md
+++ b/onnx-spec/ops/Neg.md
@@ -1,0 +1,22 @@
+# Neg
+
+Since opset **13**
+
+## Description
+
+Neg takes one input data (Tensor<T>) and produces one output data
+(Tensor<T>) where each element flipped sign, y = -x, is applied to
+the tensor elementwise.
+
+## Inputs (1 - 1)
+
+- **X** (T): Input tensor
+
+## Outputs (1 - 1)
+
+- **Y** (T): Output tensor
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8)
+  Constrain input and output types to signed numeric tensors.

--- a/onnx-spec/ops/NegativeLogLikelihoodLoss.md
+++ b/onnx-spec/ops/NegativeLogLikelihoodLoss.md
@@ -1,0 +1,129 @@
+# NegativeLogLikelihoodLoss
+
+Since opset **22**
+
+## Description
+
+A NegativeLogLikelihoodLoss operator computes (weighted) negative log likelihood loss.
+Its "input" tensor has the shape of (N, C, d1, d2, ..., dk) where k >= 0.
+The "input" tensor contains log-probabilities for input[n, :, d_1, d_2,..., d_k] being in a class of [0, C).
+The operator's "target" input tensor has the shape of (N, d1, d2, ..., dk). It encodes class labels (one of C classes)
+or it may contain a special value (indicated by an attribute ignore_index) for N x d1 x d2 x ... x dk samples.
+The loss value for input[n, :, d_1, d_2,...d_k] being classified as class c = target[n][d_1][d_2]...[d_k] is computed as:
+
+```
+loss[n][d_1][d_2]...[d_k] = -input[n][c][d_1][d_2]...[d_k].
+```
+
+When an optional "weight" is provided, the sample loss is calculated as:
+
+```
+loss[n][d_1][d_2]...[d_k] = -input[n][c][d_1][d_2]...[d_k] * weight[c].
+```
+
+loss is zero for the case when target-value equals ignore_index.
+
+```
+loss[n][d_1][d_2]...[d_k] = 0, when target[n][d_1][d_2]...[d_k] = ignore_index
+```
+
+If "reduction" attribute is set to "none", the operator's output will be the above loss with shape (N, d1, d2, ..., dk).
+If "reduction" attribute is set to "mean" (the default attribute value), the output loss is (weight) averaged:
+
+```
+mean(loss), if "weight" is not provided,
+```
+
+or if weight is provided,
+
+```
+sum(loss) / sum(weight[target[n][d_1][d_2]...[d_k]]]), for all samples.
+```
+
+If "reduction" attribute is set to "sum", the output is a scalar: `sum(loss)`.
+
+See also https://pytorch.org/docs/stable/nn.html#torch.nn.NLLLoss.
+
+Example 1:
+
+```
+// negative log likelihood loss, "none" reduction
+N, C, d1 = 2, 3, 2
+input = [[[1.0, 2.0], [2.0, 2.0], [3.0, 2.0]],
+          [[0.0, 1.0], [2.0, 2.0], [1.0, 2]]]
+target = [[2, 1], [0, 2]]
+
+loss = np.zeros((N, d1))
+for n in range(N):
+    for d_1 in range(d1):
+        c = target[n][d_1]
+        loss[n][d_1] = -input[n][c][d_1]
+
+// print(loss)
+// [[-3. -2.]
+//  [-0. -2.]]
+```
+
+Example 2:
+
+```
+// weighted negative log likelihood loss, sum reduction
+N, C, d1 = 2, 3, 2
+input = [[[1.0, 2.0], [2.0, 2.0], [3.0, 2.0]],
+        [[0.0, 1.0], [2.0, 2.0], [1.0, 2]]]
+target = [[2, 1], [0, 2]]
+weight = [0.2, 0.3, 0.1]
+loss = np.zeros((N, d1))
+for n in range(N):
+    for d_1 in range(d1):
+        c = target[n][d_1]
+        loss[n][d_1] = -input[n][c][d_1] * weight[c]
+
+loss = np.sum(loss)
+// print(loss)
+// -1.1
+```
+
+Example 3:
+
+```
+// weighted negative log likelihood loss, mean reduction
+N, C, d1 = 2, 3, 2
+input = [[[1.0, 2.0], [2.0, 2.0], [3.0, 2.0]],
+        [[0.0, 1.0], [2.0, 2.0], [1.0, 2]]]
+target = [[2, 1], [0, 2]]
+weight = [0.2, 0.3, 0.1]
+loss = np.zeros((N, d1))
+weight_total = 0
+for n in range(N):
+    for d_1 in range(d1):
+        c = target[n][d_1]
+        loss[n][d_1] = -input[n][c][d_1] * weight[c]
+        weight_total = weight_total + weight[c]
+
+loss = np.sum(loss) / weight_total
+// print(loss)
+// -1.57
+```
+
+## Attributes
+
+- **ignore_index** (INT, optional): Specifies a target value that is ignored and does not contribute to the input gradient. It's an optional value.
+- **reduction** (STRING, optional): Type of reduction to apply to loss: none, sum, mean (default). 'none': the output is the loss for each sample. 'sum': the output will be summed. 'mean': the sum of the output will be divided by the sum of applied weights.
+
+## Inputs (2 - 3)
+
+- **input** (T): Input tensor of shape (N, C) or (N, C, d1, d2, ..., dk).
+- **target** (Tind): Target tensor of shape (N) or (N, d1, d2, ..., dk). Target element value shall be in range of [0, C). If ignore_index is specified, it may have a value outside [0, C) and the target values should either be in the range [0, C) or have the value ignore_index.
+- **weight** (T, optional): Optional rescaling weight tensor. If given, it has to be a tensor of size C. Otherwise, it is treated as if having all ones.
+
+## Outputs (1 - 1)
+
+- **loss** (T): The negative log likelihood loss
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain input, weight, and output types to floating-point tensors.
+- **Tind**: tensor(int32), tensor(int64)
+  Constrain target to integer types

--- a/onnx-spec/ops/NonMaxSuppression.md
+++ b/onnx-spec/ops/NonMaxSuppression.md
@@ -1,0 +1,29 @@
+# NonMaxSuppression
+
+Since opset **11**
+
+## Description
+
+Filter out boxes that have high intersection-over-union (IOU) overlap with previously selected boxes.
+Bounding boxes with score less than score_threshold are removed. Bounding box format is indicated by attribute center_point_box.
+Note that this algorithm is agnostic to where the origin is in the coordinate system and more generally is invariant to
+orthogonal transformations and translations of the coordinate system; thus translating or reflections of the coordinate system
+result in the same boxes being selected by the algorithm.
+The selected_indices output is a set of integers indexing into the input collection of bounding boxes representing the selected boxes.
+The bounding box coordinates corresponding to the selected indices can then be obtained using the Gather or GatherND operation.
+
+## Attributes
+
+- **center_point_box** (INT, optional): Integer indicate the format of the box data. The default is 0. 0 - the box data is supplied as [y1, x1, y2, x2] where (y1, x1) and (y2, x2) are the coordinates of any diagonal pair of box corners and the coordinates can be provided as normalized (i.e., lying in the interval [0, 1]) or absolute. Mostly used for TF models. 1 - the box data is supplied as [x_center, y_center, width, height]. Mostly used for Pytorch models.
+
+## Inputs (2 - 5)
+
+- **boxes** (tensor(float)): An input tensor with shape [num_batches, spatial_dimension, 4]. The single box data format is indicated by center_point_box.
+- **scores** (tensor(float)): An input tensor with shape [num_batches, num_classes, spatial_dimension]
+- **max_output_boxes_per_class** (tensor(int64), optional): Integer representing the maximum number of boxes to be selected per batch per class. It is a scalar. Default to 0, which means no output.
+- **iou_threshold** (tensor(float), optional): Float representing the threshold for deciding whether boxes overlap too much with respect to IOU. It is scalar. Value range [0, 1]. Default to 0.
+- **score_threshold** (tensor(float), optional): Float representing the threshold for deciding when to remove boxes based on score. It is a scalar.
+
+## Outputs (1 - 1)
+
+- **selected_indices** (tensor(int64)): selected indices from the boxes tensor. [num_selected_indices, 3], the selected index format is [batch_index, class_index, box_index].

--- a/onnx-spec/ops/NonZero.md
+++ b/onnx-spec/ops/NonZero.md
@@ -1,0 +1,24 @@
+# NonZero
+
+Since opset **13**
+
+## Description
+
+Returns the indices of the elements that are non-zero
+    (in row-major order - by dimension).
+    NonZero behaves similar to numpy.nonzero:
+    https://docs.scipy.org/doc/numpy/reference/generated/numpy.nonzero.html,
+    but for scalar input, NonZero produces output shape (0, N) instead of (1, N), which is different from Numpy's behavior.
+
+## Inputs (1 - 1)
+
+- **X** (T): input
+
+## Outputs (1 - 1)
+
+- **Y** (tensor(int64)): output
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(bool), tensor(complex128), tensor(complex64), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(string), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)
+  Constrain to all tensor types.

--- a/onnx-spec/ops/Not.md
+++ b/onnx-spec/ops/Not.md
@@ -1,0 +1,20 @@
+# Not
+
+Since opset **1**
+
+## Description
+
+Returns the negation of the input tensor element-wise.
+
+## Inputs (1 - 1)
+
+- **X** (T): Input tensor
+
+## Outputs (1 - 1)
+
+- **Y** (T): Output tensor
+
+## Type Constraints
+
+- **T**: tensor(bool)
+  Constrain input/output to boolean tensors.

--- a/onnx-spec/ops/OneHot.md
+++ b/onnx-spec/ops/OneHot.md
@@ -1,0 +1,47 @@
+# OneHot
+
+Since opset **11**
+
+## Description
+
+Produces a one-hot tensor based on inputs.
+    The locations represented by the index values in the 'indices' input tensor will have 'on_value'
+    and the other locations will have 'off_value' in the output tensor, where 'on_value' and 'off_value'
+    are specified as part of required input argument 'values', which is a two-element tensor of format
+    [off_value, on_value]. The rank of the output tensor will be one greater than the rank of the
+    input tensor. The additional dimension is for one-hot representation. The additional dimension will
+    be inserted at the position specified by 'axis'. If 'axis' is not specified then then additional
+    dimension will be inserted as the innermost dimension, i.e. axis=-1. The size of the additional
+    dimension is specified by required scalar input 'depth'. The type of the output tensor is the same
+    as the type of the 'values' input. Any entries in the 'indices' input tensor with values outside
+    the range [-depth, depth-1] will result in one-hot representation with all 'off_value' values in the
+    output tensor.
+
+    when axis = 0:
+    output[input[i, j, k], i, j, k] = 1 for all i, j, k and 0 otherwise.
+
+    when axis = -1:
+    output[i, j, k, input[i, j, k]] = 1 for all i, j, k and 0 otherwise.
+
+## Attributes
+
+- **axis** (INT, optional): (Optional) Axis along which one-hot representation in added. Default: axis=-1. axis=-1 means that the additional dimension will be inserted as the innermost/last dimension in the output tensor. Negative value means counting dimensions from the back. Accepted range is [-r-1, r] where r = rank(indices).
+
+## Inputs (3 - 3)
+
+- **indices** (T1): Input tensor containing indices. Any entries in the 'indices' input tensor with values outside the range [-depth, depth-1] will result in one-hot representation with all 'off_value' values in the output tensor.In case 'indices' is of non-integer type, the values will be casted to int64 before use.
+- **depth** (T2): Scalar or Rank 1 tensor containing exactly one element, specifying the number of classes in one-hot tensor. This is also the size of the one-hot dimension (specified by 'axis' attribute) added on in the output tensor. The values in the 'indices' input tensor are expected to be in the range [-depth, depth-1]. In case 'depth' is of non-integer type, it will be casted to int64 before use.
+- **values** (T3): Rank 1 tensor containing exactly two elements, in the format [off_value, on_value], where 'on_value' is the value used for filling locations specified in 'indices' input tensor, and 'off_value' is the value used for filling locations other than those specified in 'indices' input tensor.
+
+## Outputs (1 - 1)
+
+- **output** (T3): Tensor of rank one greater than input tensor 'indices', i.e. rank(output) = rank(indices) + 1. The data type for the elements of the output tensor is the same as the type of input 'values' is used.
+
+## Type Constraints
+
+- **T1**: tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)
+  Constrain input to only numeric types.
+- **T2**: tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)
+  Constrain input to only numeric types.
+- **T3**: tensor(bool), tensor(complex128), tensor(complex64), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(string), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)
+  Constrain to any tensor type.

--- a/onnx-spec/ops/Optional.md
+++ b/onnx-spec/ops/Optional.md
@@ -1,0 +1,27 @@
+# Optional
+
+Since opset **15**
+
+## Description
+
+Constructs an optional-type value containing either an empty optional of a certain type specified by the attribute,
+or a non-empty value containing the input element.
+
+## Attributes
+
+- **type** (TYPE_PROTO, optional): Type of the element in the optional output
+
+## Inputs (0 - 1)
+
+- **input** (V, optional): The input element.
+
+## Outputs (1 - 1)
+
+- **output** (O): The optional output enclosing the input element.
+
+## Type Constraints
+
+- **V**: seq(tensor(bool)), seq(tensor(complex128)), seq(tensor(complex64)), seq(tensor(double)), seq(tensor(float)), seq(tensor(float16)), seq(tensor(int16)), seq(tensor(int32)), seq(tensor(int64)), seq(tensor(int8)), seq(tensor(string)), seq(tensor(uint16)), seq(tensor(uint32)), seq(tensor(uint64)), seq(tensor(uint8)), tensor(bool), tensor(complex128), tensor(complex64), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(string), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)
+  Constrain input type to all tensor and sequence types.
+- **O**: optional(seq(tensor(bool))), optional(seq(tensor(complex128))), optional(seq(tensor(complex64))), optional(seq(tensor(double))), optional(seq(tensor(float))), optional(seq(tensor(float16))), optional(seq(tensor(int16))), optional(seq(tensor(int32))), optional(seq(tensor(int64))), optional(seq(tensor(int8))), optional(seq(tensor(string))), optional(seq(tensor(uint16))), optional(seq(tensor(uint32))), optional(seq(tensor(uint64))), optional(seq(tensor(uint8))), optional(tensor(bool)), optional(tensor(complex128)), optional(tensor(complex64)), optional(tensor(double)), optional(tensor(float)), optional(tensor(float16)), optional(tensor(int16)), optional(tensor(int32)), optional(tensor(int64)), optional(tensor(int8)), optional(tensor(string)), optional(tensor(uint16)), optional(tensor(uint32)), optional(tensor(uint64)), optional(tensor(uint8))
+  Constrain output type to all optional tensor or optional sequence types.

--- a/onnx-spec/ops/OptionalGetElement.md
+++ b/onnx-spec/ops/OptionalGetElement.md
@@ -1,0 +1,24 @@
+# OptionalGetElement
+
+Since opset **18**
+
+## Description
+
+If the input is a tensor or sequence type, it returns the input.
+If the input is an optional type, it outputs the element in the input.
+It is an error if the input is an empty optional-type (i.e. does not have an element) and the behavior is undefined in this case.
+
+## Inputs (1 - 1)
+
+- **input** (O): The optional input.
+
+## Outputs (1 - 1)
+
+- **output** (V): Output element in the optional input.
+
+## Type Constraints
+
+- **O**: optional(seq(tensor(bool))), optional(seq(tensor(complex128))), optional(seq(tensor(complex64))), optional(seq(tensor(double))), optional(seq(tensor(float))), optional(seq(tensor(float16))), optional(seq(tensor(int16))), optional(seq(tensor(int32))), optional(seq(tensor(int64))), optional(seq(tensor(int8))), optional(seq(tensor(string))), optional(seq(tensor(uint16))), optional(seq(tensor(uint32))), optional(seq(tensor(uint64))), optional(seq(tensor(uint8))), optional(tensor(bool)), optional(tensor(complex128)), optional(tensor(complex64)), optional(tensor(double)), optional(tensor(float)), optional(tensor(float16)), optional(tensor(int16)), optional(tensor(int32)), optional(tensor(int64)), optional(tensor(int8)), optional(tensor(string)), optional(tensor(uint16)), optional(tensor(uint32)), optional(tensor(uint64)), optional(tensor(uint8)), seq(tensor(bool)), seq(tensor(complex128)), seq(tensor(complex64)), seq(tensor(double)), seq(tensor(float)), seq(tensor(float16)), seq(tensor(int16)), seq(tensor(int32)), seq(tensor(int64)), seq(tensor(int8)), seq(tensor(string)), seq(tensor(uint16)), seq(tensor(uint32)), seq(tensor(uint64)), seq(tensor(uint8)), tensor(bool), tensor(complex128), tensor(complex64), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(string), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)
+  Constrain input type to optional tensor and optional sequence types.
+- **V**: seq(tensor(bool)), seq(tensor(complex128)), seq(tensor(complex64)), seq(tensor(double)), seq(tensor(float)), seq(tensor(float16)), seq(tensor(int16)), seq(tensor(int32)), seq(tensor(int64)), seq(tensor(int8)), seq(tensor(string)), seq(tensor(uint16)), seq(tensor(uint32)), seq(tensor(uint64)), seq(tensor(uint8)), tensor(bool), tensor(complex128), tensor(complex64), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(string), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)
+  Constrain output type to all tensor or sequence types.

--- a/onnx-spec/ops/OptionalHasElement.md
+++ b/onnx-spec/ops/OptionalHasElement.md
@@ -1,0 +1,24 @@
+# OptionalHasElement
+
+Since opset **18**
+
+## Description
+
+Returns true if (1) the input is an optional-type and contains an element,
+or, (2) the input is a tensor or sequence type.
+If the input is not provided or is an empty optional-type, this op returns false.
+
+## Inputs (0 - 1)
+
+- **input** (O, optional): The optional input.
+
+## Outputs (1 - 1)
+
+- **output** (B): A scalar boolean tensor. If true, it indicates that optional-type input contains an element. Otherwise, it is empty.
+
+## Type Constraints
+
+- **O**: optional(seq(tensor(bool))), optional(seq(tensor(complex128))), optional(seq(tensor(complex64))), optional(seq(tensor(double))), optional(seq(tensor(float))), optional(seq(tensor(float16))), optional(seq(tensor(int16))), optional(seq(tensor(int32))), optional(seq(tensor(int64))), optional(seq(tensor(int8))), optional(seq(tensor(string))), optional(seq(tensor(uint16))), optional(seq(tensor(uint32))), optional(seq(tensor(uint64))), optional(seq(tensor(uint8))), optional(tensor(bool)), optional(tensor(complex128)), optional(tensor(complex64)), optional(tensor(double)), optional(tensor(float)), optional(tensor(float16)), optional(tensor(int16)), optional(tensor(int32)), optional(tensor(int64)), optional(tensor(int8)), optional(tensor(string)), optional(tensor(uint16)), optional(tensor(uint32)), optional(tensor(uint64)), optional(tensor(uint8)), seq(tensor(bool)), seq(tensor(complex128)), seq(tensor(complex64)), seq(tensor(double)), seq(tensor(float)), seq(tensor(float16)), seq(tensor(int16)), seq(tensor(int32)), seq(tensor(int64)), seq(tensor(int8)), seq(tensor(string)), seq(tensor(uint16)), seq(tensor(uint32)), seq(tensor(uint64)), seq(tensor(uint8)), tensor(bool), tensor(complex128), tensor(complex64), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(string), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)
+  Constrain input type to optional tensor and optional sequence types.
+- **B**: tensor(bool)
+  Constrain output to a boolean tensor.

--- a/onnx-spec/ops/Or.md
+++ b/onnx-spec/ops/Or.md
@@ -1,0 +1,26 @@
+# Or
+
+Since opset **7**
+
+## Description
+
+Returns the tensor resulted from performing the `or` logical operation
+elementwise on the input tensors `A` and `B` (with Numpy-style broadcasting support).
+
+This operator supports **multidirectional (i.e., Numpy-style) broadcasting**; for more details please check [the doc](Broadcasting.md).
+
+## Inputs (2 - 2)
+
+- **A** (T): First input operand for the logical operator.
+- **B** (T): Second input operand for the logical operator.
+
+## Outputs (1 - 1)
+
+- **C** (T1): Result tensor.
+
+## Type Constraints
+
+- **T**: tensor(bool)
+  Constrain input to boolean tensor.
+- **T1**: tensor(bool)
+  Constrain output to boolean tensor.

--- a/onnx-spec/ops/PRelu.md
+++ b/onnx-spec/ops/PRelu.md
@@ -1,0 +1,24 @@
+# PRelu
+
+Since opset **16**
+
+## Description
+
+PRelu takes input data (Tensor<T>) and slope tensor as input, and produces one
+output data (Tensor<T>) where the function `f(x) = slope * x for x < 0`,
+`f(x) = x for x >= 0`., is applied to the data tensor elementwise.
+This operator supports **unidirectional broadcasting** (tensor slope should be unidirectional broadcastable to input tensor X); for more details please check [the doc](Broadcasting.md).
+
+## Inputs (2 - 2)
+
+- **X** (T): Input tensor
+- **slope** (T): Slope tensor. The shape of slope can be smaller than first input X; if so, its shape must be unidirectional broadcastable to X
+
+## Outputs (1 - 1)
+
+- **Y** (T): Output tensor (same size as X)
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16), tensor(int32), tensor(int64), tensor(uint32), tensor(uint64)
+  Constrain input and output types to float/int tensors.

--- a/onnx-spec/ops/Pad.md
+++ b/onnx-spec/ops/Pad.md
@@ -1,0 +1,128 @@
+# Pad
+
+Since opset **24**
+
+## Description
+
+Given a tensor containing the data to be padded (`data`), a tensor containing the number of start and end pad values for axis (`pads`), (optionally) a `mode`, and (optionally) `constant_value`,
+a padded tensor (`output`) is generated.
+
+The three supported `modes` are (similar to corresponding modes supported by `numpy.pad`):
+
+1) `constant`(default) - pads with a given constant value as specified by `constant_value` (which defaults to 0, empty string, or False)
+
+2) `reflect` - pads with the reflection of the vector mirrored on the first and last values of the vector along each axis
+
+3) `edge` - pads with the edge values of array
+
+4) `wrap` - wrap-around padding as if the data tensor forms a torus
+
+
+Example 1 (`constant` mode):
+
+Insert 0 pads to the beginning of the second dimension.
+
+```
+data = [
+    [1.0, 1.2],
+    [2.3, 3.4],
+    [4.5, 5.7],
+]
+
+pads = [0, 2, 0, 0]
+
+mode = 'constant'
+
+constant_value = 0.0
+
+output = [
+    [0.0, 0.0, 1.0, 1.2],
+    [0.0, 0.0, 2.3, 3.4],
+    [0.0, 0.0, 4.5, 5.7],
+]
+```
+
+Example 2 (`reflect` mode):
+
+```
+data = [
+    [1.0, 1.2],
+    [2.3, 3.4],
+    [4.5, 5.7],
+]
+
+pads = [0, 2, 0, 0]
+
+mode = 'reflect'
+
+output = [
+    [1.0, 1.2, 1.0, 1.2],
+    [2.3, 3.4, 2.3, 3.4],
+    [4.5, 5.7, 4.5, 5.7],
+]
+```
+
+Example 3 (`edge` mode):
+
+```
+data = [
+    [1.0, 1.2],
+    [2.3, 3.4],
+    [4.5, 5.7],
+]
+
+pads = [0, 2, 0, 0]
+
+mode = 'edge'
+
+output = [
+    [1.0, 1.0, 1.0, 1.2],
+    [2.3, 2.3, 2.3, 3.4],
+    [4.5, 4.5, 4.5, 5.7],
+]
+```
+
+Example 4 (`wrap` mode):
+
+```
+data = [
+    [1.0, 1.2],
+    [2.3, 3.4],
+    [4.5, 5.7],
+]
+
+pads = [2, 1, 1, 1]
+
+mode = 'wrap'
+
+output = [
+    [3.4, 2.3, 3.4, 2.3],
+    [5.7, 4.5, 5.7, 4.5],
+    [1.2, 1.0, 1.2, 1.0],
+    [3.4, 2.3, 3.4, 2.3],
+    [5.7, 4.5, 5.7, 4.5],
+    [1.2, 1.0, 1.2, 1.0],
+]
+```
+
+## Attributes
+
+- **mode** (STRING, optional): Supported modes: `constant`(default), `reflect`, `edge`, `wrap`
+
+## Inputs (2 - 4)
+
+- **data** (T): Input tensor.
+- **pads** (tensor(int64)): Tensor of integers indicating the number of padding elements to add or remove (if negative) at the beginning and end of each axis. For 2D input tensor, it is the number of pixels. `pads` should be a 1D tensor of shape [2 * num_axes] where `num_axes` refers to the number of elements in the `axes` input or the input rank if `axes` are not provided explicitly. `pads` format should be: [x1_begin, x2_begin, ..., x1_end, x2_end,...], where xi_begin is the number of pad values added at the beginning of axis `axes[i]` and xi_end, the number of pad values added at the end of axis `axes[i]`.
+- **constant_value** (T, optional): (Optional) A scalar value to be used if the mode chosen is `constant` (by default it is 0, empty string or False).
+- **axes** (Tind, optional): 1-D tensor of axes that `pads` apply to. Negative value means counting dimensions from the back. Accepted range is [-r, r-1] where r = rank(data). Behavior is undefined if an axis is repeated. If not provided, all axes are assumed (`[0, 1, ..., input_rank-1]`).
+
+## Outputs (1 - 1)
+
+- **output** (T): Tensor after padding.
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(bool), tensor(complex128), tensor(complex64), tensor(double), tensor(float), tensor(float16), tensor(float4e2m1), tensor(float8e4m3fn), tensor(float8e4m3fnuz), tensor(float8e5m2), tensor(float8e5m2fnuz), tensor(float8e8m0), tensor(int16), tensor(int32), tensor(int4), tensor(int64), tensor(int8), tensor(string), tensor(uint16), tensor(uint32), tensor(uint4), tensor(uint64), tensor(uint8)
+  Constrain input and output types to all tensor types up to IRv12.
+- **Tind**: tensor(int32), tensor(int64)
+  Constrain indices to integer types

--- a/onnx-spec/ops/Pow.md
+++ b/onnx-spec/ops/Pow.md
@@ -1,0 +1,26 @@
+# Pow
+
+Since opset **15**
+
+## Description
+
+Pow takes input data (Tensor<T>) and exponent Tensor, and
+produces one output data (Tensor<T>) where the function `f(x) = x^exponent`,
+is applied to the data tensor elementwise.
+This operator supports **multidirectional (i.e., Numpy-style) broadcasting**; for more details please check [the doc](Broadcasting.md).
+
+## Inputs (2 - 2)
+
+- **X** (T): First operand, base of the exponent.
+- **Y** (T1): Second operand, power of the exponent.
+
+## Outputs (1 - 1)
+
+- **Z** (T): Output tensor
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16), tensor(int32), tensor(int64)
+  Constrain input X and output types to float/int tensors.
+- **T1**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)
+  Constrain input Y types to float/int tensors.

--- a/onnx-spec/ops/QLinearConv.md
+++ b/onnx-spec/ops/QLinearConv.md
@@ -1,0 +1,49 @@
+# QLinearConv
+
+Since opset **10**
+
+## Description
+
+The convolution operator consumes a quantized input tensor, its scale and zero point,
+a quantized filter, its scale and zero point, and output's scale and zero point,
+and computes the quantized output. Each scale and zero-point pair must have same shape.
+It means they must be either scalars (per tensor) or 1-D tensors (per output channel).
+Each input or output and its related zero point must have same type.
+When bias is present it must be quantized using scale = input scale * weight scale and
+zero point as 0.
+
+## Attributes
+
+- **auto_pad** (STRING, optional): auto_pad must be either NOTSET, SAME_UPPER, SAME_LOWER or VALID. Where default value is NOTSET, which means explicit padding is used. SAME_UPPER or SAME_LOWER mean pad the input so that `output_shape[i] = ceil(input_shape[i] / strides[i])` for each axis `i`. The padding is split between the two sides equally or almost equally (depending on whether it is even or odd). In case the padding is an odd number, the extra padding is added at the end for SAME_UPPER and at the beginning for SAME_LOWER.
+- **dilations** (INTS, optional): dilation value along each spatial axis of the filter. If not present, the dilation defaults to 1 along each spatial axis.
+- **group** (INT, optional): number of groups input channels and output channels are divided into. default is 1.
+- **kernel_shape** (INTS, optional): The shape of the convolution kernel. If not present, should be inferred from input 'w'.
+- **pads** (INTS, optional): Padding for the beginning and ending along each spatial axis, it can take any value greater than or equal to 0.The value represent the number of pixels added to the beginning and end part of the corresponding axis.`pads` format should be as follow [x1_begin, x2_begin...x1_end, x2_end,...], where xi_begin the number ofpixels added at the beginning of axis `i` and xi_end, the number of pixels added at the end of axis `i`.This attribute cannot be used simultaneously with auto_pad attribute. If not present, the padding defaultsto 0 along start and end of each spatial axis.
+- **strides** (INTS, optional): Stride along each spatial axis. If not present, the stride defaults to 1 along each spatial axis.
+
+## Inputs (8 - 9)
+
+- **x** (T1): Input data tensor from previous layer; has size (N x C x H x W), where N is the batch size, C is the number of channels, and H and W are the height and width. Note that this is for the 2D image. Otherwise the size is (N x C x D1 x D2 ... x Dn). Optionally, if dimension denotation is in effect, the operation expects input data tensor to arrive with the dimension denotation of [DATA_BATCH, DATA_CHANNEL, DATA_FEATURE, DATA_FEATURE ...].
+- **x_scale** (tensor(float)): Scale tensor for input 'x'. It's a scalar, which means a per-tensor/layer quantization.
+- **x_zero_point** (T1): Zero point tensor for input 'x'. It's a scalar, which means a per-tensor/layer quantization.
+- **w** (T2): The weight tensor that will be used in the convolutions; has size (M x C/group x kH x kW), where C is the number of channels, and kH and kW are the height and width of the kernel, and M is the number of feature maps. For more than 2 dimensions, the kernel shape will be (M x C/group x k1 x k2 x ... x kn), where (k1 x k2 x ... kn) is the dimension of the kernel. Optionally, if dimension denotation is in effect, the operation expects the weight tensor to arrive with the dimension denotation of [FILTER_OUT_CHANNEL, FILTER_IN_CHANNEL, FILTER_SPATIAL, FILTER_SPATIAL ...]. X.shape[1] == (W.shape[1] * group) == C (assuming zero based indices for the shape array). Or in other words FILTER_IN_CHANNEL should be equal to DATA_CHANNEL.
+- **w_scale** (tensor(float)): Scale tensor for input 'w'. It could be a scalar or a 1-D tensor, which means a per-tensor/layer or per output channel quantization. If it's a 1-D tensor, its number of elements should be equal to the number of output channels (M).
+- **w_zero_point** (T2): Zero point tensor for input 'w'. It could be a scalar or a 1-D tensor, which means a per-tensor/layer or per output channel quantization. If it's a 1-D tensor, its number of elements should be equal to the number of output channels (M).
+- **y_scale** (tensor(float)): Scale tensor for output 'y'. It's a scalar, which means a per-tensor/layer quantization.
+- **y_zero_point** (T3): Zero point tensor for output 'y'. It's a scalar, which means a per-tensor/layer quantization.
+- **B** (T4, optional): Optional 1D bias to be added to the convolution, has size of M. Bias must be quantized using scale = x_scale * w_scale and zero_point = 0
+
+## Outputs (1 - 1)
+
+- **y** (T3): Output data tensor that contains the result of the convolution. The output dimensions are functions of the kernel size, stride size, and pad lengths.
+
+## Type Constraints
+
+- **T1**: tensor(int8), tensor(uint8)
+  Constrain input type to 8-bit integer tensor.
+- **T2**: tensor(int8), tensor(uint8)
+  Constrain filter type to 8-bit integer tensor.
+- **T3**: tensor(int8), tensor(uint8)
+  Constrain output type to 8-bit integer tensor.
+- **T4**: tensor(int32)
+  Constrain bias type to 32-bit integer tensor.

--- a/onnx-spec/ops/QLinearMatMul.md
+++ b/onnx-spec/ops/QLinearMatMul.md
@@ -1,0 +1,43 @@
+# QLinearMatMul
+
+Since opset **21**
+
+## Description
+
+Matrix product that behaves like [numpy.matmul](https://numpy.org/doc/stable/reference/generated/numpy.matmul.html).
+It consumes two quantized input tensors, their scales and zero points, scale and zero point of output,
+and computes the quantized output. The quantization formula is y = saturate((x / y_scale) + y_zero_point).
+For (x / y_scale), it is rounding to nearest ties to even. Refer to https://en.wikipedia.org/wiki/Rounding for details.
+Scale and zero point must have same shape. They must be either scalar (per tensor) or N-D tensor
+(per row for 'a' and per column for 'b'). Scalar refers to per tensor quantization whereas N-D refers to per row
+or per column quantization. If the input is 2D of shape [M, K] then zero point and scale tensor may be
+an M element vector [v_1, v_2, ..., v_M] for per row quantization and K element vector of shape [v_1, v_2, ..., v_K]
+for per column quantization. If the input is N-D tensor with shape [D1, D2, M, K] then zero point and scale tensor may
+have shape [D1, D2, M, 1] for per row quantization and shape [D1, D2, 1, K] for per column quantization.
+Production must never overflow, and accumulation may overflow if and only if in 32 bits.
+
+## Inputs (8 - 8)
+
+- **a** (T1): N-dimensional quantized matrix a
+- **a_scale** (TS): scale of quantized input a
+- **a_zero_point** (T1): zero point of quantized input a
+- **b** (T2): N-dimensional quantized matrix b
+- **b_scale** (TS): scale of quantized input b
+- **b_zero_point** (T2): zero point of quantized input b
+- **y_scale** (TS): scale of quantized output y
+- **y_zero_point** (T3): zero point of quantized output y
+
+## Outputs (1 - 1)
+
+- **y** (T3): Quantized matrix multiply results from a * b
+
+## Type Constraints
+
+- **TS**: tensor(bfloat16), tensor(float), tensor(float16)
+  Constrain scales.
+- **T1**: tensor(float8e4m3fn), tensor(float8e4m3fnuz), tensor(float8e5m2), tensor(float8e5m2fnuz), tensor(int8), tensor(uint8)
+  The type of input a and its zeropoint.
+- **T2**: tensor(float8e4m3fn), tensor(float8e4m3fnuz), tensor(float8e5m2), tensor(float8e5m2fnuz), tensor(int8), tensor(uint8)
+  The type of input b and its zeropoint.
+- **T3**: tensor(float8e4m3fn), tensor(float8e4m3fnuz), tensor(float8e5m2), tensor(float8e5m2fnuz), tensor(int8), tensor(uint8)
+  The type of the output and its zeropoint.

--- a/onnx-spec/ops/QuantizeLinear.md
+++ b/onnx-spec/ops/QuantizeLinear.md
@@ -1,0 +1,60 @@
+# QuantizeLinear
+
+Since opset **24**
+
+## Description
+
+The linear quantization operator consumes a high-precision tensor, a scale, and a zero point to compute the
+low-precision/quantized tensor. The scale factor and zero point must have the same shape, determining the quantization
+granularity. The quantization formula is `y = saturate((x / y_scale) + y_zero_point)`.
+
+Saturation is done according to:
+- uint16: [0, 65535]
+- int16: [-32768, 32767]
+- uint8: [0, 255]
+- int8: [-128, 127]
+- uint4: [0, 15]
+- int4: [-8, 7]
+
+For `(x / y_scale)`, it rounds to the nearest even. Refer to https://en.wikipedia.org/wiki/Rounding for details.
+
+`y_zero_point` and `y` must have the same type. `y_zero_point` is usually not used for quantization to float8 and 4bit types, but the quantization
+formula remains the same for consistency, and the type of the attribute `y_zero_point` still determines the quantization type.
+`x` and `y_scale` are allowed to have different types. The type of `y_scale` determines the precision of the division operation between `x` and
+`y_scale`, unless the `precision` attribute is specified.
+
+There are three supported quantization granularities, determined by the shape of `y_scale`.
+In all cases, `y_zero_point` must have the same shape as `y_scale`.
+- Per-tensor (per-layer) quantization: `y_scale` is a scalar.
+- Per-axis quantization: The scale must be a 1-D tensor, with the length of the quantization axis. For an input shape
+ `(D0, ..., Di, ..., Dn)` and `axis=i`, `y_scale` is a 1-D tensor of length `Di`.
+- Blocked quantization: The scale's shape is identical to the input's shape, except for one dimension, in which
+  blocking is performed. Given `x` shape `(D0, ..., Di, ..., Dn)`, `axis=i`, and block size `B`: `y_scale` shape is
+  `(D0, ..., ceil(Di/B), ..., Dn)`.
+
+## Attributes
+
+- **axis** (INT, optional): (Optional) The axis of the dequantizing dimension of the input tensor. Used only for per-axis and blocked quantization. Negative value means counting dimensions from the back. Accepted range is `[-r, r-1]` where `r = rank(input)`. When the rank of the input is 1, per-tensor quantization is applied, rendering the axis unnecessary in this scenario.
+- **block_size** (INT, optional): (Optional) The size of the quantization block (number of times every scale is replicated). Used only for blocked quantization. The block size is a positive integer. Given `x` shape `(D0, ..., Di, ..., Dn)`, `y_scale` shape `(S0, ... Si, ...Sn)` and `axis=i`, the accepted range is `[ceil(Di/Si), ceil(Di/(Si-1))-1]`
+- **output_dtype** (INT, optional): (Optional) The output data type. If not supplied, the output data type is inferred from `y_zero_point` data type (`T3`). If neither `output_dtype` nor `y_zero_point` are supplied, output data type is uint8. If both `output_dtype` and `y_zero_point` are specified, `output_dtype` must be `T3`.
+- **precision** (INT, optional): (Optional) The precision of the division operation between `x` and `y_scale`. If not provided, it will be the same as the type of `y_scale`.
+- **saturate** (INT, optional): The parameter defines how the conversion behaves if an input value is out of range of the destination type. It only applies for float 8 quantization (float8e4m3fn, float8e4m3fnuz, float8e5m2, float8e5m2fnuz). It is true by default. All cases are fully described in two tables inserted in the operator description.
+
+## Inputs (2 - 3)
+
+- **x** (T1): N-D full precision Input tensor to be quantized.
+- **y_scale** (T2): Scale for doing quantization to get `y`. For per-tensor/layer quantization the scale is a scalar, for per-axis quantization it is a 1-D Tensor and for blocked quantization it has the same shape as the input, except for one dimension in which blocking is performed.
+- **y_zero_point** (T3, optional): Zero point for doing quantization to get `y`. Shape must match `y_scale`. Default is uint8 with zero point of 0 if it's not specified.
+
+## Outputs (1 - 1)
+
+- **y** (T3): N-D quantized output tensor. It has same shape as input `x`.
+
+## Type Constraints
+
+- **T1**: tensor(bfloat16), tensor(float), tensor(float16), tensor(int32)
+  The type of the input 'x'.
+- **T2**: tensor(bfloat16), tensor(float), tensor(float16), tensor(float8e8m0), tensor(int32)
+  The type of the input 'y_scale'.
+- **T3**: tensor(float4e2m1), tensor(float8e4m3fn), tensor(float8e4m3fnuz), tensor(float8e5m2), tensor(float8e5m2fnuz), tensor(int16), tensor(int4), tensor(int8), tensor(uint16), tensor(uint4), tensor(uint8)
+  The type of the input `y_zero_point` and the output `y`.

--- a/onnx-spec/ops/RMSNormalization.md
+++ b/onnx-spec/ops/RMSNormalization.md
@@ -1,0 +1,56 @@
+# RMSNormalization
+
+Since opset **23**
+
+## Description
+
+This is RMS normalization defined in ONNX as function as described in the paper https://arxiv.org/pdf/1910.07467.
+      The overall computation can be split into two stages. The root mean squared norm is taken over the last D dimensions,
+      where D is the dimension of normalized_shape. For example, if normalized_shape is (3, 5) (a 2-dimensional shape),
+      the rms norm is computed over the last 2 dimensions of the input. The computation required by standardization can be
+      described by the following equations.
+      ```
+      XSquared = Mul(X, X)
+      XSquaredMean = ReduceMean<axes=normalized_axes>(XSquared)
+      MeanSquareEpsilon = Add(XSquaredMean, epsilon)
+      RMS = Sqrt(MeanSquareEpsilon)
+      Normalized = Div(X, RMS)
+      ```
+      where `normalized_axes` is `[axis, ..., rank of X - 1]`. The variables `RMS` stand for root mean square,
+      Depending on `stash_type` attribute, the actual computation
+      must happen in different floating-point precision.
+      For example, if `stash_type` is 1, this operator casts
+      all input variables to 32-bit float, perform the computation, and
+      finally cast `Normalized` back to the original type of `X`.
+      The second stage then scales the outcome of the first stage using:
+      ```
+      Y= Mul(Normalized, Scale)
+      ```
+      Let `d[i]` indicate the i-th dimension of `X`.
+      If `X`'s shape is `[d[0], ..., d[axis-1], d[axis], ..., d[rank-1]]`,
+      the shape of `RMS` is `[d[0], ..., d[axis-1], 1, ..., 1]`.
+      `Y` and `X` have the same shape. This operator supports unidirectional broadcasting
+      (`Scale` should be unidirectional broadcastable to tensor `X`);
+      for more details please check [the doc](Broadcasting.md).
+
+## Attributes
+
+- **axis** (INT, optional): The first normalization dimension. If rank(X) is r, axis' allowed range is [-r, r). Negative value means counting dimensions from the back.
+- **epsilon** (FLOAT, optional): The epsilon value to use to avoid division by zero.
+- **stash_type** (INT, optional): The floating-point precision used in stage one of the computation.
+
+## Inputs (2 - 2)
+
+- **X** (T): The input tensor to be normalized. In general, the shape is (D1, D2, ... , Dn) for n-dimensional data, where the root mean squared norm is taken over the last D dimensions, D is determined by the axis attribute.
+- **scale** (V): Scale tensor. Scale tensor shape should be broadcastable to the normalized shape.
+
+## Outputs (1 - 1)
+
+- **Y** (V): Output data tensor. Same shape as X
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain input X type to float tensors.
+- **V**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain output Y and scale type to float tensors.

--- a/onnx-spec/ops/RNN.md
+++ b/onnx-spec/ops/RNN.md
@@ -1,0 +1,77 @@
+# RNN
+
+Since opset **22**
+
+## Description
+
+Computes an one-layer simple RNN. This operator is usually supported
+via some custom implementation such as CuDNN.
+
+Notations:
+
+* `X` - input tensor
+* `i` - input gate
+* `t` - time step (t-1 means previous time step)
+* `Wi` - W parameter weight matrix for input gate
+* `Ri` - R recurrence weight matrix for input gate
+* `Wbi` - W parameter bias vector for input gate
+* `Rbi` - R parameter bias vector for input gate
+* `WBi` - W parameter weight matrix for backward input gate
+* `RBi` - R recurrence weight matrix for backward input gate
+* `WBbi` - WR bias vectors for backward input gate
+* `RBbi` - RR bias vectors for backward input gate
+* `H` - Hidden state
+* `num_directions` - 2 if direction == bidirectional else 1
+
+Activation functions:
+
+* Relu(x)                - max(0, x)
+* Tanh(x)                - (1 - e^{-2x})/(1 + e^{-2x})
+* Sigmoid(x)             - 1/(1 + e^{-x})
+
+NOTE: Below are optional
+
+* Affine(x)              - alpha*x + beta
+* LeakyRelu(x)           - x if x >= 0 else alpha * x
+* ThresholdedRelu(x)     - x if x >= alpha else 0
+* ScaledTanh(x)          - alpha*Tanh(beta*x)
+* HardSigmoid(x)         - min(max(alpha*x + beta, 0), 1)
+* Elu(x)                 - x if x >= 0 else alpha*(e^x - 1)
+* Softsign(x)            - x/(1 + |x|)
+* Softplus(x)            - log(1 + e^x)
+
+Equations (Default: f=Tanh):
+
+* Ht = f(Xt*(Wi^T) + Ht-1*(Ri^T) + Wbi + Rbi)
+This operator has **optional** inputs/outputs. See [the doc](IR.md) for more details about the representation of optional arguments. An empty string may be used in the place of an actual argument's name to indicate a missing argument. Trailing optional arguments (those not followed by an argument that is present) may also be simply omitted.
+
+## Attributes
+
+- **activation_alpha** (FLOATS, optional): Optional scaling values used by some activation functions. The values are consumed in the order of activation functions, for example (f, g, h) in LSTM. Default values are the same as of corresponding ONNX operators.For example with LeakyRelu, the default alpha is 0.01.
+- **activation_beta** (FLOATS, optional): Optional scaling values used by some activation functions. The values are consumed in the order of activation functions, for example (f, g, h) in LSTM. Default values are the same as of corresponding ONNX operators.
+- **activations** (STRINGS, optional): One (or two if bidirectional) activation function for input gate. The activation function must be one of the activation functions specified above. Optional: Default `Tanh` if not specified.
+- **clip** (FLOAT, optional): Cell clip threshold. Clipping bounds the elements of a tensor in the range of [-threshold, +threshold] and is applied to the input of activations. No clip if not specified.
+- **direction** (STRING, optional): Specify if the RNN is forward, reverse, or bidirectional. Must be one of forward (default), reverse, or bidirectional.
+- **hidden_size** (INT, optional): Number of neurons in the hidden layer
+- **layout** (INT, optional): The shape format of inputs X, initial_h and outputs Y, Y_h. If 0, the following shapes are expected: X.shape = [seq_length, batch_size, input_size], Y.shape = [seq_length, num_directions, batch_size, hidden_size], initial_h.shape = Y_h.shape = [num_directions, batch_size, hidden_size]. If 1, the following shapes are expected: X.shape = [batch_size, seq_length, input_size], Y.shape = [batch_size, seq_length, num_directions, hidden_size], initial_h.shape = Y_h.shape = [batch_size, num_directions, hidden_size].
+
+## Inputs (3 - 6)
+
+- **X** (T): The input sequences packed (and potentially padded) into one 3-D tensor with the shape of `[seq_length, batch_size, input_size]`.
+- **W** (T): The weight tensor for input gate. Concatenation of `Wi` and `WBi` (if bidirectional). The tensor has shape `[num_directions, hidden_size, input_size]`.
+- **R** (T): The recurrence weight tensor. Concatenation of `Ri` and `RBi` (if bidirectional). The tensor has shape `[num_directions, hidden_size, hidden_size]`.
+- **B** (T, optional): The bias tensor for input gate. Concatenation of `[Wbi, Rbi]` and `[WBbi, RBbi]` (if bidirectional). The tensor has shape `[num_directions, 2*hidden_size]`. Optional: If not specified - assumed to be 0.
+- **sequence_lens** (T1, optional): Optional tensor specifying lengths of the sequences in a batch. If not specified - assumed all sequences in the batch to have length `seq_length`. It has shape `[batch_size]`.
+- **initial_h** (T, optional): Optional initial value of the hidden. If not specified - assumed to be 0. It has shape `[num_directions, batch_size, hidden_size]`.
+
+## Outputs (0 - 2)
+
+- **Y** (T, optional): A tensor that concats all the intermediate output values of the hidden. It has shape `[seq_length, num_directions, batch_size, hidden_size]`.
+- **Y_h** (T, optional): The last output value of the hidden. It has shape `[num_directions, batch_size, hidden_size]`.
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain input and output types to float tensors.
+- **T1**: tensor(int32)
+  Constrain seq_lens to integer tensor.

--- a/onnx-spec/ops/RandomNormal.md
+++ b/onnx-spec/ops/RandomNormal.md
@@ -1,0 +1,30 @@
+# RandomNormal
+
+Since opset **22**
+
+## Description
+
+Generate a tensor with random values drawn from a normal distribution. The shape
+of the tensor is specified by the `shape` argument and the parameter of the normal distribution
+specified by `mean` and `scale`.
+
+The data type is specified by the 'dtype' argument. The 'dtype' argument must
+be one of the data types specified in the 'DataType' enum field in the
+TensorProto message.
+
+## Attributes
+
+- **dtype** (INT, optional): The data type for the elements of the output tensor. Default is TensorProto::FLOAT.
+- **mean** (FLOAT, optional): The mean of the normal distribution.
+- **scale** (FLOAT, optional): The standard deviation of the normal distribution.
+- **seed** (FLOAT, optional): (Optional) Seed to the random generator, if not specified we will auto generate one.
+- **shape** (INTS, required): The shape of the output tensor.
+
+## Outputs (1 - 1)
+
+- **output** (T): Output tensor of random values drawn from normal distribution
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain output types to float tensors.

--- a/onnx-spec/ops/RandomNormalLike.md
+++ b/onnx-spec/ops/RandomNormalLike.md
@@ -1,0 +1,35 @@
+# RandomNormalLike
+
+Since opset **22**
+
+## Description
+
+Generate a tensor with random values drawn from a normal distribution.
+The shape of the output tensor is copied from the shape of the input tensor,
+and the parameters of the normal distribution are specified by `mean` and `scale`.
+
+The data type is specified by the 'dtype' argument, or copied from the input tensor if not provided.
+The 'dtype' argument must be one of the data types specified in the 'DataType' enum field in the
+TensorProto message, and be valid as an output type.
+
+## Attributes
+
+- **dtype** (INT, optional): (Optional) The data type for the elements of the output tensor, if not specified, we will use the data type of the input tensor.
+- **mean** (FLOAT, optional): The mean of the normal distribution.
+- **scale** (FLOAT, optional): The standard deviation of the normal distribution.
+- **seed** (FLOAT, optional): (Optional) Seed to the random generator, if not specified we will auto generate one.
+
+## Inputs (1 - 1)
+
+- **input** (T1): Input tensor to copy shape and optionally type information from.
+
+## Outputs (1 - 1)
+
+- **output** (T2): Output tensor of random values drawn from normal distribution
+
+## Type Constraints
+
+- **T1**: tensor(bfloat16), tensor(bool), tensor(complex128), tensor(complex64), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(string), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)
+  Constrain to any tensor type. If the dtype attribute is not provided this must be a valid output type.
+- **T2**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain output types to float tensors.

--- a/onnx-spec/ops/RandomUniform.md
+++ b/onnx-spec/ops/RandomUniform.md
@@ -1,0 +1,29 @@
+# RandomUniform
+
+Since opset **22**
+
+## Description
+
+Generate a tensor with random values drawn from a uniform distribution. The shape
+of the tensor is specified by the `shape` argument and the range by `low` and `high`.
+
+The data type is specified by the 'dtype' argument. The 'dtype' argument must
+be one of the data types specified in the 'DataType' enum field in the
+TensorProto message.
+
+## Attributes
+
+- **dtype** (INT, optional): The data type for the elements of the output tensor. If not specified, default is TensorProto::FLOAT.
+- **high** (FLOAT, optional): Upper boundary of the output values.
+- **low** (FLOAT, optional): Lower boundary of the output values.
+- **seed** (FLOAT, optional): (Optional) Seed to the random generator, if not specified we will auto generate one.
+- **shape** (INTS, required): The shape of the output tensor.
+
+## Outputs (1 - 1)
+
+- **output** (T): Output tensor of random values drawn from uniform distribution
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain output types to float tensors.

--- a/onnx-spec/ops/RandomUniformLike.md
+++ b/onnx-spec/ops/RandomUniformLike.md
@@ -1,0 +1,35 @@
+# RandomUniformLike
+
+Since opset **22**
+
+## Description
+
+Generate a tensor with random values drawn from a uniform distribution.
+The shape of the output tensor is copied from the shape of the input tensor,
+and the parameters of the uniform distribution are specified by `low` and `high`.
+
+The data type is specified by the 'dtype' argument, or copied from the input tensor if not provided.
+The 'dtype' argument must be one of the data types specified in the 'DataType' enum field in the
+TensorProto message and be valid as an output type.
+
+## Attributes
+
+- **dtype** (INT, optional): (Optional) The data type for the elements of the output tensor, if not specified, we will use the data type of the input tensor.
+- **high** (FLOAT, optional): Upper boundary of the output values.
+- **low** (FLOAT, optional): Lower boundary of the output values.
+- **seed** (FLOAT, optional): (Optional) Seed to the random generator, if not specified we will auto generate one.
+
+## Inputs (1 - 1)
+
+- **input** (T1): Input tensor to copy shape and optionally type information from.
+
+## Outputs (1 - 1)
+
+- **output** (T2): Output tensor of random values drawn from uniform distribution
+
+## Type Constraints
+
+- **T1**: tensor(bfloat16), tensor(bool), tensor(complex128), tensor(complex64), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(string), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)
+  Constrain to any tensor type. If the dtype attribute is not provided this must be a valid output type.
+- **T2**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain output types to float tensors.

--- a/onnx-spec/ops/Range.md
+++ b/onnx-spec/ops/Range.md
@@ -1,0 +1,51 @@
+# Range
+
+Since opset **11**
+
+## Description
+
+Generate a tensor containing a sequence of numbers that begin at `start` and extends by increments of `delta`
+up to `limit` (exclusive).
+
+The number of elements in the output of range is computed as below:
+
+```
+number_of_elements = max( ceil( (limit - start) / delta ) , 0 )
+```
+
+The pseudocode determining the contents of the output is shown below:
+
+```
+for(int i=0; i<number_of_elements; ++i) {
+  output[i] =  start + (i * delta);
+}
+```
+
+Example 1
+
+```
+Inputs: start = 3, limit = 9, delta = 3
+Output: [3, 6]
+```
+
+Example 2
+
+```
+Inputs: start = 10, limit = 4, delta = -2
+Output: [10, 8, 6]
+```
+
+## Inputs (3 - 3)
+
+- **start** (T): Scalar. First entry for the range of output values.
+- **limit** (T): Scalar. Exclusive upper limit for the range of output values.
+- **delta** (T): Scalar. Value to step by.
+
+## Outputs (1 - 1)
+
+- **output** (T): A 1-D tensor with same type as the inputs containing generated range of values.
+
+## Type Constraints
+
+- **T**: tensor(double), tensor(float), tensor(int16), tensor(int32), tensor(int64)
+  Constrain input types to common numeric type tensors.

--- a/onnx-spec/ops/Reciprocal.md
+++ b/onnx-spec/ops/Reciprocal.md
@@ -1,0 +1,22 @@
+# Reciprocal
+
+Since opset **13**
+
+## Description
+
+Reciprocal takes one input data (Tensor<T>) and produces one output data
+(Tensor<T>) where the reciprocal is, y = 1/x, is applied to
+the tensor elementwise.
+
+## Inputs (1 - 1)
+
+- **X** (T): Input tensor
+
+## Outputs (1 - 1)
+
+- **Y** (T): Output tensor
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain input and output types to float tensors.

--- a/onnx-spec/ops/ReduceL1.md
+++ b/onnx-spec/ops/ReduceL1.md
@@ -1,0 +1,33 @@
+# ReduceL1
+
+Since opset **18**
+
+## Description
+
+Computes the L1 norm of the input tensor's elements along the provided axes. The resulting
+tensor has the same rank as the input if `keepdims` equals 1. If `keepdims` equals 0, then
+the resulting tensor has the reduced dimension pruned. Input tensors of rank zero are
+valid. Reduction over an empty set of values yields 0.
+
+
+The above behavior is similar to numpy, with the exception that numpy defaults `keepdims`
+to `False` instead of `True`.
+
+## Attributes
+
+- **keepdims** (INT, optional): Keep the reduced dimension or not, default 1 means keep reduced dimension.
+- **noop_with_empty_axes** (INT, optional): Defines behavior when axes is not provided or is empty. If false (default), reduction happens over all axes. If true, no reduction is applied, but other operations will be performed. For example, ReduceSumSquare acts as a vanilla Square.
+
+## Inputs (1 - 2)
+
+- **data** (T): An input tensor.
+- **axes** (tensor(int64), optional): Optional input list of integers, along which to reduce. The default is to reduce over empty axes. When axes is empty (either not provided or explicitly empty), behavior depends on 'noop_with_empty_axes': reduction over all axes if 'noop_with_empty_axes' is false, or no reduction is applied if 'noop_with_empty_axes' is true (but other operations will be performed). Accepted range is [-r, r-1] where r = rank(data).
+
+## Outputs (1 - 1)
+
+- **reduced** (T): Reduced output tensor.
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16), tensor(int32), tensor(int64), tensor(uint32), tensor(uint64)
+  Constrain input and output types to numeric tensors.

--- a/onnx-spec/ops/ReduceL2.md
+++ b/onnx-spec/ops/ReduceL2.md
@@ -1,0 +1,33 @@
+# ReduceL2
+
+Since opset **18**
+
+## Description
+
+Computes the L2 norm of the input tensor's elements along the provided axes. The resulting
+tensor has the same rank as the input if `keepdims` equals 1. If `keepdims` equals 0, then
+the resulting tensor has the reduced dimension pruned. Input tensors of rank zero are
+valid. Reduction over an empty set of values yields 0.
+
+
+The above behavior is similar to numpy, with the exception that numpy defaults `keepdims`
+to `False` instead of `True`.
+
+## Attributes
+
+- **keepdims** (INT, optional): Keep the reduced dimension or not, default 1 means keep reduced dimension.
+- **noop_with_empty_axes** (INT, optional): Defines behavior when axes is not provided or is empty. If false (default), reduction happens over all axes. If true, no reduction is applied, but other operations will be performed. For example, ReduceSumSquare acts as a vanilla Square.
+
+## Inputs (1 - 2)
+
+- **data** (T): An input tensor.
+- **axes** (tensor(int64), optional): Optional input list of integers, along which to reduce. The default is to reduce over empty axes. When axes is empty (either not provided or explicitly empty), behavior depends on 'noop_with_empty_axes': reduction over all axes if 'noop_with_empty_axes' is false, or no reduction is applied if 'noop_with_empty_axes' is true (but other operations will be performed). Accepted range is [-r, r-1] where r = rank(data).
+
+## Outputs (1 - 1)
+
+- **reduced** (T): Reduced output tensor.
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16), tensor(int32), tensor(int64), tensor(uint32), tensor(uint64)
+  Constrain input and output types to numeric tensors.

--- a/onnx-spec/ops/ReduceLogSum.md
+++ b/onnx-spec/ops/ReduceLogSum.md
@@ -1,0 +1,33 @@
+# ReduceLogSum
+
+Since opset **18**
+
+## Description
+
+Computes the log sum of the input tensor's elements along the provided axes. The resulting
+tensor has the same rank as the input if `keepdims` equals 1. If `keepdims` equals 0, then
+the resulting tensor has the reduced dimension pruned. Input tensors of rank zero are
+valid. Reduction over an empty set of values yields minus infinity (if supported by the datatype) or undefined otherwise.
+
+
+The above behavior is similar to numpy, with the exception that numpy defaults `keepdims`
+to `False` instead of `True`.
+
+## Attributes
+
+- **keepdims** (INT, optional): Keep the reduced dimension or not, default 1 means keep reduced dimension.
+- **noop_with_empty_axes** (INT, optional): Defines behavior when axes is not provided or is empty. If false (default), reduction happens over all axes. If true, no reduction is applied, but other operations will be performed. For example, ReduceSumSquare acts as a vanilla Square.
+
+## Inputs (1 - 2)
+
+- **data** (T): An input tensor.
+- **axes** (tensor(int64), optional): Optional input list of integers, along which to reduce. The default is to reduce over empty axes. When axes is empty (either not provided or explicitly empty), behavior depends on 'noop_with_empty_axes': reduction over all axes if 'noop_with_empty_axes' is false, or no reduction is applied if 'noop_with_empty_axes' is true (but other operations will be performed). Accepted range is [-r, r-1] where r = rank(data).
+
+## Outputs (1 - 1)
+
+- **reduced** (T): Reduced output tensor.
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16), tensor(int32), tensor(int64), tensor(uint32), tensor(uint64)
+  Constrain input and output types to numeric tensors.

--- a/onnx-spec/ops/ReduceLogSumExp.md
+++ b/onnx-spec/ops/ReduceLogSumExp.md
@@ -1,0 +1,33 @@
+# ReduceLogSumExp
+
+Since opset **18**
+
+## Description
+
+Computes the log sum exponent of the input tensor's elements along the provided axes. The resulting
+tensor has the same rank as the input if `keepdims` equals 1. If `keepdims` equals 0, then
+the resulting tensor has the reduced dimension pruned. Input tensors of rank zero are
+valid. Reduction over an empty set of values yields minus infinity (if supported by the datatype) or undefined otherwise.
+
+
+The above behavior is similar to numpy, with the exception that numpy defaults `keepdims`
+to `False` instead of `True`.
+
+## Attributes
+
+- **keepdims** (INT, optional): Keep the reduced dimension or not, default 1 means keep reduced dimension.
+- **noop_with_empty_axes** (INT, optional): Defines behavior when axes is not provided or is empty. If false (default), reduction happens over all axes. If true, no reduction is applied, but other operations will be performed. For example, ReduceSumSquare acts as a vanilla Square.
+
+## Inputs (1 - 2)
+
+- **data** (T): An input tensor.
+- **axes** (tensor(int64), optional): Optional input list of integers, along which to reduce. The default is to reduce over empty axes. When axes is empty (either not provided or explicitly empty), behavior depends on 'noop_with_empty_axes': reduction over all axes if 'noop_with_empty_axes' is false, or no reduction is applied if 'noop_with_empty_axes' is true (but other operations will be performed). Accepted range is [-r, r-1] where r = rank(data).
+
+## Outputs (1 - 1)
+
+- **reduced** (T): Reduced output tensor.
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16), tensor(int32), tensor(int64), tensor(uint32), tensor(uint64)
+  Constrain input and output types to numeric tensors.

--- a/onnx-spec/ops/ReduceMax.md
+++ b/onnx-spec/ops/ReduceMax.md
@@ -1,0 +1,35 @@
+# ReduceMax
+
+Since opset **20**
+
+## Description
+
+Computes the max of the input tensor's elements along the provided axes. The resulting
+tensor has the same rank as the input if `keepdims` equals 1. If `keepdims` equals 0, then
+the resulting tensor has the reduced dimension pruned. Input tensors of rank zero are
+valid. Reduction over an empty set of values yields minus infinity (if supported by the datatype) or the minimum value of the data type otherwise.
+
+
+If the input data type is Boolean, the comparison should consider `False < True`.
+
+The above behavior is similar to numpy, with the exception that numpy defaults `keepdims`
+to `False` instead of `True`.
+
+## Attributes
+
+- **keepdims** (INT, optional): Keep the reduced dimension or not, default 1 means keep reduced dimension.
+- **noop_with_empty_axes** (INT, optional): Defines behavior when axes is not provided or is empty. If false (default), reduction happens over all axes. If true, no reduction is applied, but other operations will be performed. For example, ReduceSumSquare acts as a vanilla Square.
+
+## Inputs (1 - 2)
+
+- **data** (T): An input tensor.
+- **axes** (tensor(int64), optional): Optional input list of integers, along which to reduce. The default is to reduce over empty axes. When axes is empty (either not provided or explicitly empty), behavior depends on 'noop_with_empty_axes': reduction over all axes if 'noop_with_empty_axes' is false, or no reduction is applied if 'noop_with_empty_axes' is true (but other operations will be performed). Accepted range is [-r, r-1] where r = rank(data).
+
+## Outputs (1 - 1)
+
+- **reduced** (T): Reduced output tensor.
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(bool), tensor(double), tensor(float), tensor(float16), tensor(int32), tensor(int64), tensor(int8), tensor(uint32), tensor(uint64), tensor(uint8)
+  Constrain input and output types to numeric and Boolean tensors.

--- a/onnx-spec/ops/ReduceMean.md
+++ b/onnx-spec/ops/ReduceMean.md
@@ -1,0 +1,33 @@
+# ReduceMean
+
+Since opset **18**
+
+## Description
+
+Computes the mean of the input tensor's elements along the provided axes. The resulting
+tensor has the same rank as the input if `keepdims` equals 1. If `keepdims` equals 0, then
+the resulting tensor has the reduced dimension pruned. Input tensors of rank zero are
+valid. Reduction over an empty set of values yields undefined.
+
+
+The above behavior is similar to numpy, with the exception that numpy defaults `keepdims`
+to `False` instead of `True`.
+
+## Attributes
+
+- **keepdims** (INT, optional): Keep the reduced dimension or not, default 1 means keep reduced dimension.
+- **noop_with_empty_axes** (INT, optional): Defines behavior when axes is not provided or is empty. If false (default), reduction happens over all axes. If true, no reduction is applied, but other operations will be performed. For example, ReduceSumSquare acts as a vanilla Square.
+
+## Inputs (1 - 2)
+
+- **data** (T): An input tensor.
+- **axes** (tensor(int64), optional): Optional input list of integers, along which to reduce. The default is to reduce over empty axes. When axes is empty (either not provided or explicitly empty), behavior depends on 'noop_with_empty_axes': reduction over all axes if 'noop_with_empty_axes' is false, or no reduction is applied if 'noop_with_empty_axes' is true (but other operations will be performed). Accepted range is [-r, r-1] where r = rank(data).
+
+## Outputs (1 - 1)
+
+- **reduced** (T): Reduced output tensor.
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16), tensor(int32), tensor(int64), tensor(uint32), tensor(uint64)
+  Constrain input and output types to numeric tensors.

--- a/onnx-spec/ops/ReduceMin.md
+++ b/onnx-spec/ops/ReduceMin.md
@@ -1,0 +1,35 @@
+# ReduceMin
+
+Since opset **20**
+
+## Description
+
+Computes the min of the input tensor's elements along the provided axes. The resulting
+tensor has the same rank as the input if `keepdims` equals 1. If `keepdims` equals 0, then
+the resulting tensor has the reduced dimension pruned. Input tensors of rank zero are
+valid. Reduction over an empty set of values yields plus infinity (if supported by the datatype) or the maximum value of the data type otherwise.
+
+
+If the input data type is Boolean, the comparison should consider `False < True`.
+
+The above behavior is similar to numpy, with the exception that numpy defaults `keepdims`
+to `False` instead of `True`.
+
+## Attributes
+
+- **keepdims** (INT, optional): Keep the reduced dimension or not, default 1 means keep reduced dimension.
+- **noop_with_empty_axes** (INT, optional): Defines behavior when axes is not provided or is empty. If false (default), reduction happens over all axes. If true, no reduction is applied, but other operations will be performed. For example, ReduceSumSquare acts as a vanilla Square.
+
+## Inputs (1 - 2)
+
+- **data** (T): An input tensor.
+- **axes** (tensor(int64), optional): Optional input list of integers, along which to reduce. The default is to reduce over empty axes. When axes is empty (either not provided or explicitly empty), behavior depends on 'noop_with_empty_axes': reduction over all axes if 'noop_with_empty_axes' is false, or no reduction is applied if 'noop_with_empty_axes' is true (but other operations will be performed). Accepted range is [-r, r-1] where r = rank(data).
+
+## Outputs (1 - 1)
+
+- **reduced** (T): Reduced output tensor.
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(bool), tensor(double), tensor(float), tensor(float16), tensor(int32), tensor(int64), tensor(int8), tensor(uint32), tensor(uint64), tensor(uint8)
+  Constrain input and output types to numeric and Boolean tensors.

--- a/onnx-spec/ops/ReduceProd.md
+++ b/onnx-spec/ops/ReduceProd.md
@@ -1,0 +1,33 @@
+# ReduceProd
+
+Since opset **18**
+
+## Description
+
+Computes the product of the input tensor's elements along the provided axes. The resulting
+tensor has the same rank as the input if `keepdims` equals 1. If `keepdims` equals 0, then
+the resulting tensor has the reduced dimension pruned. Input tensors of rank zero are
+valid. Reduction over an empty set of values yields 1.
+
+
+The above behavior is similar to numpy, with the exception that numpy defaults `keepdims`
+to `False` instead of `True`.
+
+## Attributes
+
+- **keepdims** (INT, optional): Keep the reduced dimension or not, default 1 means keep reduced dimension.
+- **noop_with_empty_axes** (INT, optional): Defines behavior when axes is not provided or is empty. If false (default), reduction happens over all axes. If true, no reduction is applied, but other operations will be performed. For example, ReduceSumSquare acts as a vanilla Square.
+
+## Inputs (1 - 2)
+
+- **data** (T): An input tensor.
+- **axes** (tensor(int64), optional): Optional input list of integers, along which to reduce. The default is to reduce over empty axes. When axes is empty (either not provided or explicitly empty), behavior depends on 'noop_with_empty_axes': reduction over all axes if 'noop_with_empty_axes' is false, or no reduction is applied if 'noop_with_empty_axes' is true (but other operations will be performed). Accepted range is [-r, r-1] where r = rank(data).
+
+## Outputs (1 - 1)
+
+- **reduced** (T): Reduced output tensor.
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16), tensor(int32), tensor(int64), tensor(uint32), tensor(uint64)
+  Constrain input and output types to numeric tensors.

--- a/onnx-spec/ops/ReduceSum.md
+++ b/onnx-spec/ops/ReduceSum.md
@@ -1,0 +1,33 @@
+# ReduceSum
+
+Since opset **13**
+
+## Description
+
+Computes the sum of the input tensor's elements along the provided axes. The resulting
+tensor has the same rank as the input if `keepdims` equals 1. If `keepdims` equals 0, then
+the resulting tensor has the reduced dimension pruned. Input tensors of rank zero are
+valid. Reduction over an empty set of values yields 0.
+
+
+The above behavior is similar to numpy, with the exception that numpy defaults `keepdims`
+to `False` instead of `True`.
+
+## Attributes
+
+- **keepdims** (INT, optional): Keep the reduced dimension or not, default 1 means keep reduced dimension.
+- **noop_with_empty_axes** (INT, optional): Defines behavior when axes is not provided or is empty. If false (default), reduction happens over all axes. If true, no reduction is applied, but other operations will be performed. For example, ReduceSumSquare acts as a vanilla Square.
+
+## Inputs (1 - 2)
+
+- **data** (T): An input tensor.
+- **axes** (tensor(int64), optional): Optional input list of integers, along which to reduce. The default is to reduce over empty axes. When axes is empty (either not provided or explicitly empty), behavior depends on 'noop_with_empty_axes': reduction over all axes if 'noop_with_empty_axes' is false, or no reduction is applied if 'noop_with_empty_axes' is true (but other operations will be performed). Accepted range is [-r, r-1] where r = rank(data).
+
+## Outputs (1 - 1)
+
+- **reduced** (T): Reduced output tensor.
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16), tensor(int32), tensor(int64), tensor(uint32), tensor(uint64)
+  Constrain input and output types to numeric tensors.

--- a/onnx-spec/ops/ReduceSumSquare.md
+++ b/onnx-spec/ops/ReduceSumSquare.md
@@ -1,0 +1,33 @@
+# ReduceSumSquare
+
+Since opset **18**
+
+## Description
+
+Computes the sum square of the input tensor's elements along the provided axes. The resulting
+tensor has the same rank as the input if `keepdims` equals 1. If `keepdims` equals 0, then
+the resulting tensor has the reduced dimension pruned. Input tensors of rank zero are
+valid. Reduction over an empty set of values yields 0.
+
+
+The above behavior is similar to numpy, with the exception that numpy defaults `keepdims`
+to `False` instead of `True`.
+
+## Attributes
+
+- **keepdims** (INT, optional): Keep the reduced dimension or not, default 1 means keep reduced dimension.
+- **noop_with_empty_axes** (INT, optional): Defines behavior when axes is not provided or is empty. If false (default), reduction happens over all axes. If true, no reduction is applied, but other operations will be performed. For example, ReduceSumSquare acts as a vanilla Square.
+
+## Inputs (1 - 2)
+
+- **data** (T): An input tensor.
+- **axes** (tensor(int64), optional): Optional input list of integers, along which to reduce. The default is to reduce over empty axes. When axes is empty (either not provided or explicitly empty), behavior depends on 'noop_with_empty_axes': reduction over all axes if 'noop_with_empty_axes' is false, or no reduction is applied if 'noop_with_empty_axes' is true (but other operations will be performed). Accepted range is [-r, r-1] where r = rank(data).
+
+## Outputs (1 - 1)
+
+- **reduced** (T): Reduced output tensor.
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16), tensor(int32), tensor(int64), tensor(uint32), tensor(uint64)
+  Constrain input and output types to numeric tensors.

--- a/onnx-spec/ops/RegexFullMatch.md
+++ b/onnx-spec/ops/RegexFullMatch.md
@@ -1,0 +1,26 @@
+# RegexFullMatch
+
+Since opset **20**
+
+## Description
+
+RegexFullMatch performs a full regex match on each element of the input tensor. If an element fully matches the regex pattern specified as an attribute, the corresponding element in the output is True and it is False otherwise. [RE2](https://github.com/google/re2/wiki/Syntax) regex syntax is used.
+
+## Attributes
+
+- **pattern** (STRING, optional): Regex pattern to match on. This must be valid RE2 syntax.
+
+## Inputs (1 - 1)
+
+- **X** (T1): Tensor with strings to match on.
+
+## Outputs (1 - 1)
+
+- **Y** (T2): Tensor of bools indicating if each input string fully matches the regex pattern specified.
+
+## Type Constraints
+
+- **T1**: tensor(string)
+  Inputs must be UTF-8 strings
+- **T2**: tensor(bool)
+  Outputs are bools and are True where there is a full regex match and False otherwise.

--- a/onnx-spec/ops/Relu.md
+++ b/onnx-spec/ops/Relu.md
@@ -1,0 +1,22 @@
+# Relu
+
+Since opset **14**
+
+## Description
+
+Relu takes one input data (Tensor<T>) and produces one output data
+(Tensor<T>) where the rectified linear function, y = max(0, x), is applied to
+the tensor elementwise.
+
+## Inputs (1 - 1)
+
+- **X** (T): Input tensor
+
+## Outputs (1 - 1)
+
+- **Y** (T): Output tensor
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8)
+  Constrain input and output types to signed numeric tensors.

--- a/onnx-spec/ops/Reshape.md
+++ b/onnx-spec/ops/Reshape.md
@@ -1,0 +1,37 @@
+# Reshape
+
+Since opset **24**
+
+## Description
+
+Reshape the input tensor similar to numpy.reshape.
+First input is the data tensor, second input is a shape tensor which specifies the output shape. It outputs the reshaped tensor.
+At most one dimension of the new shape can be -1. In this case, the value is
+inferred from the size of the tensor and the remaining dimensions. A dimension
+could also be 0, in which case the actual dimension value is unchanged (i.e. taken
+from the input tensor). If 'allowzero' is set, and the new shape includes 0, the
+dimension will be set explicitly to zero (i.e. not taken from input tensor).
+Shape (second input) could be an empty shape, which means converting to a scalar.
+The input tensor's shape and the output tensor's shape are required to have the same number of elements.
+
+If the attribute 'allowzero' is set, it is invalid for the specified shape to
+contain both a zero value and -1, as the value of the dimension corresponding
+to -1 cannot be determined uniquely.
+
+## Attributes
+
+- **allowzero** (INT, optional): (Optional) By default, when any value in the 'shape' input is equal to zero the corresponding dimension value is copied from the input tensor dynamically. allowzero=1 indicates that if any value in the 'shape' input is set to zero, the zero value is honored, similar to NumPy.
+
+## Inputs (2 - 2)
+
+- **data** (T): An input tensor.
+- **shape** (tensor(int64)): Specified shape for output.
+
+## Outputs (1 - 1)
+
+- **reshaped** (T): Reshaped data.
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(bool), tensor(complex128), tensor(complex64), tensor(double), tensor(float), tensor(float16), tensor(float4e2m1), tensor(float8e4m3fn), tensor(float8e4m3fnuz), tensor(float8e5m2), tensor(float8e5m2fnuz), tensor(float8e8m0), tensor(int16), tensor(int32), tensor(int4), tensor(int64), tensor(int8), tensor(string), tensor(uint16), tensor(uint32), tensor(uint4), tensor(uint64), tensor(uint8)
+  Constrain input and output types to all tensor types.

--- a/onnx-spec/ops/Resize.md
+++ b/onnx-spec/ops/Resize.md
@@ -1,0 +1,42 @@
+# Resize
+
+Since opset **19**
+
+## Description
+
+Resize the input tensor. In general, it calculates every value in the output tensor as a weighted average of neighborhood (a.k.a. sampling locations) in the input tensor.
+Each dimension value of the output tensor is:
+```
+output_dimension = floor(input_dimension * (roi_end - roi_start) * scale)
+```
+if input \"sizes\" is not specified.
+
+## Attributes
+
+- **antialias** (INT, optional): If set to 1, "linear" and "cubic" interpolation modes will use an antialiasing filter when downscaling. Antialiasing is achieved by stretching the resampling filter by a factor max(1, 1 / scale), which means that when downsampling, more input pixels contribute to an output pixel.
+- **axes** (INTS, optional): If provided, it specifies a subset of axes that 'roi', 'scales' and 'sizes' refer to. If not provided, all axes are assumed [0, 1, ..., r-1], where r = rank(data). Non-specified dimensions are interpreted as non-resizable. Negative value means counting dimensions from the back. Accepted range is [-r, r-1], where r = rank(data). Behavior is undefined if an axis is repeated.
+- **coordinate_transformation_mode** (STRING, optional): This attribute describes how to transform the coordinate in the resized tensor to the coordinate in the original tensor.
+- **cubic_coeff_a** (FLOAT, optional): The coefficient 'a' used in cubic interpolation. Two common choice are -0.5 (in some cases of TensorFlow) and -0.75 (in PyTorch). Check out Equation (4) in https://ieeexplore.ieee.org/document/1163711 for the details. This attribute is valid only if mode is "cubic".
+- **exclude_outside** (INT, optional): If set to 1, the weight of sampling locations outside the tensor will be set to 0 and the weight will be renormalized so that their sum is 1.0. The default value is 0.
+- **extrapolation_value** (FLOAT, optional): When coordinate_transformation_mode is "tf_crop_and_resize" and x_original is outside the range [0, length_original - 1], this value is used as the corresponding output value. Default is 0.0f.
+- **keep_aspect_ratio_policy** (STRING, optional): This attribute describes how to interpret the `sizes` input with regard to keeping the original aspect ratio of the input, and it is not applicable when
+- **mode** (STRING, optional): Three interpolation modes: "nearest" (default), "linear" and "cubic". The "linear" mode includes linear interpolation for 1D tensor and N-linear interpolation for N-D tensor (for example, bilinear interpolation for 2D tensor). The "cubic" mode includes cubic interpolation for 1D tensor and N-cubic interpolation for N-D tensor (for example, bicubic interpolation for 2D tensor).
+- **nearest_mode** (STRING, optional): Four modes: "round_prefer_floor" (default, as known as round half down), "round_prefer_ceil" (as known as round half up), "floor", "ceil". Only used by nearest interpolation. It indicates how to get "nearest" pixel in input tensor from x_original, so this attribute is valid only if "mode" is "nearest".
+
+## Inputs (1 - 4)
+
+- **X** (T1): N-D tensor
+- **roi** (T2, optional): 1-D tensor given as [start1, ..., startN, end1, ..., endN], where N is the rank of X or the length of axes, if provided. The RoIs' coordinates are normalized in the coordinate system of the input image. It only takes effect when coordinate_transformation_mode is "tf_crop_and_resize"
+- **scales** (tensor(float), optional): The scale array along each dimension. It takes value greater than 0. If it's less than 1, it's sampling down, otherwise, it's upsampling. The number of elements of 'scales' should be the same as the rank of input 'X' or the length of 'axes', if provided. One of 'scales' and 'sizes' MUST be specified and it is an error if both are specified. If 'sizes' is needed, the user can use an empty string as the name of 'scales' in this operator's input list.
+- **sizes** (tensor(int64), optional): Target size of the output tensor. Its interpretation depends on the 'keep_aspect_ratio_policy' value.The number of elements of 'sizes' should be the same as the rank of input 'X', or the length of 'axes', if provided. Only one of 'scales' and 'sizes' can be specified.
+
+## Outputs (1 - 1)
+
+- **Y** (T1): N-D tensor after resizing
+
+## Type Constraints
+
+- **T1**: tensor(bfloat16), tensor(bool), tensor(complex128), tensor(complex64), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(string), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)
+  Constrain input 'X' and output 'Y' to all tensor types.
+- **T2**: tensor(double), tensor(float), tensor(float16)
+  Constrain roi type to float or double.

--- a/onnx-spec/ops/ReverseSequence.md
+++ b/onnx-spec/ops/ReverseSequence.md
@@ -1,0 +1,58 @@
+# ReverseSequence
+
+Since opset **10**
+
+## Description
+
+Reverse batch of sequences having different lengths specified by `sequence_lens`.
+
+For each slice i iterating on batch axis, the operator reverses the first sequence_lens[i] elements on time axis,
+and copies elements whose index's beyond sequence_lens[i] to the output. So the output slice i contains reversed
+sequences on the first sequence_lens[i] elements, then have original values copied for the other elements.
+
+Example 1:
+  input = [[0.0, 4.0, 8.0,  12.0],
+           [1.0, 5.0, 9.0,  13.0],
+           [2.0, 6.0, 10.0, 14.0],
+           [3.0, 7.0, 11.0, 15.0]]
+  sequence_lens = [4, 3, 2, 1]
+  time_axis = 0
+  batch_axis = 1
+
+  output = [[3.0, 6.0, 9.0,  12.0],
+            [2.0, 5.0, 8.0,  13.0],
+            [1.0, 4.0, 10.0, 14.0],
+            [0.0, 7.0, 11.0, 15.0]]
+
+Example 2:
+  input = [[0.0,  1.0,  2.0,  3.0 ],
+           [4.0,  5.0,  6.0,  7.0 ],
+           [8.0,  9.0,  10.0, 11.0],
+           [12.0, 13.0, 14.0, 15.0]]
+  sequence_lens = [1, 2, 3, 4]
+  time_axis = 1
+  batch_axis = 0
+
+  output = [[0.0,  1.0,  2.0,  3.0 ],
+            [5.0,  4.0,  6.0,  7.0 ],
+            [10.0, 9.0,  8.0,  11.0],
+            [15.0, 14.0, 13.0, 12.0]]
+
+## Attributes
+
+- **batch_axis** (INT, optional): (Optional) Specify which axis is batch axis. Must be one of 1 (default), or 0.
+- **time_axis** (INT, optional): (Optional) Specify which axis is time axis. Must be one of 0 (default), or 1.
+
+## Inputs (2 - 2)
+
+- **input** (T): Tensor of rank r >= 2.
+- **sequence_lens** (tensor(int64)): Tensor specifying lengths of the sequences in a batch. It has shape `[batch_size]`.
+
+## Outputs (1 - 1)
+
+- **Y** (T): Tensor with same shape of input.
+
+## Type Constraints
+
+- **T**: tensor(bool), tensor(complex128), tensor(complex64), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(string), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)
+  Input and output types can be of any tensor type.

--- a/onnx-spec/ops/RoiAlign.md
+++ b/onnx-spec/ops/RoiAlign.md
@@ -1,0 +1,43 @@
+# RoiAlign
+
+Since opset **22**
+
+## Description
+
+Region of Interest (RoI) align operation described in the
+[Mask R-CNN paper](https://arxiv.org/abs/1703.06870).
+RoiAlign consumes an input tensor X and region of interests (rois)
+to apply pooling across each RoI; it produces a 4-D tensor of shape
+(num_rois, C, output_height, output_width).
+
+RoiAlign is proposed to avoid the misalignment by removing
+quantizations while converting from original image into feature
+map and from feature map into RoI feature; in each ROI bin,
+the value of the sampled locations are computed directly
+through bilinear interpolation.
+
+## Attributes
+
+- **coordinate_transformation_mode** (STRING, optional): Allowed values are 'half_pixel' and 'output_half_pixel'. Use the value 'half_pixel' to pixel shift the input coordinates by -0.5 (the recommended behavior). Use the value 'output_half_pixel' to omit the pixel shift for the input (use this for a backward-compatible behavior).
+- **mode** (STRING, optional): The pooling method. Two modes are supported: 'avg' and 'max'. Default is 'avg'.
+- **output_height** (INT, optional): default 1; Pooled output Y's height.
+- **output_width** (INT, optional): default 1; Pooled output Y's width.
+- **sampling_ratio** (INT, optional): Number of sampling points in the interpolation grid used to compute the output value of each pooled output bin. If > 0, then exactly sampling_ratio x sampling_ratio grid points are used. If == 0, then an adaptive number of grid points are used (computed as ceil(roi_width / output_width), and likewise for height). Default is 0.
+- **spatial_scale** (FLOAT, optional): Multiplicative spatial scale factor to translate ROI coordinates from their input spatial scale to the scale used when pooling, i.e., spatial scale of the input feature map X relative to the input image. E.g.; default is 1.0f.
+
+## Inputs (3 - 3)
+
+- **X** (T1): Input data tensor from the previous operator; 4-D feature map of shape (N, C, H, W), where N is the batch size, C is the number of channels, and H and W are the height and the width of the data.
+- **rois** (T1): RoIs (Regions of Interest) to pool over; rois is 2-D input of shape (num_rois, 4) given as [[x1, y1, x2, y2], ...]. The RoIs' coordinates are in the coordinate system of the input image. Each coordinate set has a 1:1 correspondence with the 'batch_indices' input.
+- **batch_indices** (T2): 1-D tensor of shape (num_rois,) with each element denoting the index of the corresponding image in the batch.
+
+## Outputs (1 - 1)
+
+- **Y** (T1): RoI pooled output, 4-D tensor of shape (num_rois, C, output_height, output_width). The r-th batch element Y[r-1] is a pooled feature map corresponding to the r-th RoI X[r-1].
+
+## Type Constraints
+
+- **T1**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain types to float tensors.
+- **T2**: tensor(int64)
+  Constrain types to int tensors.

--- a/onnx-spec/ops/RotaryEmbedding.md
+++ b/onnx-spec/ops/RotaryEmbedding.md
@@ -1,0 +1,115 @@
+# RotaryEmbedding
+
+Since opset **23**
+
+## Description
+
+RotaryEmbedding is the implementation of rotary positional embeddings (RoPE) based on the paper https://arxiv.org/pdf/2104.09864.
+The key advantage of RoPE is that it allows the model to understand both the absolute position of a token and the relative distances
+between tokens. This is achieved through a rotational mechanism where the extent of rotation is computed based on the token's absolute position (position_ids).
+
+The rotational mechanism is defined by sine and cosine functions that are used to represent the rotation angles.
+For each token in the sequence, its positional embedding is computed by rotating its embedding vector. This is done by splitting the
+embedding vector either into two halves or interleaving every alternate token and applying the rotation matrix to each half of the embedding vector.
+The rotation matrix is parameterized by the token's position in the sequence. The rotated halves of the embedding vector are concatenated
+to form the final positional embedding for each token. The rotated positional embeddings are used in the self-attention mechanism.
+The rotation ensures that the model captures both absolute and relative positional information.
+
+Rotary embeddings are defined using the following algorithm:
+
+```python
+def compute_rotary_embedding(
+    input,
+    position_ids,
+    sin_cache,
+    cos_cache,
+    interleaved=0,
+    rotary_embedding_dim=0,
+    num_heads=0,
+):
+    # First ensure input to be processed has shape [batch_size, seq_len, num_heads, head_size]
+    if len(input.shape) == 4:
+        input = np.transpose(input, (0, 2, 1, 3))
+    batch_size = input.shape[0]
+    sequence_length = input.shape[1]
+    if len(input.shape) == 3:
+        hidden_size = input.shape[2]
+        assert num_heads != 0
+        head_size = int(hidden_size / num_heads)
+        new_shape = [batch_size, sequence_length, num_heads, head_size]
+        input = np.reshape(input, new_shape)
+    assert len(input.shape) == 4
+    head_size = input.shape[3]
+
+    # Fully or partially perform rotation on input based on rotary_embedding_dim attribute
+    if rotary_embedding_dim == 0:
+        # If rotary_embedding_dim not provided, perform full rotation by using head_size
+        rotary_embedding_dim = head_size
+    x_rotate = input[:, :, :, :rotary_embedding_dim]
+    x_not_rotate = input[:, :, :, rotary_embedding_dim:]
+    rotary_embedding_dim_half = int(rotary_embedding_dim / 2)
+
+    # Retrieve sin and cos caches using position ids
+    if position_ids is not None:
+        cos = cos_cache[position_ids]  # Shape: [batch_size, sequence_length, head_size/2]
+        sin = sin_cache[position_ids]  # Shape: [batch_size, sequence_length, head_size/2]
+    else:
+        cos = cos_cache
+        sin = sin_cache
+    cos = cos[:, :, :rotary_embedding_dim_half]  # Shape: [batch_size, sequence_length, rotary_embedding_dim/2]
+    sin = sin[:, :, :rotary_embedding_dim_half]  # Shape: [batch_size, sequence_length, rotary_embedding_dim/2]
+    cos = np.expand_dims(cos, axis=2)  # Shape: [batch_size, sequence_length, 1, rotary_embedding_dim/2]
+    sin = np.expand_dims(sin, axis=2)  # Shape: [batch_size, sequence_length, 1, rotary_embedding_dim/2]
+
+    # Either divide the input in halves or interleave (based on interleaved attribute)
+    if interleaved:
+        x1 = x_rotate[:, :, :, 0::2]
+        x2 = x_rotate[:, :, :, 1::2]
+    else:
+        x1, x2 = np.split(x_rotate, 2, axis=-1)
+
+    # Calculate real and imaginary values
+    real = cos * x1 - sin * x2
+    imag = sin * x1 + cos * x2
+
+    # Inserted rotated embeddings back to the original input
+    if interleaved:
+        # x_rotate[:, :, :, 0::2] = real
+        # x_rotate[:, :, :, 1::2] = imag
+        real = np.expand_dims(real, axis=-1)
+        imag = np.expand_dims(imag, axis=-1)
+        x_rotate_concat = np.concatenate((real, imag), axis=-1)
+        x_rotate = np.reshape(x_rotate_concat, x_rotate.shape)
+    else:
+        x_rotate = np.concatenate((real, imag), axis=-1)
+    output = np.concatenate((x_rotate, x_not_rotate), axis=-1)
+    if len(original_input_shape) == 3:
+        output = np.reshape(output, input.shape)
+    else:
+        output = np.transpose(output, (0, 2, 1, 3))
+    return output
+```
+
+## Attributes
+
+- **interleaved** (INT, optional): Rotate using interleaved pattern. Default value is 0 (False).
+- **num_heads** (INT, optional): Number of attention heads. Must be provided when input is a 3D tensor.
+- **rotary_embedding_dim** (INT, optional): Rotary embedding dimension used to apply partial rotary embeddings.
+
+## Inputs (3 - 4)
+
+- **X** (T): The input tensor representing the token embeddings. 4D tensor with shape `(batch_size, num_heads, sequence_length, head_size)` or 3D tensor with shape `(batch_size, sequence_length, hidden_size)`. For cases with a 4D input tensor, `head_size` has to be even. For cases with a 3D input tensor, `num_heads` attribute must be provided and `hidden_size` must be an even multiple of `num_heads` where `hidden_size = num_heads * head_size`
+- **cos_cache** (T): The cosine values for the rotation. 2D tensor with shape `(max_position_id_plus_1, head_size / 2)` for full rotation or `(max_position_id_plus_1, rotary_embedding_dim / 2)` for partial rotation when `position_ids` are provided. 3D tensor with shape `(batch_size, sequence_length, head_size / 2)` for full rotation or `(batch_size, sequence_length, rotary_embedding_dim / 2)` for partial rotation when `position_ids` are not provided. `max_position_id_plus_1` is a parameter to the model.
+- **sin_cache** (T): The sine values for the rotation. 2D tensor with shape `(max_position_id_plus_1, head_size / 2)` for full rotation or `(max_position_id_plus_1, rotary_embedding_dim / 2)` for partial rotation when `position_ids` are provided. 3D tensor with shape `(batch_size, sequence_length, head_size / 2)` for full rotation or `(batch_size, sequence_length, rotary_embedding_dim / 2)` for partial rotation when `position_ids` are not provided. `max_position_id_plus_1` is a parameter to the model.
+- **position_ids** (M, optional): The position indices for the tokens. 2D tensor with shape `(batch_size, sequence_length)`
+
+## Outputs (1 - 1)
+
+- **Y** (T): Tensor with same shape as input.
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(float), tensor(float16)
+  Constrain input and output types to float tensors.
+- **M**: tensor(int64)
+  Constrain input and output types to integer tensors.

--- a/onnx-spec/ops/Round.md
+++ b/onnx-spec/ops/Round.md
@@ -1,0 +1,33 @@
+# Round
+
+Since opset **22**
+
+## Description
+
+Round takes one input Tensor and rounds the values, element-wise, meaning
+it finds the nearest integer for each value.
+In case of halves, the rule is to round them to the nearest even integer.
+If input x is integral, +0, -0, NaN,  or infinite, x itself is returned.
+The output tensor has the same shape and type as the input.
+
+Examples:
+```
+round([0.9]) = [1.0]
+round([2.5]) = [2.0]
+round([2.3]) = [2.0]
+round([1.5]) = [2.0]
+round([-4.5]) = [-4.0]
+```
+
+## Inputs (1 - 1)
+
+- **X** (T): Input tensor
+
+## Outputs (1 - 1)
+
+- **Y** (T): Output tensor
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain input and output types to float tensors.

--- a/onnx-spec/ops/STFT.md
+++ b/onnx-spec/ops/STFT.md
@@ -1,0 +1,29 @@
+# STFT
+
+Since opset **17**
+
+## Description
+
+Computes the Short-time Fourier Transform of the signal.
+
+## Attributes
+
+- **onesided** (INT, optional): If onesided is 1, only values for w in [0, 1, 2, ..., floor(n_fft/2) + 1] are returned because the real-to-complex Fourier transform satisfies the conjugate symmetry, i.e., X[m, w] = X[m,w]=X[m,n_fft-w]*. Note if the input or window tensors are complex, then onesided output is not possible. Enabling onesided with real inputs performs a Real-valued fast Fourier transform (RFFT).When invoked with real or complex valued input, the default value is 1. Values can be 0 or 1.
+
+## Inputs (2 - 4)
+
+- **signal** (T1): Input tensor representing a real or complex valued signal. For real input, the following shape is expected: [batch_size][signal_length][1]. For complex input, the following shape is expected: [batch_size][signal_length][2], where [batch_size][signal_length][0] represents the real component and [batch_size][signal_length][1] represents the imaginary component of the signal.
+- **frame_step** (T2): The number of samples to step between successive DFTs.
+- **window** (T1, optional): A tensor representing the window that will be slid over the signal.The window must have rank 1 with shape: [window_shape]. It's an optional value.
+- **frame_length** (T2, optional): A scalar representing the size of the DFT. It's an optional value.
+
+## Outputs (1 - 1)
+
+- **output** (T1): The Short-time Fourier Transform of the signals.If onesided is 1, the output has the shape: [batch_size][frames][dft_unique_bins][2], where dft_unique_bins is frame_length // 2 + 1 (the unique components of the DFT) If onesided is 0, the output has the shape: [batch_size][frames][frame_length][2], where frame_length is the length of the DFT.
+
+## Type Constraints
+
+- **T1**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain signal and output to float tensors.
+- **T2**: tensor(int32), tensor(int64)
+  Constrain scalar length types to int64_t.

--- a/onnx-spec/ops/Scan.md
+++ b/onnx-spec/ops/Scan.md
@@ -1,0 +1,148 @@
+# Scan
+
+Since opset **24**
+
+## Description
+
+Scan can be used to iterate over one or more scan_input tensors,
+constructing zero or more scan_output tensors. It combines ideas from general recurrences,
+functional programming constructs such as scan, fold, map, and zip, and is intended to enable
+generalizations of RNN-like constructs for sequence-to-sequence processing.
+Other tensors (referred to as state_variables here) can be used to carry a state
+when iterating from one element to another (similar to hidden-state in RNNs, also referred
+to as loop-carried dependences in the context of loops).
+Many common usages involve a single scan_input tensor (where functionality
+similar to scan, fold and map can be obtained). When more than one scan_input is used,
+a behavior similar to zip is obtained.
+
+The attribute body must be a graph, specifying the computation to be performed in
+every iteration. It takes as input the current values of the state_variables and
+the current iterated element of the scan_inputs. It must return the (updated) values
+of the state_variables and zero or more scan_output_element tensors. The values of the
+scan_output_element tensors are concatenated over all the iterations to produce the
+scan_output values of the scan construct (similar to the concatenated intermediate
+hidden-state values of RNN-like constructs). All the output tensors (state_variables as
+well as scan_output_element tensors) are required to have the same shape in each iteration
+of the loop (a restriction imposed to enable efficient memory allocation).
+
+Note that the iterated element passed to the body subgraph does not have a sequence
+axis. It will have a rank one less than the rank of the corresponding scan_input.
+
+The scan operation returns the final values of the state_variables as well as the
+scan_outputs.
+
+The optional attribute scan_input_directions specifies the direction (forward or backward)
+for each scan input. If this attribute is omitted, all sequences are scanned in the forward
+direction. A bidirectional scan may be performed by specifying the same tensor input twice
+in the scan_inputs, once with a forward direction, and once with a backward direction.
+
+The scan_output of the operation is produced by concatenating the scan_output_element
+values produced by the body in each iteration.  The optional attribute scan_output_directions
+specifies the direction in which scan_output is constructed (by appending or prepending the
+scan_output_element to scan_output in each iteration) for each scan_output. If this attribute
+is omitted, the scan_output_element is appended to the scan_output in each iteration.
+
+The optional attribute scan_input_axes specifies the axis to be scanned for each scan_input.
+If omitted, every scan_input will be scanned in axis 0. For example, if axis 0 is the
+batch axis and axis 1 is the time axis (to be scanned), specify an axis value of 1.
+Note that scanning a non-zero axis may be less efficient than scanning axis zero.
+
+The optional attribute scan_output_axes specifies the axis along which the scan_outputs
+are accumulated for each scan_output. For example, if axis 1 is the time axis (to be
+scanned) for both inputs and outputs, specify a scan_input axis and scan_output axis
+value of 1.
+
+Note that because of the ONNX restriction that only the last parameter of an operator can
+be variadic, the initial-states and scan-inputs are listed together as one input parameter.
+Similarly, the final-states and scan-outputs are listed together as one output parameter.
+The attribute num_scan_inputs indicates the number M of scan-inputs.
+
+The behavior of
+
+    Scan <
+        num_scan_inputs = m,
+        body = loop-body,
+        scan_input_axes = [axis_1, ..., axis_m]
+    > (init_1, ..., init_n, scan_1, ..., scan_m)
+
+is equivalent to the following pseudo-code:
+
+    // scan_i.shape[axis_i] denotes the (max) sequence-length of scan_i
+    // scan_i.shape[axis_i] is required to be equal to scan_j.shape[axis_j] for all i,j.
+    sequence_length = scan_1.shape[axis_1];
+
+    // initialize state-variables
+    st_1 = init_1; ... st_n = init_n;
+    // initialize scan-output variables: [] denotes an empty tensor
+    scan_out_1 = []; ...; scan_out_k = [];
+    // identify number of iterations:
+
+    // execute loop
+    for (int t = 0; t < sequence_length; ++t) {
+        // generate the scan-input elements: the notation T<axis=k>[t] indicates the sub-tensor
+        // of rank one less than T obtained by indexing T at position t along axis k.
+        si_1 = scan_1<axis=axis_1>[t];
+        ... ;
+        si_m = scan_m<axis=axis_m>[t];
+        // execute loop-body
+        st_1, ..., st_n, so_1, ..., so_k = loop-body(st_1, ..., st_n, si_1, ..., si_m)
+        // accumulate the scan-output elements
+        scan_out_1 = Concat<axis=0>(scan_out_1, so_1); ... ; scan_out_k = Concat<axis=0>(scan_out_k, so_k);
+    }
+
+    return st_1, ..., st_n, scan_out_1, ..., scan_out_k;
+
+*Sample usage: Encoding RNN using a Scan*
+
+The following example shows how a simple RNN over an input tensor %X, with weight tensor %Wi,
+recurrence weight tensor %Ri, bias tensors %Wbi and %Rbi, and initial hidden-state %H_0 can
+be encoded as a ScanLoop. Note that the loop-body is a nested graph, and it directly computes
+%Wi, %Ri, %Wbi, and %Rbi (typically constants or initializers in the body graph). If these
+values are computed in the outer graph, they need to be passed in as extra state_variables.
+
+    graph rnn-encoding {
+      %H_0 = ...
+      %X = ...
+      %Y_h, %Y = Scan[body = <graph rnn-cell-1>, num_scan_inputs=1](%H_0, %X)
+      return %Y, %Y_h
+    }
+
+    graph rnn-cell-1 (
+      %H_tminus1[FLOAT, tensor]
+      %X_t[FLOAT, tensor]
+    ) {
+      %Wi = ...
+      %Ri = ...
+      %Wbi = ...
+      %Rbi = ...
+      %t1 = X_t * (Wi^T)
+      %t2 = H_tminus1*(Ri^T)
+      %t3 = Add(%t1, %t2)
+      %t4 = Add(%t3, %Wbi)
+      %t5 = Add(%t4, %Rbi)
+      %Ht = Tanh(%t5)
+      %Accumulate = Identity(%Ht)
+      return %Ht, %Accumulate
+    }
+
+## Attributes
+
+- **body** (GRAPH, required): The graph run each iteration. It has N+M inputs: (loop state variables..., scan_input_elts...). It has N+K outputs: (loop state variables..., scan_output_elts...). Each scan_output is created by concatenating the value of the specified scan_output_elt value at the end of each iteration of the loop. It is an error if the dimensions of these values change across loop iterations.
+- **num_scan_inputs** (INT, required): An attribute specifying the number of scan_inputs M.
+- **scan_input_axes** (INTS, optional): An optional list of M flags. The i-th element of the list specifies the axis to be scanned (the sequence axis) for the i-th scan_input. If omitted, 0 will be used as the scan axis for every scan_input. Negative value for an axis means counting dimensions from the back. Accepted range is [-r, r-1] where r = rank(input).
+- **scan_input_directions** (INTS, optional): An optional list of M flags. The i-th element of the list specifies the direction to be scanned for the i-th scan_input tensor: 0 indicates forward direction and 1 indicates reverse direction. If omitted, all scan_input tensors will be scanned in the forward direction.
+- **scan_output_axes** (INTS, optional): An optional list of K flags. The i-th element of the list specifies the axis for the i-th scan_output. The scan outputs are accumulated along the specified axis. If omitted, 0 will be used as the scan axis for every scan_output. Negative value for an axis means counting dimensions from the back. Accepted range is [-r, r-1].
+- **scan_output_directions** (INTS, optional): An optional list of K flags, one for each scan_output. The i-th element of the list specifies whether the i-th scan_output should be constructed by appending or prepending a new value in each iteration: 0 indicates appending and 1 indicates prepending. If omitted, all scan_output tensors will be produced by appending a value in each iteration.
+
+## Inputs (1 - 2147483647)
+
+- **initial_state_and_scan_inputs** (V, variadic): Initial values of the loop's N state variables followed by M scan_inputs
+
+## Outputs (1 - 2147483647)
+
+- **final_state_and_scan_outputs** (V, variadic): Final values of the loop's N state variables followed by K scan_outputs
+
+## Type Constraints
+
+- **V**: tensor(bfloat16), tensor(bool), tensor(complex128), tensor(complex64), tensor(double), tensor(float), tensor(float16), tensor(float4e2m1), tensor(float8e4m3fn), tensor(float8e4m3fnuz), tensor(float8e5m2), tensor(float8e5m2fnuz), tensor(float8e8m0), tensor(int16), tensor(int32), tensor(int4), tensor(int64), tensor(int8), tensor(string), tensor(uint16), tensor(uint32), tensor(uint4), tensor(uint64), tensor(uint8)
+  All Tensor types up to IRv12.

--- a/onnx-spec/ops/Scatter.md
+++ b/onnx-spec/ops/Scatter.md
@@ -1,0 +1,80 @@
+# Scatter
+
+Since opset **11**
+
+## Description
+
+This operator is deprecated. Please use ScatterElements, which provides the same functionality.
+
+Scatter takes three inputs `data`, `updates`, and `indices` of the same
+rank r >= 1 and an optional attribute axis that identifies an axis of `data`
+(by default, the outer-most axis, that is axis 0). The output of the operation
+is produced by creating a copy of the input `data`, and then updating its value
+to values specified by `updates` at specific index positions specified by
+`indices`. Its output shape is the same as the shape of `data`.
+
+For each entry in `updates`, the target index in `data` is obtained by combining
+the corresponding entry in `indices` with the index of the entry itself: the
+index-value for dimension = axis is obtained from the value of the corresponding
+entry in `indices` and the index-value for dimension != axis is obtained from the
+index of the entry itself.
+
+For instance, in a 2-D tensor case, the update corresponding to the [i][j] entry
+is performed as below:
+```
+  output[indices[i][j]][j] = updates[i][j] if axis = 0,
+  output[i][indices[i][j]] = updates[i][j] if axis = 1,
+```
+
+This operator is the inverse of GatherElements. It is similar to Torch's Scatter operation.
+
+Example 1:
+```
+  data = [
+      [0.0, 0.0, 0.0],
+      [0.0, 0.0, 0.0],
+      [0.0, 0.0, 0.0],
+  ]
+  indices = [
+      [1, 0, 2],
+      [0, 2, 1],
+  ]
+  updates = [
+      [1.0, 1.1, 1.2],
+      [2.0, 2.1, 2.2],
+  ]
+  output = [
+      [2.0, 1.1, 0.0]
+      [1.0, 0.0, 2.2]
+      [0.0, 2.1, 1.2]
+  ]
+```
+Example 2:
+```
+  data = [[1.0, 2.0, 3.0, 4.0, 5.0]]
+  indices = [[1, 3]]
+  updates = [[1.1, 2.1]]
+  axis = 1
+  output = [[1.0, 1.1, 3.0, 2.1, 5.0]]
+```
+
+## Attributes
+
+- **axis** (INT, optional): Which axis to scatter on. Negative value means counting dimensions from the back. Accepted range is [-r, r-1] where r = rank(data).
+
+## Inputs (3 - 3)
+
+- **data** (T): Tensor of rank r >= 1.
+- **indices** (Tind): Tensor of int32/int64 indices, of r >= 1 (same rank as input). All index values are expected to be within bounds [-s, s-1] along axis of size s. It is an error if any of the index values are out of bounds.
+- **updates** (T): Tensor of rank r >=1 (same rank and shape as indices)
+
+## Outputs (1 - 1)
+
+- **output** (T): Tensor of rank r >= 1 (same rank as input).
+
+## Type Constraints
+
+- **T**: tensor(bool), tensor(complex128), tensor(complex64), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(string), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)
+  Input and output types can be of any tensor type.
+- **Tind**: tensor(int32), tensor(int64)
+  Constrain indices to integer types

--- a/onnx-spec/ops/ScatterElements.md
+++ b/onnx-spec/ops/ScatterElements.md
@@ -1,0 +1,90 @@
+# ScatterElements
+
+Since opset **18**
+
+## Description
+
+ScatterElements takes three inputs `data`, `updates`, and `indices` of the same
+rank r >= 1 and an optional attribute axis that identifies an axis of `data`
+(by default, the outer-most axis, that is axis 0). The output of the operation
+is produced by creating a copy of the input `data`, and then updating its value
+to values specified by `updates` at specific index positions specified by
+`indices`. Its output shape is the same as the shape of `data`.
+
+For each entry in `updates`, the target index in `data` is obtained by combining
+the corresponding entry in `indices` with the index of the entry itself: the
+index-value for dimension = axis is obtained from the value of the corresponding
+entry in `indices` and the index-value for dimension != axis is obtained from the
+index of the entry itself.
+
+`reduction` allows specification of an optional reduction operation, which is applied to all values in `updates`
+tensor into `output` at the specified `indices`.
+In cases where `reduction` is set to "none", indices should not have duplicate entries: that is, if idx1 != idx2,
+then indices[idx1] != indices[idx2]. For instance, in a 2-D tensor case, the update
+corresponding to the [i][j] entry is performed as below:
+```
+output[indices[i][j]][j] = updates[i][j] if axis = 0,
+output[i][indices[i][j]] = updates[i][j] if axis = 1,
+```
+When `reduction` is set to some reduction function `f`, the update corresponding to the [i][j] entry is performed as below:
+```
+output[indices[i][j]][j] = f(output[indices[i][j]][j], updates[i][j]) if axis = 0,
+output[i][indices[i][j]] = f(output[i][indices[i][j]], updates[i][j]) if axis = 1,
+```
+where the `f` is `+`, `*`, `max` or `min` as specified.
+
+This operator is the inverse of GatherElements. It is similar to Torch's Scatter operation.
+
+(Opset 18 change): Adds max/min to the set of allowed reduction ops.
+
+Example 1:
+```
+data = [
+    [0.0, 0.0, 0.0],
+    [0.0, 0.0, 0.0],
+    [0.0, 0.0, 0.0],
+]
+indices = [
+    [1, 0, 2],
+    [0, 2, 1],
+]
+updates = [
+    [1.0, 1.1, 1.2],
+    [2.0, 2.1, 2.2],
+]
+output = [
+    [2.0, 1.1, 0.0]
+    [1.0, 0.0, 2.2]
+    [0.0, 2.1, 1.2]
+]
+```
+Example 2:
+```
+data = [[1.0, 2.0, 3.0, 4.0, 5.0]]
+indices = [[1, 3]]
+updates = [[1.1, 2.1]]
+axis = 1
+output = [[1.0, 1.1, 3.0, 2.1, 5.0]]
+```
+
+## Attributes
+
+- **axis** (INT, optional): Which axis to scatter on. Negative value means counting dimensions from the back. Accepted range is [-r, r-1] where r = rank(data).
+- **reduction** (STRING, optional): Type of reduction to apply: none (default), add, mul, max, min. 'none': no reduction applied. 'add':  reduction using the addition operation. 'mul': reduction using the multiplication operation.'max': reduction using the maximum operation.'min': reduction using the minimum operation.
+
+## Inputs (3 - 3)
+
+- **data** (T): Tensor of rank r >= 1.
+- **indices** (Tind): Tensor of int32/int64 indices, of r >= 1 (same rank as input). All index values are expected to be within bounds [-s, s-1] along axis of size s. It is an error if any of the index values are out of bounds.
+- **updates** (T): Tensor of rank r >=1 (same rank and shape as indices)
+
+## Outputs (1 - 1)
+
+- **output** (T): Tensor of rank r >= 1 (same rank as input).
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(bool), tensor(complex128), tensor(complex64), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(string), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)
+  Input and output types can be of any tensor type.
+- **Tind**: tensor(int32), tensor(int64)
+  Constrain indices to integer types

--- a/onnx-spec/ops/ScatterND.md
+++ b/onnx-spec/ops/ScatterND.md
@@ -1,0 +1,100 @@
+# ScatterND
+
+Since opset **18**
+
+## Description
+
+ScatterND takes three inputs `data` tensor of rank r >= 1, `indices` tensor of rank q >= 1,
+and `updates` tensor of rank q + r - indices.shape[-1] - 1. The output of the operation
+is produced by creating a copy of the input `data`, and then updating its value to values
+specified by `updates` at specific index positions specified by `indices`. Its output shape
+is the same as the shape of `data`.
+
+`indices` is an integer tensor. Let k denote indices.shape[-1], the last dimension in the shape of `indices`.
+`indices` is treated as a (q-1)-dimensional tensor of k-tuples, where each k-tuple is a partial-index into `data`.
+Hence, k can be a value at most the rank of `data`. When k equals rank(data), each update entry specifies an
+update to a single element of the tensor. When k is less than rank(data) each update entry specifies an
+update to a slice of the tensor. Index values are allowed to be negative, as per the usual
+convention for counting backwards from the end, but are expected in the valid range.
+
+`updates` is treated as a (q-1)-dimensional tensor of replacement-slice-values. Thus, the
+first (q-1) dimensions of updates.shape must match the first (q-1) dimensions of indices.shape.
+The remaining dimensions of `updates` correspond to the dimensions of the
+replacement-slice-values. Each replacement-slice-value is a (r-k) dimensional tensor,
+corresponding to the trailing (r-k) dimensions of `data`.  Thus, the shape of `updates`
+must equal indices.shape[0:q-1] ++ data.shape[k:r-1], where ++ denotes the concatenation
+of shapes.
+
+The `output` is calculated via the following equation:
+
+```
+output = np.copy(data)
+update_indices = indices.shape[:-1]
+for idx in np.ndindex(update_indices):
+    output[indices[idx]] = updates[idx]
+```
+
+The order of iteration in the above loop is not specified.
+In particular, indices should not have duplicate entries: that is, if idx1 != idx2, then indices[idx1] != indices[idx2].
+This ensures that the output value does not depend on the iteration order.
+
+`reduction` allows specification of an optional reduction operation, which is applied to all values in `updates`
+tensor into `output` at the specified `indices`.
+In cases where `reduction` is set to "none", indices should not have duplicate entries: that is, if idx1 != idx2,
+then indices[idx1] != indices[idx2]. This ensures that the output value does not depend on the iteration order.
+When `reduction` is set to some reduction function `f`, `output` is calculated as follows:
+
+```
+output = np.copy(data)
+update_indices = indices.shape[:-1]
+for idx in np.ndindex(update_indices):
+    output[indices[idx]] = f(output[indices[idx]], updates[idx])
+```
+
+where the `f` is `+`, `*`, `max` or `min` as specified.
+
+This operator is the inverse of GatherND.
+
+(Opset 18 change): Adds max/min to the set of allowed reduction ops.
+
+Example 1:
+```
+data    = [1, 2, 3, 4, 5, 6, 7, 8]
+indices = [[4], [3], [1], [7]]
+updates = [9, 10, 11, 12]
+output  = [1, 11, 3, 10, 9, 6, 7, 12]
+```
+
+Example 2:
+```
+data    = [[[1, 2, 3, 4], [5, 6, 7, 8], [8, 7, 6, 5], [4, 3, 2, 1]],
+            [[1, 2, 3, 4], [5, 6, 7, 8], [8, 7, 6, 5], [4, 3, 2, 1]],
+            [[8, 7, 6, 5], [4, 3, 2, 1], [1, 2, 3, 4], [5, 6, 7, 8]],
+            [[8, 7, 6, 5], [4, 3, 2, 1], [1, 2, 3, 4], [5, 6, 7, 8]]]
+indices = [[0], [2]]
+updates = [[[5, 5, 5, 5], [6, 6, 6, 6], [7, 7, 7, 7], [8, 8, 8, 8]],
+            [[1, 1, 1, 1], [2, 2, 2, 2], [3, 3, 3, 3], [4, 4, 4, 4]]]
+output  = [[[5, 5, 5, 5], [6, 6, 6, 6], [7, 7, 7, 7], [8, 8, 8, 8]],
+            [[1, 2, 3, 4], [5, 6, 7, 8], [8, 7, 6, 5], [4, 3, 2, 1]],
+            [[1, 1, 1, 1], [2, 2, 2, 2], [3, 3, 3, 3], [4, 4, 4, 4]],
+            [[8, 7, 6, 5], [4, 3, 2, 1], [1, 2, 3, 4], [5, 6, 7, 8]]]
+```
+
+## Attributes
+
+- **reduction** (STRING, optional): Type of reduction to apply: none (default), add, mul, max, min. 'none': no reduction applied. 'add':  reduction using the addition operation. 'mul':  reduction using the addition operation. 'max': reduction using the maximum operation.'min': reduction using the minimum operation.
+
+## Inputs (3 - 3)
+
+- **data** (T): Tensor of rank r >= 1.
+- **indices** (tensor(int64)): Tensor of rank q >= 1.
+- **updates** (T): Tensor of rank q + r - indices_shape[-1] - 1.
+
+## Outputs (1 - 1)
+
+- **output** (T): Tensor of rank r >= 1.
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(bool), tensor(complex128), tensor(complex64), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(string), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)
+  Constrain input and output types to any tensor type.

--- a/onnx-spec/ops/Selu.md
+++ b/onnx-spec/ops/Selu.md
@@ -1,0 +1,28 @@
+# Selu
+
+Since opset **22**
+
+## Description
+
+Selu takes one input data (Tensor<T>) and produces one output data
+(Tensor<T>) where the scaled exponential linear unit function,
+`y = gamma * (alpha * e^x - alpha) for x <= 0`, `y = gamma * x for x > 0`,
+is applied to the tensor elementwise.
+
+## Attributes
+
+- **alpha** (FLOAT, optional): Coefficient of SELU default to 1.67326319217681884765625 (i.e., float32 approximation of 1.6732632423543772848170429916717).
+- **gamma** (FLOAT, optional): Coefficient of SELU default to 1.05070102214813232421875 (i.e., float32 approximation of 1.0507009873554804934193349852946).
+
+## Inputs (1 - 1)
+
+- **X** (T): Input tensor
+
+## Outputs (1 - 1)
+
+- **Y** (T): Output tensor
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain input and output types to float tensors.

--- a/onnx-spec/ops/SequenceAt.md
+++ b/onnx-spec/ops/SequenceAt.md
@@ -1,0 +1,27 @@
+# SequenceAt
+
+Since opset **11**
+
+## Description
+
+Outputs a tensor copy from the tensor at 'position' in 'input_sequence'.
+Accepted range for 'position' is in `[-n, n - 1]`, where `n` is the number of tensors in 'input_sequence'.
+Negative value means counting positions from the back.
+
+## Inputs (2 - 2)
+
+- **input_sequence** (S): Input sequence.
+- **position** (I): Position of the tensor in the sequence. Negative value means counting positions from the back. Accepted range in `[-n, n - 1]`, where `n` is the number of tensors in 'input_sequence'. It is an error if any of the index values are out of bounds. It must be a scalar(tensor of empty shape).
+
+## Outputs (1 - 1)
+
+- **tensor** (T): Output tensor at the specified position in the input sequence.
+
+## Type Constraints
+
+- **S**: seq(tensor(bool)), seq(tensor(complex128)), seq(tensor(complex64)), seq(tensor(double)), seq(tensor(float)), seq(tensor(float16)), seq(tensor(int16)), seq(tensor(int32)), seq(tensor(int64)), seq(tensor(int8)), seq(tensor(string)), seq(tensor(uint16)), seq(tensor(uint32)), seq(tensor(uint64)), seq(tensor(uint8))
+  Constrain to any tensor type.
+- **T**: tensor(bool), tensor(complex128), tensor(complex64), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(string), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)
+  Constrain to any tensor type.
+- **I**: tensor(int32), tensor(int64)
+  Constrain position to integral tensor. It must be a scalar(tensor of empty shape).

--- a/onnx-spec/ops/SequenceConstruct.md
+++ b/onnx-spec/ops/SequenceConstruct.md
@@ -1,0 +1,23 @@
+# SequenceConstruct
+
+Since opset **11**
+
+## Description
+
+Construct a tensor sequence containing 'inputs' tensors.
+All tensors in 'inputs' must have the same data type.
+
+## Inputs (1 - 2147483647)
+
+- **inputs** (T, variadic): Tensors.
+
+## Outputs (1 - 1)
+
+- **output_sequence** (S): Sequence enclosing the input tensors.
+
+## Type Constraints
+
+- **T**: tensor(bool), tensor(complex128), tensor(complex64), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(string), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)
+  Constrain input types to any tensor type.
+- **S**: seq(tensor(bool)), seq(tensor(complex128)), seq(tensor(complex64)), seq(tensor(double)), seq(tensor(float)), seq(tensor(float16)), seq(tensor(int16)), seq(tensor(int32)), seq(tensor(int64)), seq(tensor(int8)), seq(tensor(string)), seq(tensor(uint16)), seq(tensor(uint32)), seq(tensor(uint64)), seq(tensor(uint8))
+  Constrain output types to any tensor type.

--- a/onnx-spec/ops/SequenceEmpty.md
+++ b/onnx-spec/ops/SequenceEmpty.md
@@ -1,0 +1,20 @@
+# SequenceEmpty
+
+Since opset **11**
+
+## Description
+
+Construct an empty tensor sequence, with given data type.
+
+## Attributes
+
+- **dtype** (INT, optional): (Optional) The data type of the tensors in the output sequence. The default type is 'float'.
+
+## Outputs (1 - 1)
+
+- **output** (S): Empty sequence.
+
+## Type Constraints
+
+- **S**: seq(tensor(bool)), seq(tensor(complex128)), seq(tensor(complex64)), seq(tensor(double)), seq(tensor(float)), seq(tensor(float16)), seq(tensor(int16)), seq(tensor(int32)), seq(tensor(int64)), seq(tensor(int8)), seq(tensor(string)), seq(tensor(uint16)), seq(tensor(uint32)), seq(tensor(uint64)), seq(tensor(uint8))
+  Constrain output types to any tensor type.

--- a/onnx-spec/ops/SequenceErase.md
+++ b/onnx-spec/ops/SequenceErase.md
@@ -1,0 +1,26 @@
+# SequenceErase
+
+Since opset **11**
+
+## Description
+
+Outputs a tensor sequence that removes the tensor at 'position' from 'input_sequence'.
+Accepted range for 'position' is in `[-n, n - 1]`, where `n` is the number of tensors in 'input_sequence'.
+Negative value means counting positions from the back.
+'position' is optional, by default it erases the last tensor from 'input_sequence'.
+
+## Inputs (1 - 2)
+
+- **input_sequence** (S): Input sequence.
+- **position** (I, optional): Position of the tensor in the sequence. Negative value means counting positions from the back. Accepted range in `[-n, n - 1]`, where `n` is the number of tensors in 'input_sequence'. It is an error if any of the index values are out of bounds. It must be a scalar(tensor of empty shape).
+
+## Outputs (1 - 1)
+
+- **output_sequence** (S): Output sequence that has the tensor at the specified position removed.
+
+## Type Constraints
+
+- **S**: seq(tensor(bool)), seq(tensor(complex128)), seq(tensor(complex64)), seq(tensor(double)), seq(tensor(float)), seq(tensor(float16)), seq(tensor(int16)), seq(tensor(int32)), seq(tensor(int64)), seq(tensor(int8)), seq(tensor(string)), seq(tensor(uint16)), seq(tensor(uint32)), seq(tensor(uint64)), seq(tensor(uint8))
+  Constrain to any tensor type.
+- **I**: tensor(int32), tensor(int64)
+  Constrain position to integral tensor. It must be a scalar(tensor of empty shape).

--- a/onnx-spec/ops/SequenceInsert.md
+++ b/onnx-spec/ops/SequenceInsert.md
@@ -1,0 +1,30 @@
+# SequenceInsert
+
+Since opset **11**
+
+## Description
+
+Outputs a tensor sequence that inserts 'tensor' into 'input_sequence' at 'position'.
+'tensor' must have the same data type as 'input_sequence'.
+Accepted range for 'position' is in `[-n, n]`, where `n` is the number of tensors in 'input_sequence'.
+Negative value means counting positions from the back.
+'position' is optional, by default it inserts 'tensor' to the back of 'input_sequence'.
+
+## Inputs (2 - 3)
+
+- **input_sequence** (S): Input sequence.
+- **tensor** (T): Input tensor to be inserted into the input sequence.
+- **position** (I, optional): Position in the sequence where the new tensor is inserted. It is optional and default is to insert to the back of the sequence. Negative value means counting positions from the back. Accepted range in `[-n, n]`, where `n` is the number of tensors in 'input_sequence'. It is an error if any of the index values are out of bounds. It must be a scalar(tensor of empty shape).
+
+## Outputs (1 - 1)
+
+- **output_sequence** (S): Output sequence that contains the inserted tensor at given position.
+
+## Type Constraints
+
+- **T**: tensor(bool), tensor(complex128), tensor(complex64), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(string), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)
+  Constrain to any tensor type.
+- **S**: seq(tensor(bool)), seq(tensor(complex128)), seq(tensor(complex64)), seq(tensor(double)), seq(tensor(float)), seq(tensor(float16)), seq(tensor(int16)), seq(tensor(int32)), seq(tensor(int64)), seq(tensor(int8)), seq(tensor(string)), seq(tensor(uint16)), seq(tensor(uint32)), seq(tensor(uint64)), seq(tensor(uint8))
+  Constrain to any tensor type.
+- **I**: tensor(int32), tensor(int64)
+  Constrain position to integral tensor. It must be a scalar(tensor of empty shape).

--- a/onnx-spec/ops/SequenceLength.md
+++ b/onnx-spec/ops/SequenceLength.md
@@ -1,0 +1,22 @@
+# SequenceLength
+
+Since opset **11**
+
+## Description
+
+Produces a scalar(tensor of empty shape) containing the number of tensors in 'input_sequence'.
+
+## Inputs (1 - 1)
+
+- **input_sequence** (S): Input sequence.
+
+## Outputs (1 - 1)
+
+- **length** (I): Length of input sequence. It must be a scalar(tensor of empty shape).
+
+## Type Constraints
+
+- **S**: seq(tensor(bool)), seq(tensor(complex128)), seq(tensor(complex64)), seq(tensor(double)), seq(tensor(float)), seq(tensor(float16)), seq(tensor(int16)), seq(tensor(int32)), seq(tensor(int64)), seq(tensor(int8)), seq(tensor(string)), seq(tensor(uint16)), seq(tensor(uint32)), seq(tensor(uint64)), seq(tensor(uint8))
+  Constrain to any tensor type.
+- **I**: tensor(int64)
+  Constrain output to integral tensor. It must be a scalar(tensor of empty shape).

--- a/onnx-spec/ops/SequenceMap.md
+++ b/onnx-spec/ops/SequenceMap.md
@@ -1,0 +1,40 @@
+# SequenceMap
+
+Since opset **17**
+
+## Description
+
+Applies a sub-graph to each sample in the input sequence(s).
+
+Inputs can be either tensors or sequences, with the exception of the first input which must
+be a sequence. The length of the first input sequence will determine the number of samples in the
+outputs. Any other sequence inputs should have the same number of samples. The number of inputs
+and outputs, should match the one of the subgraph.
+
+For each i-th element in the output, a sample will be extracted from the input sequence(s) at
+the i-th position and the sub-graph will be applied to it.
+The outputs will contain the outputs of the sub-graph for each sample, in the same order as in
+the input.
+
+This operator assumes that processing each sample is independent and could executed in parallel
+or in any order. Users cannot expect any specific ordering in which each subgraph is computed.
+
+## Attributes
+
+- **body** (GRAPH, required): The graph to be run for each sample in the sequence(s). It should have as many inputs and outputs as inputs and outputs to the SequenceMap function.
+
+## Inputs (1 - 2147483647)
+
+- **input_sequence** (S): Input sequence.
+- **additional_inputs** (V, variadic): Additional inputs to the graph
+
+## Outputs (1 - 2147483647)
+
+- **out_sequence** (S, variadic): Output sequence(s)
+
+## Type Constraints
+
+- **S**: seq(tensor(bool)), seq(tensor(complex128)), seq(tensor(complex64)), seq(tensor(double)), seq(tensor(float)), seq(tensor(float16)), seq(tensor(int16)), seq(tensor(int32)), seq(tensor(int64)), seq(tensor(int8)), seq(tensor(string)), seq(tensor(uint16)), seq(tensor(uint32)), seq(tensor(uint64)), seq(tensor(uint8))
+  Constrain input types to any sequence type.
+- **V**: seq(tensor(bool)), seq(tensor(complex128)), seq(tensor(complex64)), seq(tensor(double)), seq(tensor(float)), seq(tensor(float16)), seq(tensor(int16)), seq(tensor(int32)), seq(tensor(int64)), seq(tensor(int8)), seq(tensor(string)), seq(tensor(uint16)), seq(tensor(uint32)), seq(tensor(uint64)), seq(tensor(uint8)), tensor(bool), tensor(complex128), tensor(complex64), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(string), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)
+  Constrain to any tensor or sequence type.

--- a/onnx-spec/ops/Shape.md
+++ b/onnx-spec/ops/Shape.md
@@ -1,0 +1,64 @@
+# Shape
+
+Since opset **24**
+
+## Description
+
+Takes a tensor as input and outputs an 1D int64 tensor containing the shape of the input tensor.
+Optional attributes start and end can be used to compute a slice of the input tensor's shape.
+If start axis is omitted, the slice starts from axis 0.
+The end axis, if specified, is exclusive (and the returned value will not include the size of that axis).
+If the end axis is omitted, the axes upto the last one will be included.
+Negative axes indicate counting back from the last axis.
+Note that axes will be clamped to the range [0, r], where r is the
+rank of the input tensor if they are out-of-range (after adding r in the case of
+negative axis). Thus, specifying any end value > r is equivalent to specifying an end
+value of r, and specifying any start value < -r is equivalent to specifying a start
+value of 0. If start > end, the result will be an empty shape.
+
+Examples:
+
+```
+Input tensor with shape: [2, 3, 4]
+No attributes specified.
+Output: [2, 3, 4]
+```
+
+```
+Input tensor with shape: [2, 3, 4]
+start: -1
+Output: [4]
+```
+
+```
+Input tensor with shape: [2, 3, 4]
+end: -1
+Output: [2, 3]
+```
+
+```
+Input tensor with shape: [2, 3, 4]
+start: 1
+end: 2
+Output: [3]
+```
+
+## Attributes
+
+- **end** (INT, optional): (Optional) Ending axis for slicing the shape. Negative value means counting dimensions from the back. If omitted, sizes of all axes upto (including) the last one will be included.
+- **start** (INT, optional): (Optional) Starting axis for slicing the shape. Default value is 0.Negative value means counting dimensions from the back.
+
+## Inputs (1 - 1)
+
+- **data** (T): An input tensor.
+
+## Outputs (1 - 1)
+
+- **shape** (T1): Shape of the input tensor
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(bool), tensor(complex128), tensor(complex64), tensor(double), tensor(float), tensor(float16), tensor(float4e2m1), tensor(float8e4m3fn), tensor(float8e4m3fnuz), tensor(float8e5m2), tensor(float8e5m2fnuz), tensor(float8e8m0), tensor(int16), tensor(int32), tensor(int4), tensor(int64), tensor(int8), tensor(string), tensor(uint16), tensor(uint32), tensor(uint4), tensor(uint64), tensor(uint8)
+  Input tensor can be of arbitrary type.
+- **T1**: tensor(int64)
+  Constrain output to int64 tensor.

--- a/onnx-spec/ops/Shrink.md
+++ b/onnx-spec/ops/Shrink.md
@@ -1,0 +1,28 @@
+# Shrink
+
+Since opset **9**
+
+## Description
+
+Shrink takes one input data (Tensor<numeric>) and produces one Tensor output,
+having same datatype and shape with input. It has two attributes, lambd and
+bias. The formula of this operator is: If x < -lambd, y = x + bias;
+If x > lambd, y = x - bias; Otherwise, y = 0.
+
+## Attributes
+
+- **bias** (FLOAT, optional): The bias value added to output. Default is 0.
+- **lambd** (FLOAT, optional): The lambd value for the Shrink formulation. Default is 0.5.
+
+## Inputs (1 - 1)
+
+- **input** (T): The input data as Tensor.
+
+## Outputs (1 - 1)
+
+- **output** (T): The output.
+
+## Type Constraints
+
+- **T**: tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)
+  Constrain input to only numeric types.

--- a/onnx-spec/ops/Sigmoid.md
+++ b/onnx-spec/ops/Sigmoid.md
@@ -1,0 +1,22 @@
+# Sigmoid
+
+Since opset **13**
+
+## Description
+
+Sigmoid takes one input data (Tensor<T>) and produces one output data
+(Tensor<T>) where the sigmoid function, y = 1 / (1 + exp(-x)), is applied to the
+tensor elementwise.
+
+## Inputs (1 - 1)
+
+- **X** (T): Input tensor
+
+## Outputs (1 - 1)
+
+- **Y** (T): Output tensor
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain input and output types to float tensors.

--- a/onnx-spec/ops/Sign.md
+++ b/onnx-spec/ops/Sign.md
@@ -1,0 +1,21 @@
+# Sign
+
+Since opset **13**
+
+## Description
+
+Calculate the sign of the given input tensor element-wise.
+If input > 0, output 1. if input < 0, output -1. if input == 0, output 0.
+
+## Inputs (1 - 1)
+
+- **input** (T): Input tensor
+
+## Outputs (1 - 1)
+
+- **output** (T): The sign of the input tensor computed element-wise. It has the same shape and type of the input.
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)
+  Constrain input and output types to all numeric tensors.

--- a/onnx-spec/ops/Sin.md
+++ b/onnx-spec/ops/Sin.md
@@ -1,0 +1,20 @@
+# Sin
+
+Since opset **22**
+
+## Description
+
+Calculates the sine of the given input tensor, element-wise.
+
+## Inputs (1 - 1)
+
+- **input** (T): Input tensor
+
+## Outputs (1 - 1)
+
+- **output** (T): The sine of the input tensor computed element-wise
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain input and output types to float tensors.

--- a/onnx-spec/ops/Sinh.md
+++ b/onnx-spec/ops/Sinh.md
@@ -1,0 +1,20 @@
+# Sinh
+
+Since opset **22**
+
+## Description
+
+Calculates the hyperbolic sine of the given input tensor element-wise.
+
+## Inputs (1 - 1)
+
+- **input** (T): Input tensor
+
+## Outputs (1 - 1)
+
+- **output** (T): The hyperbolic sine values of the input tensor computed element-wise
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain input and output types to float tensors.

--- a/onnx-spec/ops/Size.md
+++ b/onnx-spec/ops/Size.md
@@ -1,0 +1,22 @@
+# Size
+
+Since opset **24**
+
+## Description
+
+Takes a tensor as input and outputs a int64 scalar that equals to the total number of elements of the input tensor.
+
+## Inputs (1 - 1)
+
+- **data** (T): An input tensor.
+
+## Outputs (1 - 1)
+
+- **size** (T1): Total number of elements of the input tensor
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(bool), tensor(complex128), tensor(complex64), tensor(double), tensor(float), tensor(float16), tensor(float4e2m1), tensor(float8e4m3fn), tensor(float8e4m3fnuz), tensor(float8e5m2), tensor(float8e5m2fnuz), tensor(float8e8m0), tensor(int16), tensor(int32), tensor(int4), tensor(int64), tensor(int8), tensor(string), tensor(uint16), tensor(uint32), tensor(uint4), tensor(uint64), tensor(uint8)
+  Input tensor can be of arbitrary type.
+- **T1**: tensor(int64)
+  Constrain output to int64 tensor, which should be a scalar though.

--- a/onnx-spec/ops/Slice.md
+++ b/onnx-spec/ops/Slice.md
@@ -1,0 +1,87 @@
+# Slice
+
+Since opset **13**
+
+## Description
+
+Produces a slice of the input tensor along multiple axes. Similar to numpy:
+https://numpy.org/doc/stable/user/basics.indexing.html?highlight=slice#slicing-and-striding
+
+Slice uses the `starts`, `ends`, `axes` and `steps` inputs to select a sub-tensor
+of its input `data` tensor.
+
+An effective `starts[i]`, `ends[i]`, and `steps[i]` must be computed for each `i`
+in `[0, ... r-1]` where `r = rank(input)` as follows:
+
+If `axes` are omitted, they are set to `[0, ..., r-1]`.
+If `steps` are omitted, they are set to `[1, ..., 1]` of length `len(starts)`
+
+The effective values are initialized as `start[i] = 0`, `ends[i] = dims[i]` where
+`dims` are the dimensions of `input` and `steps[i] = 1`.
+
+All negative elements of `axes` are made non-negative by adding `r` to them, where
+`r =rank(input)`.
+
+All negative values in `starts[i]` and `ends[i]` have `dims[axes[i]]` added to them,
+where `dims` are the dimensions of `input`. Then `start[axes[i]]` is the adjusted
+`starts[i]` is clamped into the range `[0, dims[axes[i]]]` for positive stepping
+and `[0, dims[axes[i]]-1]` for negative stepping.
+
+The clamping for the adjusted `ends[i]` depends on the sign of `steps[i]` and must
+accommodate copying 0 through `dims[axes[i]]` elements, so for positive stepping
+`ends[axes[i]]` is clamped to `[0, dims[axes[i]]]`, while for negative stepping it
+is clamped to `[-1, dims[axes[i]]-1]`.
+
+Finally, `steps[axes[i]] = steps[i]`.
+
+For slicing to the end of a dimension with unknown size, it is recommended to pass
+in `INT_MAX` when slicing forward and 'INT_MIN' when slicing backward.
+
+Example 1:
+
+```
+data = [
+    [1, 2, 3, 4],
+    [5, 6, 7, 8],
+]
+axes = [0, 1]
+starts = [1, 0]
+ends = [2, 3]
+steps = [1, 2]
+result = [
+    [5, 7],
+]
+```
+
+Example 2:
+
+```
+data = [
+    [1, 2, 3, 4],
+    [5, 6, 7, 8],
+]
+starts = [0, 1]
+ends = [-1, 1000]
+result = [
+    [2, 3, 4],
+]
+```
+
+## Inputs (3 - 5)
+
+- **data** (T): Tensor of data to extract slices from.
+- **starts** (Tind): 1-D tensor of starting indices of corresponding axis in `axes`
+- **ends** (Tind): 1-D tensor of ending indices (exclusive) of corresponding axis in `axes`
+- **axes** (Tind, optional): 1-D tensor of axes that `starts` and `ends` apply to. Negative value means counting dimensions from the back. Accepted range is [-r, r-1] where r = rank(data). Behavior is undefined if an axis is repeated.
+- **steps** (Tind, optional): 1-D tensor of slice step of corresponding axis in `axes`. Negative value means slicing backward. 'steps' cannot be 0. Defaults to 1s.
+
+## Outputs (1 - 1)
+
+- **output** (T): Sliced data tensor.
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(bool), tensor(complex128), tensor(complex64), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(string), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)
+  Constrain input and output types to all tensor types.
+- **Tind**: tensor(int32), tensor(int64)
+  Constrain indices to integer types

--- a/onnx-spec/ops/Softmax.md
+++ b/onnx-spec/ops/Softmax.md
@@ -1,0 +1,30 @@
+# Softmax
+
+Since opset **13**
+
+## Description
+
+The operator computes the normalized exponential values for the given input:
+
+ Softmax(input, axis) = Exp(input) / ReduceSum(Exp(input), axis=axis, keepdims=1) 
+
+The "axis" attribute indicates the dimension along which Softmax
+will be performed. The output tensor has the same shape
+and contains the Softmax values of the corresponding input.
+
+## Attributes
+
+- **axis** (INT, optional): Describes the dimension Softmax will be performed on.
+
+## Inputs (1 - 1)
+
+- **input** (T): The input tensor of rank >= axis.
+
+## Outputs (1 - 1)
+
+- **output** (T): The output values with the same shape as the input tensor.
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain input and output types to float tensors.

--- a/onnx-spec/ops/SoftmaxCrossEntropyLoss.md
+++ b/onnx-spec/ops/SoftmaxCrossEntropyLoss.md
@@ -1,0 +1,69 @@
+# SoftmaxCrossEntropyLoss
+
+Since opset **13**
+
+## Description
+
+Loss function that measures the softmax cross entropy
+between 'scores' and 'labels'.
+This operator first computes a loss tensor whose shape is identical to the labels input.
+If the input is 2-D with shape (N, C), the loss tensor may be a N-element vector L = (l_1, l_2, ..., l_N).
+If the input is N-D tensor with shape (N, C, D1, D2, ..., Dk),
+the loss tensor L may have (N, D1, D2, ..., Dk) as its shape and L[i,][j_1][j_2]...[j_k] denotes a scalar element in L.
+After L is available, this operator can optionally do a reduction operator.
+
+* shape(scores): (N, C) where C is the number of classes, or (N, C, D1, D2,..., Dk),
+  with K >= 1 in case of K-dimensional loss.
+* shape(labels): (N) where each value is 0 <= labels[i] <= C-1, or (N, D1, D2,..., Dk),
+  with K >= 1 in case of K-dimensional loss.
+
+The loss for one sample, l_i, can calculated as follows:
+```
+l[i][d1][d2]...[dk] = -y[i][c][d1][d2]..[dk], where i is the index of classes.
+```
+or
+```
+l[i][d1][d2]...[dk] = -y[i][c][d1][d2]..[dk] * weights[c], if 'weights' is provided.
+```
+
+loss is zero for the case when label-value equals ignore_index.
+```
+l[i][d1][d2]...[dk]  = 0, when labels[n][d1][d2]...[dk] = ignore_index
+```
+
+where:
+```
+p = Softmax(scores)
+y = Log(p)
+c = labels[i][d1][d2]...[dk]
+```
+
+Finally, L is optionally reduced:
+
+* If reduction = 'none', the output is L with shape (N, D1, D2, ..., Dk).
+* If reduction = 'sum', the output is scalar: Sum(L).
+* If reduction = 'mean', the output is scalar: ReduceMean(L), or if weight is provided: `ReduceSum(L) / ReduceSum(W)`,
+  where tensor W is of shape `(N, D1, D2, ..., Dk)` and `W[n][d1][d2]...[dk] = weights[labels[i][d1][d2]...[dk]]`.
+
+## Attributes
+
+- **ignore_index** (INT, optional): Specifies a target value that is ignored and does not contribute to the input gradient. It's an optional value.
+- **reduction** (STRING, optional): Type of reduction to apply to loss: none, sum, mean(default). 'none': no reduction will be applied, 'sum': the output will be summed. 'mean': the sum of the output will be divided by the number of elements in the output.
+
+## Inputs (2 - 3)
+
+- **scores** (T): The predicted outputs with shape [batch_size, class_size], or [batch_size, class_size, D1, D2 , ..., Dk], where K is the number of dimensions.
+- **labels** (Tind): The ground truth output tensor, with shape [batch_size], or [batch_size, D1, D2, ..., Dk], where K is the number of dimensions. Labels element value shall be in range of [0, C). If ignore_index is specified, it may have a value outside [0, C) and the label values should either be in the range [0, C) or have the value ignore_index.
+- **weights** (T, optional): A manual rescaling weight given to each class. If given, it has to be a 1D Tensor assigning weight to each of the classes. Otherwise, it is treated as if having all ones.
+
+## Outputs (1 - 2)
+
+- **output** (T): Weighted loss float Tensor. If reduction is 'none', this has the shape of [batch_size], or [batch_size, D1, D2, ..., Dk] in case of K-dimensional loss. Otherwise, it is a scalar.
+- **log_prob** (T, optional): Log probability tensor. If the output of softmax is prob, its value is log(prob).
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain input and output types to float tensors.
+- **Tind**: tensor(int32), tensor(int64)
+  Constrain target to integer types

--- a/onnx-spec/ops/Softplus.md
+++ b/onnx-spec/ops/Softplus.md
@@ -1,0 +1,22 @@
+# Softplus
+
+Since opset **22**
+
+## Description
+
+Softplus takes one input data (Tensor<T>) and produces one output data
+(Tensor<T>) where the softplus function, y = ln(exp(x) + 1), is applied to
+the tensor elementwise.
+
+## Inputs (1 - 1)
+
+- **X** (T): Input tensor
+
+## Outputs (1 - 1)
+
+- **Y** (T): Output tensor
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain input and output types to float tensors.

--- a/onnx-spec/ops/Softsign.md
+++ b/onnx-spec/ops/Softsign.md
@@ -1,0 +1,20 @@
+# Softsign
+
+Since opset **22**
+
+## Description
+
+Calculates the softsign (x/(1+|x|)) of the given input tensor element-wise.
+
+## Inputs (1 - 1)
+
+- **input** (T): Input tensor
+
+## Outputs (1 - 1)
+
+- **output** (T): The softsign (x/(1+|x|)) values of the input tensor computed element-wise
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain input and output types to float tensors.

--- a/onnx-spec/ops/SpaceToDepth.md
+++ b/onnx-spec/ops/SpaceToDepth.md
@@ -1,0 +1,26 @@
+# SpaceToDepth
+
+Since opset **13**
+
+## Description
+
+SpaceToDepth rearranges blocks of spatial data into depth. More specifically,
+this op outputs a copy of the input tensor where values from the height and width dimensions
+are moved to the depth dimension.
+
+## Attributes
+
+- **blocksize** (INT, required): Blocks of [blocksize, blocksize] are moved.
+
+## Inputs (1 - 1)
+
+- **input** (T): Input tensor of [N,C,H,W], where N is the batch axis, C is the channel or depth, H is the height and W is the width.
+
+## Outputs (1 - 1)
+
+- **output** (T): Output tensor of [N, C * blocksize * blocksize, H/blocksize, W/blocksize].
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(bool), tensor(complex128), tensor(complex64), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(string), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)
+  Constrain input and output types to all tensor types.

--- a/onnx-spec/ops/Split.md
+++ b/onnx-spec/ops/Split.md
@@ -1,0 +1,30 @@
+# Split
+
+Since opset **18**
+
+## Description
+
+Split a tensor into a list of tensors, along the specified 'axis'.
+Either input 'split' or the attribute 'num_outputs' should be specified, but not both.
+If the attribute 'num_outputs' is specified, then the tensor is split into equal sized parts.
+If the tensor is not evenly splittable into `num_outputs`, the last chunk will be smaller.
+If the input 'split' is specified, it indicates the sizes of each output in the split.
+
+## Attributes
+
+- **axis** (INT, optional): Which axis to split on. A negative value means counting dimensions from the back. Accepted range is [-rank, rank-1] where r = rank(input).
+- **num_outputs** (INT, optional): Number of outputs to split parts of the tensor into. If the tensor is not evenly splittable the last chunk will be smaller.
+
+## Inputs (1 - 2)
+
+- **input** (T): The tensor to split
+- **split** (tensor(int64), optional): Optional length of each output. Values should be >= 0.Sum of the values must be equal to the dim value at 'axis' specified.
+
+## Outputs (1 - 2147483647)
+
+- **outputs** (T, variadic): One or more outputs forming list of tensors after splitting
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(bool), tensor(complex128), tensor(complex64), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(string), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)
+  Constrain input and output types to all tensor types.

--- a/onnx-spec/ops/SplitToSequence.md
+++ b/onnx-spec/ops/SplitToSequence.md
@@ -1,0 +1,41 @@
+# SplitToSequence
+
+Since opset **24**
+
+## Description
+
+Split a tensor into a sequence of tensors, along the specified 'axis'.
+Lengths of the parts can be specified using the optional argument 'split'.
+If the argument `split' is not specified, a default scalar value of 1
+is used as the value of `split'.
+'split' must contain only positive numbers.
+'split' is either a scalar (tensor of empty shape), or a 1-D tensor.
+If 'split' is a scalar, then 'input' will be split into chunks all of size 'split'
+if possible. The last chunk alone may be smaller than 'split' if the 'input' size
+along the given axis 'axis' is not divisible by 'split'.
+If 'split' is a 1-dimensional tensor, the input tensor is split into 'size(split)' chunks,
+with lengths of the parts on 'axis' specified in 'split'. In this scenario, the sum of entries
+in 'split' must be equal to the dimension size of input tensor on 'axis'.
+
+## Attributes
+
+- **axis** (INT, optional): Which axis to split on. A negative value means counting dimensions from the back. Accepted range is [-rank, rank-1].
+- **keepdims** (INT, optional): Keep the split dimension or not. Default 1, which means we keep split dimension. If input 'split' is specified, this attribute is ignored.
+
+## Inputs (1 - 2)
+
+- **input** (T): The tensor to split
+- **split** (I, optional): Length of each output. It can be either a scalar(tensor of empty shape), or a 1-D tensor. All values must be >= 0.
+
+## Outputs (1 - 1)
+
+- **output_sequence** (S): One or more outputs forming a sequence of tensors after splitting
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(bool), tensor(complex128), tensor(complex64), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(string), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)
+  Constrain input types to all tensor types.
+- **I**: tensor(int32), tensor(int64)
+  Constrain split size to integral tensor.
+- **S**: seq(tensor(bfloat16)), seq(tensor(bool)), seq(tensor(complex128)), seq(tensor(complex64)), seq(tensor(double)), seq(tensor(float)), seq(tensor(float16)), seq(tensor(int16)), seq(tensor(int32)), seq(tensor(int64)), seq(tensor(int8)), seq(tensor(string)), seq(tensor(uint16)), seq(tensor(uint32)), seq(tensor(uint64)), seq(tensor(uint8))
+  Constrain output types to all tensor types.

--- a/onnx-spec/ops/Sqrt.md
+++ b/onnx-spec/ops/Sqrt.md
@@ -1,0 +1,22 @@
+# Sqrt
+
+Since opset **13**
+
+## Description
+
+Square root takes one input data (Tensor<T>) and produces one output data
+(Tensor<T>) where the square root is, y = x^0.5, is applied to
+the tensor elementwise. If x is negative, then it will return NaN.
+
+## Inputs (1 - 1)
+
+- **X** (T): Input tensor
+
+## Outputs (1 - 1)
+
+- **Y** (T): Output tensor
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain input and output types to float tensors.

--- a/onnx-spec/ops/Squeeze.md
+++ b/onnx-spec/ops/Squeeze.md
@@ -1,0 +1,24 @@
+# Squeeze
+
+Since opset **24**
+
+## Description
+
+Remove single-dimensional entries from the shape of a tensor.
+Takes an input `axes` with a list of axes to squeeze.
+If `axes` is not provided, all the single dimensions will be removed from
+the shape. If an axis is selected with shape entry not equal to one, an error is raised.
+
+## Inputs (1 - 2)
+
+- **data** (T): Tensors with at least max(dims) dimensions.
+- **axes** (tensor(int64), optional): 1D tensor of integers indicating the dimensions to squeeze. Negative value means counting dimensions from the back. Accepted range is [-r, r-1] where r = rank(data).
+
+## Outputs (1 - 1)
+
+- **squeezed** (T): Reshaped tensor with same data as input.
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(bool), tensor(complex128), tensor(complex64), tensor(double), tensor(float), tensor(float16), tensor(float4e2m1), tensor(float8e4m3fn), tensor(float8e4m3fnuz), tensor(float8e5m2), tensor(float8e5m2fnuz), tensor(float8e8m0), tensor(int16), tensor(int32), tensor(int4), tensor(int64), tensor(int8), tensor(string), tensor(uint16), tensor(uint32), tensor(uint4), tensor(uint64), tensor(uint8)
+  Constrain input and output types to all tensor types up to IRv12.

--- a/onnx-spec/ops/StringConcat.md
+++ b/onnx-spec/ops/StringConcat.md
@@ -1,0 +1,21 @@
+# StringConcat
+
+Since opset **20**
+
+## Description
+
+StringConcat concatenates string tensors elementwise (with NumPy-style broadcasting support)
+
+## Inputs (2 - 2)
+
+- **X** (T): Tensor to prepend in concatenation
+- **Y** (T): Tensor to append in concatenation
+
+## Outputs (1 - 1)
+
+- **Z** (T): Concatenated string tensor
+
+## Type Constraints
+
+- **T**: tensor(string)
+  Inputs and outputs must be UTF-8 strings

--- a/onnx-spec/ops/StringNormalizer.md
+++ b/onnx-spec/ops/StringNormalizer.md
@@ -1,0 +1,30 @@
+# StringNormalizer
+
+Since opset **10**
+
+## Description
+
+StringNormalization performs string operations for basic cleaning.
+This operator has only one input (denoted by X) and only one output
+(denoted by Y). This operator first examines the elements in the X,
+and removes elements specified in "stopwords" attribute.
+After removing stop words, the intermediate result can be further lowercased,
+uppercased, or just returned depending the "case_change_action" attribute.
+This operator only accepts [C]- and [1, C]-tensor.
+If all elements in X are dropped, the output will be the empty value of string tensor with shape [1]
+if input shape is [C] and shape [1, 1] if input shape is [1, C].
+
+## Attributes
+
+- **case_change_action** (STRING, optional): string enum that cases output to be lowercased/uppercases/unchanged. Valid values are "LOWER", "UPPER", "NONE". Default is "NONE"
+- **is_case_sensitive** (INT, optional): Boolean. Whether the identification of stop words in X is case-sensitive. Default is false
+- **locale** (STRING, optional): Environment dependent string that denotes the locale according to which output strings needs to be upper/lowercased.Default en_US or platform specific equivalent as decided by the implementation.
+- **stopwords** (STRINGS, optional): List of stop words. If not set, no word would be removed from X.
+
+## Inputs (1 - 1)
+
+- **X** (tensor(string)): UTF-8 strings to normalize
+
+## Outputs (1 - 1)
+
+- **Y** (tensor(string)): UTF-8 Normalized strings

--- a/onnx-spec/ops/StringSplit.md
+++ b/onnx-spec/ops/StringSplit.md
@@ -1,0 +1,34 @@
+# StringSplit
+
+Since opset **20**
+
+## Description
+
+StringSplit splits a string tensor's elements into substrings based on a delimiter attribute and a maxsplit attribute.
+
+The first output of this operator is a tensor of strings representing the substrings from splitting each input string on the `delimiter` substring. This tensor has one additional rank compared to the input tensor in order to store the substrings for each input element (where the input tensor is not empty). Note that, in order to ensure the same number of elements are present in the final dimension, this tensor will pad empty strings as illustrated in the examples below. Consecutive delimiters are not grouped together and are deemed to delimit empty strings, except if the `delimiter` is unspecified or is the empty string (""). In the case where the `delimiter` is unspecified or the empty string, consecutive whitespace characters are regarded as a single separator and leading or trailing whitespace is removed in the output.
+
+The second output tensor represents the number of substrings generated. `maxsplit` can be used to limit the number of splits performed - after the `maxsplit`th split if the string is not fully split, the trailing suffix of input string after the final split point is also added. For elements where fewer splits are possible than specified in `maxsplit`, it has no effect.
+
+## Attributes
+
+- **delimiter** (STRING, optional): Delimiter to split on. If left unset or set to the empty string (""), the input is split on consecutive whitespace.
+- **maxsplit** (INT, optional): Maximum number of splits (from left to right). If left unset (or if the number of possible splits are less than maxsplit), it will make as many splits as possible. Note that the maximum possible number of substrings returned with `maxsplit` specified is `maxsplit+1` since the remaining suffix after the `maxsplit`th split is included in the output.
+
+## Inputs (1 - 1)
+
+- **X** (T1): Tensor of strings to split.
+
+## Outputs (2 - 2)
+
+- **Y** (T2): Tensor of substrings representing the outcome of splitting the strings in the input on the delimiter. Note that to ensure the same number of elements are present in the final rank, this tensor will pad any necessary empty strings.
+- **Z** (T3): The number of substrings generated for each input element.
+
+## Type Constraints
+
+- **T1**: tensor(string)
+  The input must be a UTF-8 string tensor
+- **T2**: tensor(string)
+  Tensor of substrings.
+- **T3**: tensor(int64)
+  The number of substrings generated.

--- a/onnx-spec/ops/Sub.md
+++ b/onnx-spec/ops/Sub.md
@@ -1,0 +1,25 @@
+# Sub
+
+Since opset **14**
+
+## Description
+
+Performs element-wise binary subtraction (with Numpy-style broadcasting support).
+
+This operator supports **multidirectional (i.e., Numpy-style) broadcasting**; for more details please check [the doc](Broadcasting.md).
+
+(Opset 14 change): Extend supported types to include uint8, int8, uint16, and int16.
+
+## Inputs (2 - 2)
+
+- **A** (T): First operand.
+- **B** (T): Second operand.
+
+## Outputs (1 - 1)
+
+- **C** (T): Result, has same element type as two inputs
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)
+  Constrain input and output types to all numeric tensors.

--- a/onnx-spec/ops/Sum.md
+++ b/onnx-spec/ops/Sum.md
@@ -1,0 +1,22 @@
+# Sum
+
+Since opset **13**
+
+## Description
+
+Element-wise sum of each of the input tensors (with Numpy-style broadcasting support).
+All inputs and outputs must have the same data type.
+This operator supports **multidirectional (i.e., Numpy-style) broadcasting**; for more details please check [the doc](Broadcasting.md).
+
+## Inputs (1 - 2147483647)
+
+- **data_0** (T, variadic): List of tensors for sum.
+
+## Outputs (1 - 1)
+
+- **sum** (T): Output tensor.
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain input and output types to float tensors.

--- a/onnx-spec/ops/Swish.md
+++ b/onnx-spec/ops/Swish.md
@@ -1,0 +1,25 @@
+# Swish
+
+Since opset **24**
+
+## Description
+
+Swish function takes one input data (Tensor<T>) and produces one output data (Tensor<T>) of the same shape,
+where $Swish(x) = x * sigmoid(alpha * x)$.
+
+## Attributes
+
+- **alpha** (FLOAT, optional): Coefficient to multiply with input before sigmoid.
+
+## Inputs (1 - 1)
+
+- **X** (T): Input tensor
+
+## Outputs (1 - 1)
+
+- **Y** (T): Output tensor
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain input and output types to float tensors.

--- a/onnx-spec/ops/Tan.md
+++ b/onnx-spec/ops/Tan.md
@@ -1,0 +1,20 @@
+# Tan
+
+Since opset **22**
+
+## Description
+
+Calculates the tangent of the given input tensor, element-wise.
+
+## Inputs (1 - 1)
+
+- **input** (T): Input tensor
+
+## Outputs (1 - 1)
+
+- **output** (T): The tangent of the input tensor computed element-wise
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain input and output types to float tensors.

--- a/onnx-spec/ops/Tanh.md
+++ b/onnx-spec/ops/Tanh.md
@@ -1,0 +1,20 @@
+# Tanh
+
+Since opset **13**
+
+## Description
+
+Calculates the hyperbolic tangent of the given input tensor element-wise.
+
+## Inputs (1 - 1)
+
+- **input** (T): Input tensor
+
+## Outputs (1 - 1)
+
+- **output** (T): The hyperbolic tangent values of the input tensor computed element-wise
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain input and output types to float tensors.

--- a/onnx-spec/ops/TensorScatter.md
+++ b/onnx-spec/ops/TensorScatter.md
@@ -1,0 +1,52 @@
+# TensorScatter
+
+Since opset **24**
+
+## Description
+
+TensorScatter is a generic tensor update operation, motivated by the requirements for KV cache updates for Attention
+ops commonly found in LLMs. It is a functional operation that models an in-place update to a KV cache buffer.
+
+The past and present cache tensors have the same shape (batch_size, D1, D2, ..., max_sequence_length, ..., Dn), with
+the sequence dimension (indicated by the `axis` attribute) being max_sequence_length, so the sizes of these tensors do
+not need to grow between iterations. The `update` tensor's shape only differs from the cache tensors in the sequence
+dimension: (batch_size, D1, D2, ..., sequence_length, ..., Dn), where sequence_length <= max_sequence_length.
+
+The optional `write_indices` input indicates the write index for each sample in the batch, assumed to be zero
+if not provided. When the `mode` attribute is set to "circular", the write index is modulo max_sequence_length.
+The operation can be described using the following pseudocode:
+
+```
+for prefix_idx in np.ndindex(past_cache.shape[:axis]):
+    batch_idx = prefix_idx[0]
+    for sequence_idx in range(sequence_length):
+        cache_idx = (*prefix_idx, write_indices[batch_idx] + sequence_idx)
+        if mode == "circular":
+            cache_idx = tuple(np.mod(np.asarray(cache_idx), max_sequence_length))
+        update_idx = (*prefix_idx, sequence_idx)
+        present_cache[cache_idx] = update[update_idx]
+```
+
+During the prefill phase of attention, only the first two inputs are needed. During the decode phase, `write_indices`
+is also needed so that the incoming key or value update can be appended after the last valid token for each sample
+in the batch.
+
+## Attributes
+
+- **axis** (INT, optional): Sequence dimension of the `past_cache` and `update` tensors. It cannot be 0 (the batch dimension). Default is -2.
+- **mode** (STRING, optional): Write mode of cache update. Supported modes include `linear` and `circular`. `linear` mode requires write_indices+sequence_length<=max_sequence_length. For `circular` mode, the updates happen in wrap-around fashion, ie, the update index is modulo `max_sequence_length`
+
+## Inputs (2 - 3)
+
+- **past_cache** (T): Past state cache for key or value with shape `(batch_size, D1, D2, ..., max_sequence_length, ..., Dn)`.
+- **update** (T): New update tensor with shape `(batch_size, D1, D2, ..., sequence_length, ..., Dn)`.
+- **write_indices** (tensor(int64), optional): Write indices for the incoming update tensor in the cache. Shape is `(batch_size,)`. Assumed to be all zeros if not provided.
+
+## Outputs (1 - 1)
+
+- **present_cache** (T): Updated cache. Same shape as `past_cache`.
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(bool), tensor(complex128), tensor(complex64), tensor(double), tensor(float), tensor(float16), tensor(float4e2m1), tensor(float8e4m3fn), tensor(float8e4m3fnuz), tensor(float8e5m2), tensor(float8e5m2fnuz), tensor(float8e8m0), tensor(int16), tensor(int32), tensor(int4), tensor(int64), tensor(int8), tensor(string), tensor(uint16), tensor(uint32), tensor(uint4), tensor(uint64), tensor(uint8)
+  Constrain input and output types to any tensor type.

--- a/onnx-spec/ops/TfIdfVectorizer.md
+++ b/onnx-spec/ops/TfIdfVectorizer.md
@@ -1,0 +1,60 @@
+# TfIdfVectorizer
+
+Since opset **9**
+
+## Description
+
+This transform extracts n-grams from the input sequence and save them as a vector. Input can
+be either a 1-D or 2-D tensor. For 1-D input, output is the n-gram representation of that input.
+For 2-D input, the output is also a  2-D tensor whose i-th row is the n-gram representation of the i-th input row.
+More specifically, if input shape is [C], the corresponding output shape would be [max(ngram_indexes) + 1].
+If input shape is [N, C], this operator produces a [N, max(ngram_indexes) + 1]-tensor.
+
+In contrast to standard n-gram extraction, here, the indexes of extracting an n-gram from the original
+sequence are not necessarily consecutive numbers. The discontinuity between indexes are controlled by the number of skips.
+If the number of skips is 2, we should skip two tokens when scanning through the original sequence.
+Let's consider an example. Assume that input sequence is [94, 17, 36, 12, 28] and the number of skips is 2.
+The associated 2-grams are [94, 12] and [17, 28] respectively indexed by [0, 3] and [1, 4].
+If the number of skips becomes 0, the 2-grams generated are [94, 17], [17, 36], [36, 12], [12, 28]
+indexed by [0, 1], [1, 2], [2, 3], [3, 4], respectively.
+
+The output vector (denoted by Y) stores the count of each n-gram;
+Y[ngram_indexes[i]] indicates the times that the i-th n-gram is found. The attribute ngram_indexes is used to determine the mapping
+between index i and the corresponding n-gram's output coordinate. If pool_int64s is [94, 17, 17, 36], ngram_indexes is [1, 0],
+ngram_counts=[0, 0], then the Y[0] (first element in Y) and Y[1] (second element in Y) are the counts of [17, 36] and [94, 17],
+respectively. An n-gram which cannot be found in pool_strings/pool_int64s should be ignored and has no effect on the output.
+Note that we may consider all skips up to S when generating the n-grams.
+
+The examples used above are true if mode is "TF". If mode is "IDF", all the counts larger than 1 would be truncated to 1 and
+the i-th element in weights would be used to scale (by multiplication) the count of the i-th n-gram in pool. If mode is "TFIDF",
+this operator first computes the counts of all n-grams and then scale them by the associated values in the weights attribute.
+
+Only one of pool_strings and pool_int64s can be set. If pool_int64s is set, the input should be an integer tensor.
+If pool_strings is set, the input must be a string tensor.
+
+## Attributes
+
+- **max_gram_length** (INT, required): Maximum n-gram length. If this value is 3, 3-grams will be used to generate the output.
+- **max_skip_count** (INT, required): Maximum number of items (integers/strings) to be skipped when constructing an n-gram from X. If max_skip_count=1, min_gram_length=2, max_gram_length=3, this operator may generate 2-grams with skip_count=0 and skip_count=1, and 3-grams with skip_count=0 and skip_count=1
+- **min_gram_length** (INT, required): Minimum n-gram length. If this value is 2 and max_gram_length is 3, output may contain counts of 2-grams and 3-grams.
+- **mode** (STRING, required): The weighting criteria. It can be one of "TF" (term frequency), "IDF" (inverse document frequency), and "TFIDF" (the combination of TF and IDF)
+- **ngram_counts** (INTS, required): The starting indexes of 1-grams, 2-grams, and so on in pool. It is useful when determining the boundary between two consecutive collections of n-grams. For example, if ngram_counts is [0, 17, 36], the first index (zero-based) of 1-gram/2-gram/3-gram in pool are 0/17/36. This format is essentially identical to CSR (or CSC) sparse matrix format, and we choose to use this due to its popularity.
+- **ngram_indexes** (INTS, required): list of int64s (type: AttributeProto::INTS). This list is parallel to the specified 'pool_*' attribute. The i-th element in ngram_indexes indicate the coordinate of the i-th n-gram in the output tensor.
+- **pool_int64s** (INTS, optional): List of int64 n-grams learned from the training set. Either this or pool_strings attributes must be present but not both. It's an 1-D tensor starting with the collections of all 1-grams and ending with the collections of n-grams. The i-th element in pool stores the n-gram that should be mapped to coordinate ngram_indexes[i] in the output vector.
+- **pool_strings** (STRINGS, optional): List of strings n-grams learned from the training set. Either this or pool_int64s attributes must be present but not both. It's an 1-D tensor starting with the collections of all 1-grams and ending with the collections of n-grams. The i-th element in pool stores the n-gram that should be mapped to coordinate ngram_indexes[i] in the output vector.
+- **weights** (FLOATS, optional): list of floats. This attribute stores the weight of each n-gram in pool. The i-th element in weights is the weight of the i-th n-gram in pool. Its length equals to the size of ngram_indexes. By default, weights is an all-one tensor.This attribute is used when mode is "IDF" or "TFIDF" to scale the associated word counts.
+
+## Inputs (1 - 1)
+
+- **X** (T): Input for n-gram extraction
+
+## Outputs (1 - 1)
+
+- **Y** (T1): Ngram results
+
+## Type Constraints
+
+- **T**: tensor(int32), tensor(int64), tensor(string)
+  Input is ether string UTF-8 or int32/int64
+- **T1**: tensor(float)
+  1-D tensor of floats

--- a/onnx-spec/ops/ThresholdedRelu.md
+++ b/onnx-spec/ops/ThresholdedRelu.md
@@ -1,0 +1,26 @@
+# ThresholdedRelu
+
+Since opset **22**
+
+## Description
+
+ThresholdedRelu takes one input data (Tensor<T>) and produces one output data
+(Tensor<T>) where the rectified linear function, y = x for x > alpha, y = 0 otherwise,
+is applied to the tensor elementwise.
+
+## Attributes
+
+- **alpha** (FLOAT, optional): Threshold value
+
+## Inputs (1 - 1)
+
+- **X** (T): Input tensor
+
+## Outputs (1 - 1)
+
+- **Y** (T): Output tensor
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16)
+  Constrain input and output types to float tensors.

--- a/onnx-spec/ops/Tile.md
+++ b/onnx-spec/ops/Tile.md
@@ -1,0 +1,25 @@
+# Tile
+
+Since opset **13**
+
+## Description
+
+Constructs a tensor by tiling a given tensor.
+This is the same as function `tile` in Numpy, but no broadcast.
+For example A = [[1, 2], [3, 4]], B = [1, 2], tile(A, B) = [[1, 2, 1, 2], [3, 4, 3, 4]]
+
+## Inputs (2 - 2)
+
+- **input** (T): Input tensor of any shape.
+- **repeats** (T1): 1D int64 tensor of the same length as input's dimension number, includes numbers of repeated copies along input's dimensions.
+
+## Outputs (1 - 1)
+
+- **output** (T): Output tensor of the same dimensions and type as tensor input. output_dim[i] = input_dim[i] * repeats[i]
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(bool), tensor(complex128), tensor(complex64), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(string), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)
+  Constrain input and output types to all tensor types.
+- **T1**: tensor(int64)
+  Constrain repeat's type to int64 tensors.

--- a/onnx-spec/ops/TopK.md
+++ b/onnx-spec/ops/TopK.md
@@ -1,0 +1,44 @@
+# TopK
+
+Since opset **24**
+
+## Description
+
+Retrieve the top-K largest or smallest elements along a specified axis. Given an input tensor of
+shape [a_0, a_1, ..., a_{n-1}] and integer argument k, return two outputs:
+
+* Value tensor of shape [a_0, a_1, ..., a_{axis-1}, k, a_{axis+1}, ... a_{n-1}]
+  which contains the values of the top k elements along the specified axis
+* Index tensor of shape [a_0, a_1, ..., a_{axis-1}, k, a_{axis+1}, ... a_{n-1}] which
+  contains the indices of the top k elements (original indices from the input
+  tensor).
+
+* If "largest" is 1 (the default value) then the k largest elements are returned.
+* If "sorted" is 1 (the default value) then the resulting k elements will be sorted.
+* If "sorted" is 0, order of returned 'Values' and 'Indices' are undefined.
+
+Given two equivalent values, this operator uses the indices along the axis as
+a tiebreaker. That is, the element with the lower index will appear first.
+
+## Attributes
+
+- **axis** (INT, optional): Dimension on which to do the sort. Negative value means counting dimensions from the back. Accepted range is [-r, r-1] where r = rank(input).
+- **largest** (INT, optional): Whether to return the top-K largest or smallest elements.
+- **sorted** (INT, optional): Whether to return the elements in sorted order.
+
+## Inputs (2 - 2)
+
+- **X** (T): Tensor of shape [a_0, a_1, ..., a_{n-1}]
+- **K** (tensor(int64)): A 1-D tensor containing a single positive value corresponding to the number of top elements to retrieve
+
+## Outputs (2 - 2)
+
+- **Values** (T): Tensor of shape [a_0, a_1, ..., a_{axis-1}, k, a_{axis+1}, ... a_{n-1}] containing top K values from the input tensor
+- **Indices** (I): Tensor of shape [a_0, a_1, ..., a_{axis-1}, k, a_{axis+1}, ... a_{n-1}] containing the corresponding input tensor indices for the top K values.
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)
+  Constrain input and output types to numeric tensors.
+- **I**: tensor(int64)
+  Constrain index tensor to int64

--- a/onnx-spec/ops/Transpose.md
+++ b/onnx-spec/ops/Transpose.md
@@ -1,0 +1,26 @@
+# Transpose
+
+Since opset **24**
+
+## Description
+
+Transpose the input tensor similar to numpy.transpose. For example, when
+perm=(1, 0, 2), given an input tensor of shape (1, 2, 3), the output shape
+will be (2, 1, 3).
+
+## Attributes
+
+- **perm** (INTS, optional): A list of integers. By default, reverse the dimensions, otherwise permute the axes according to the values given. Its length must be equal to the rank of the input.
+
+## Inputs (1 - 1)
+
+- **data** (T): An input tensor.
+
+## Outputs (1 - 1)
+
+- **transposed** (T): Transposed output.
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(bool), tensor(complex128), tensor(complex64), tensor(double), tensor(float), tensor(float16), tensor(float4e2m1), tensor(float8e4m3fn), tensor(float8e4m3fnuz), tensor(float8e5m2), tensor(float8e5m2fnuz), tensor(float8e8m0), tensor(int16), tensor(int32), tensor(int4), tensor(int64), tensor(int8), tensor(string), tensor(uint16), tensor(uint32), tensor(uint4), tensor(uint64), tensor(uint8)
+  Constrain input and output types to all tensor types.

--- a/onnx-spec/ops/Trilu.md
+++ b/onnx-spec/ops/Trilu.md
@@ -1,0 +1,36 @@
+# Trilu
+
+Since opset **14**
+
+## Description
+
+Given a 2-D matrix or batches of 2-D matrices, returns the upper or lower triangular part of the tensor(s).
+The attribute "upper" determines whether the upper or lower part is retained. If set to true,
+the upper triangular matrix is retained. Lower triangular matrix is retained otherwise.
+Default value for the "upper" attribute is true.
+Trilu takes one input tensor of shape [*, N, M], where * is zero or more batch dimensions. The upper triangular part consists
+of the elements on and above the given diagonal (k). The lower triangular part consists of elements on and below the diagonal.
+All other elements in the matrix are set to zero.
+If k = 0, the triangular part on and above/below the main diagonal is retained.
+If upper is set to true, a positive k retains the upper triangular matrix excluding the main diagonal and (k-1) diagonals above it.
+A negative k value retains the main diagonal and |k| diagonals below it.
+If upper is set to false, a positive k retains the lower triangular matrix including the main diagonal and k diagonals above it.
+A negative k value excludes the main diagonal and (|k|-1) diagonals below it.
+
+## Attributes
+
+- **upper** (INT, optional): Boolean. Indicates whether upper or lower part of matrix is retained. Default is true.
+
+## Inputs (1 - 2)
+
+- **input** (T): Input tensor of rank 2 or higher.
+- **k** (tensor(int64), optional): A 0-D tensor containing a single value corresponding to the number diagonals above or below the main diagonal to exclude or include. Default value is 0 if it's not specified.
+
+## Outputs (1 - 1)
+
+- **output** (T): Output tensor of the same type and shape as the input tensor.
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(bool), tensor(complex128), tensor(complex64), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(string), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)
+  Constrain input and output types to all tensor types.

--- a/onnx-spec/ops/Unique.md
+++ b/onnx-spec/ops/Unique.md
@@ -1,0 +1,124 @@
+# Unique
+
+Since opset **11**
+
+## Description
+
+Find the unique elements of a tensor. When an optional attribute 'axis' is provided, unique subtensors sliced along the 'axis' are returned.
+Otherwise the input tensor is flattened and unique values of the flattened tensor are returned.
+
+This operator returns the unique values or sliced unique subtensors of the input tensor and three optional outputs.
+The first output tensor 'Y' contains all unique values or subtensors of the input.
+The second optional output tensor 'indices' contains indices of 'Y' elements' first occurrence in 'X'.
+The third optional output tensor 'inverse_indices' contains, for elements of 'X', its corresponding indices in 'Y'.
+The fourth optional output tensor 'counts' contains the count of each element of 'Y' in the input.
+
+Outputs are either sorted in ascending order or optionally in the order of the first occurrence of the values in the input.
+
+https://docs.scipy.org/doc/numpy/reference/generated/numpy.unique.html
+
+Example 1:
+```
+input_X = [2, 1, 1, 3, 4, 3]
+attribute_sorted = 0
+attribute_axis = None
+output_Y = [2, 1, 3, 4]
+output_indices = [0, 1, 3, 4]
+output_inverse_indices = [0, 1, 1, 2, 3, 2]
+output_counts = [1, 2, 2, 1]
+```
+
+Example 2:
+```
+input_X = [[1, 3], [2, 3]]
+attribute_sorted = 1
+attribute_axis = None
+output_Y = [1, 2, 3]
+output_indices = [0, 2, 1]
+output_inverse_indices = [0, 2, 1, 2]
+output_counts = [1, 1, 2]
+```
+
+Example 3:
+```
+input_X = [[1, 0, 0], [1, 0, 0], [2, 3, 4]]
+attribute_sorted = 1
+attribute_axis = 0
+output_Y = [[1, 0, 0], [2, 3, 4]]
+output_indices = [0, 2]
+output_inverse_indices = [0, 0, 1]
+output_counts = [2, 1]
+```
+
+Example 4:
+```
+input_x = [[[1., 1.], [0., 1.], [2., 1.], [0., 1.]],
+            [[1., 1.], [0., 1.], [2., 1.], [0., 1.]]]
+attribute_sorted = 1
+attribute_axis = 1
+```
+
+intermediate data are presented below for better understanding:
+there are 4 subtensors sliced along axis 1 of input_x (shape = (2, 4, 2)):
+```
+A: [[1, 1], [1, 1]],
+   [[0, 1], [0, 1]],
+   [[2, 1], [2, 1]],
+   [[0, 1], [0, 1]].
+```
+
+there are 3 unique subtensors:
+```
+[[1, 1], [1, 1]],
+[[0, 1], [0, 1]],
+[[2, 1], [2, 1]].
+```
+
+sorted unique subtensors:
+```
+B: [[0, 1], [0, 1]],
+   [[1, 1], [1, 1]],
+   [[2, 1], [2, 1]].
+```
+
+output_Y is constructed from B:
+```
+[[[0. 1.], [1. 1.], [2. 1.]],
+ [[0. 1.], [1. 1.], [2. 1.]]]
+```
+
+output_indices is to map from B to A:
+```
+[1, 0, 2]
+```
+
+output_inverse_indices is to map from A to B:
+```
+[1, 0, 2, 0]
+```
+
+output_counts:
+```
+[2, 1, 1]
+```
+
+## Attributes
+
+- **axis** (INT, optional): (Optional) The dimension to apply unique. If not specified, the unique elements of the flattened input are returned. Negative value means counting dimensions from the back. Accepted range is [-r, r-1] where r = rank(input).
+- **sorted** (INT, optional): (Optional) Whether to sort the unique elements in ascending order before returning as output. Must be one of 0, or 1 (default).
+
+## Inputs (1 - 1)
+
+- **X** (T): A N-D input tensor that is to be processed.
+
+## Outputs (1 - 4)
+
+- **Y** (T): A tensor of the same type as 'X' containing all the unique values or subtensors sliced along a provided 'axis' in 'X', either sorted or maintained in the same order they occur in input 'X'
+- **indices** (tensor(int64), optional): A 1-D INT64 tensor containing indices of 'Y' elements' first occurrence in 'X'. When 'axis' is provided, it contains indices to subtensors in input 'X' on the 'axis'. When 'axis' is not provided, it contains indices to values in the flattened input tensor.
+- **inverse_indices** (tensor(int64), optional): A 1-D INT64 tensor containing, for elements of 'X', its corresponding indices in 'Y'. When 'axis' is provided, it contains indices to subtensors in output 'Y' on the 'axis'. When 'axis' is not provided, it contains indices to values in output 'Y'.
+- **counts** (tensor(int64), optional): A 1-D INT64 tensor containing the count of each element of 'Y' in input 'X'
+
+## Type Constraints
+
+- **T**: tensor(bool), tensor(complex128), tensor(complex64), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(string), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)
+  Input can be of any tensor type.

--- a/onnx-spec/ops/Unsqueeze.md
+++ b/onnx-spec/ops/Unsqueeze.md
@@ -1,0 +1,30 @@
+# Unsqueeze
+
+Since opset **24**
+
+## Description
+
+Insert single-dimensional entries to the shape of an input tensor (`data`).
+Takes one required input `axes` - which contains a list of dimension indices and this operator will insert a dimension of value `1` into the corresponding index of the output tensor (`expanded`).
+
+For example, given an input tensor (`data`) of shape [3, 4, 5], then
+Unsqueeze(data, axes=[0, 4]) outputs a tensor (`expanded`) containing same data as `data` but with shape [1, 3, 4, 5, 1].
+
+The input `axes` should not contain any duplicate entries. It is an error if it contains duplicates.
+The rank of the output tensor (`output_rank`) is the rank of the input tensor (`data`) plus the number of values in `axes`.
+Each value in `axes` should be within the (inclusive) range [-output_rank , output_rank - 1].
+The order of values in `axes` does not matter and can come in any order.
+
+## Inputs (2 - 2)
+
+- **data** (T): Original tensor
+- **axes** (tensor(int64)): 1D tensor of integers indicating the dimensions to be inserted. Negative value means counting dimensions from the back. Accepted range is [-r, r-1] where r = rank(expanded).
+
+## Outputs (1 - 1)
+
+- **expanded** (T): Reshaped tensor with same data as input.
+
+## Type Constraints
+
+- **T**: tensor(bfloat16), tensor(bool), tensor(complex128), tensor(complex64), tensor(double), tensor(float), tensor(float16), tensor(float4e2m1), tensor(float8e4m3fn), tensor(float8e4m3fnuz), tensor(float8e5m2), tensor(float8e5m2fnuz), tensor(float8e8m0), tensor(int16), tensor(int32), tensor(int4), tensor(int64), tensor(int8), tensor(string), tensor(uint16), tensor(uint32), tensor(uint4), tensor(uint64), tensor(uint8)
+  Constrain input and output types to all tensor types up to IRv12.

--- a/onnx-spec/ops/Upsample.md
+++ b/onnx-spec/ops/Upsample.md
@@ -1,0 +1,27 @@
+# Upsample
+
+Since opset **10**
+
+## Description
+
+Upsample the input tensor.
+Each dimension value of the output tensor is:
+  output_dimension = floor(input_dimension * scale).
+
+## Attributes
+
+- **mode** (STRING, optional): Two interpolation modes: nearest (default), and linear (including bilinear, trilinear, etc)
+
+## Inputs (2 - 2)
+
+- **X** (T): N-D tensor
+- **scales** (tensor(float)): The scale array along each dimension. It takes value greater than or equal to 1. The number of elements of 'scales' should be the same as the rank of input 'X'.
+
+## Outputs (1 - 1)
+
+- **Y** (T): N-D tensor after resizing
+
+## Type Constraints
+
+- **T**: tensor(bool), tensor(complex128), tensor(complex64), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(string), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)
+  Constrain input 'X' and output 'Y' to all tensor types.

--- a/onnx-spec/ops/Where.md
+++ b/onnx-spec/ops/Where.md
@@ -1,0 +1,29 @@
+# Where
+
+Since opset **16**
+
+## Description
+
+Return elements, either from X or Y, depending on condition.
+Where behaves like
+[numpy.where](https://docs.scipy.org/doc/numpy/reference/generated/numpy.where.html)
+with three parameters.
+
+This operator supports **multidirectional (i.e., Numpy-style) broadcasting**; for more details please check [the doc](Broadcasting.md).
+
+## Inputs (3 - 3)
+
+- **condition** (B): When True (nonzero), yield X, otherwise yield Y
+- **X** (T): values selected at indices where condition is True
+- **Y** (T): values selected at indices where condition is False
+
+## Outputs (1 - 1)
+
+- **output** (T): Tensor of shape equal to the broadcasted shape of condition, X, and Y.
+
+## Type Constraints
+
+- **B**: tensor(bool)
+  Constrain to boolean tensors.
+- **T**: tensor(bfloat16), tensor(bool), tensor(complex128), tensor(complex64), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(string), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)
+  Constrain input and output types to all tensor types (including bfloat).

--- a/onnx-spec/ops/Xor.md
+++ b/onnx-spec/ops/Xor.md
@@ -1,0 +1,26 @@
+# Xor
+
+Since opset **7**
+
+## Description
+
+Returns the tensor resulted from performing the `xor` logical operation
+elementwise on the input tensors `A` and `B` (with Numpy-style broadcasting support).
+
+This operator supports **multidirectional (i.e., Numpy-style) broadcasting**; for more details please check [the doc](Broadcasting.md).
+
+## Inputs (2 - 2)
+
+- **A** (T): First input operand for the logical operator.
+- **B** (T): Second input operand for the logical operator.
+
+## Outputs (1 - 1)
+
+- **C** (T1): Result tensor.
+
+## Type Constraints
+
+- **T**: tensor(bool)
+  Constrain input to boolean tensor.
+- **T1**: tensor(bool)
+  Constrain output to boolean tensor.


### PR DESCRIPTION
## Summary

- Add `onnx-spec/fetch-specs.py` uv script that fetches all 198 ONNX operator specs from the `onnx` Python package and writes per-operator markdown files to `onnx-spec/ops/`
- These serve as a reference for AI assistants and contributors when implementing or reviewing operators
- Update `.claude/CLAUDE.md` to reference the specs in project structure, coding conventions, and operator implementation checklist
- Update PR template with a checklist item to verify implementations against the spec

## Test plan

- [x] Run `./onnx-spec/fetch-specs.py` and verify 198 operator markdown files are generated
- [x] Spot-check generated files (e.g., `Conv.md`) for correct attributes, inputs, outputs, and type constraints