### PR TITLE
Add Mish activation op import

### DIFF
--- a/SUPPORTED-ONNX-OPS.md
+++ b/SUPPORTED-ONNX-OPS.md
@@ -119,7 +119,7 @@ functionality.
 | [MeanVarianceNormalization][102] | ❌             | ❌           |
 | [MelWeightMatrix][103]           | ❌             | ❌           |
 | [Min][104]                       | ✅             | ✅           |
-| [Mish][105]                      | ❌             | ✅           |
+| [Mish][105]                      | ✅             | ✅           |
 | [Mod][106]                       | ✅             | ✅           |
 | [Mul][107]                       | ✅             | ✅           |
 | [Multinomial][108]               | ❌             | ❌           |

--- a/crates/burn-onnx/src/burn/node/mish.rs
+++ b/crates/burn-onnx/src/burn/node/mish.rs
@@ -1,0 +1,43 @@
+use super::prelude::*;
+
+impl NodeCodegen for onnx_ir::node::mish::MishNode {
+    fn inputs(&self) -> &[Argument] {
+        &self.inputs
+    }
+
+    fn outputs(&self) -> &[Argument] {
+        &self.outputs
+    }
+
+    fn forward(&self, scope: &mut ScopeAtPosition<'_>) -> TokenStream {
+        let input = scope.arg(self.inputs.first().unwrap());
+        let output = arg_to_ident(self.outputs.first().unwrap());
+
+        quote! {
+            let #output = burn::tensor::activation::mish(#input);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::test_helpers::*;
+    use burn::tensor::DType;
+    use insta::assert_snapshot;
+    use onnx_ir::node::mish::MishNodeBuilder;
+
+    #[test]
+    fn test_mish_forward() {
+        let node = MishNodeBuilder::new("mish1")
+            .input_tensor("input", 2, DType::F32)
+            .output_tensor("output", 2, DType::F32)
+            .build();
+        let code = codegen_forward_default(&node);
+        assert_snapshot!(code, @r"
+        pub fn forward(&self, input: Tensor<B, 2>) -> Tensor<B, 2> {
+            let output = burn::tensor::activation::mish(input);
+            output
+        }
+        ");
+    }
+}

--- a/crates/burn-onnx/src/burn/node/mod.rs
+++ b/crates/burn-onnx/src/burn/node/mod.rs
@@ -91,6 +91,7 @@ pub(crate) mod max_pool1d;
 pub(crate) mod max_pool2d;
 pub(crate) mod mean;
 pub(crate) mod min;
+pub(crate) mod mish;
 pub(crate) mod modulo;
 pub(crate) mod mul;
 pub(crate) mod neg;

--- a/crates/burn-onnx/src/burn/node_codegen.rs
+++ b/crates/burn-onnx/src/burn/node_codegen.rs
@@ -111,6 +111,7 @@ impl_node_codegen_dispatch! {
     // Activation ops
     Relu,
     Gelu,
+    Mish,
     LeakyRelu,
     HardSigmoid,
     HardSwish,

--- a/crates/onnx-ir/src/ir/node.rs
+++ b/crates/onnx-ir/src/ir/node.rs
@@ -182,7 +182,7 @@ define_node_enum! {
     Selu => elementwise::ElementwiseUnaryNode,
     Celu => elementwise::ElementwiseUnaryNode,
     Gelu => gelu::GeluNode,
-    Mish => elementwise::ElementwiseUnaryNode,
+    Mish => mish::MishNode,
     Softplus => elementwise::ElementwiseUnaryNode,
     Softsign => elementwise::ElementwiseUnaryNode,
     ThresholdedRelu => elementwise::ElementwiseUnaryNode,

--- a/crates/onnx-ir/src/node/elementwise.rs
+++ b/crates/onnx-ir/src/node/elementwise.rs
@@ -70,7 +70,7 @@ pub struct ElementwiseUnaryNode {
 }
 
 /// Node processor for element-wise unary operations that don't yet have
-/// dedicated processors (Elu, Selu, Celu, Mish, Softplus, Softsign,
+/// dedicated processors (Elu, Selu, Celu, Softplus, Softsign,
 /// ThresholdedRelu). Will be removed as these ops get their own processors.
 #[allow(dead_code)]
 pub(crate) struct ElementwiseUnaryProcessor;
@@ -103,7 +103,6 @@ impl NodeProcessor for ElementwiseUnaryProcessor {
             crate::ir::NodeType::Elu => 6,
             crate::ir::NodeType::Selu => 6,
             crate::ir::NodeType::Celu => 12,
-            crate::ir::NodeType::Mish => 18,
             crate::ir::NodeType::Softplus => 1,
             crate::ir::NodeType::Softsign => 1,
             crate::ir::NodeType::ThresholdedRelu => 10,
@@ -136,7 +135,6 @@ impl NodeProcessor for ElementwiseUnaryProcessor {
             NodeType::Elu => Node::Elu(node),
             NodeType::Selu => Node::Selu(node),
             NodeType::Celu => Node::Celu(node),
-            NodeType::Mish => Node::Mish(node),
             NodeType::Softplus => Node::Softplus(node),
             NodeType::Softsign => Node::Softsign(node),
             NodeType::ThresholdedRelu => Node::ThresholdedRelu(node),

--- a/crates/onnx-ir/src/node/mish.rs
+++ b/crates/onnx-ir/src/node/mish.rs
@@ -1,0 +1,66 @@
+//! # Mish Activation
+//!
+//! Mish: A Self Regularized Non-Monotonic Neural Activation Function.
+//!
+//! `mish(x) = x * tanh(softplus(x)) = x * tanh(ln(1 + e^x))`
+//!
+//! **ONNX Spec**: <https://onnx.ai/onnx/operators/onnx__Mish.html>
+//!
+//! ## Type Constraints
+//!
+//! T: Float tensor types (float16, float, double, bfloat16)
+//!
+//! ## Opset Versions
+//! - **Opset 18**: Initial support
+//! - **Opset 22**: Added bfloat16
+
+use onnx_ir_derive::NodeBuilder;
+
+use crate::ir::{Argument, Node, RawNode};
+use crate::processor::{
+    InputSpec, NodeProcessor, NodeSpec, OutputPreferences, OutputSpec, ProcessError, same_as_input,
+    validate_opset,
+};
+
+/// Node representation for Mish operation
+#[derive(Debug, Clone, NodeBuilder)]
+pub struct MishNode {
+    pub name: String,
+    pub inputs: Vec<Argument>,
+    pub outputs: Vec<Argument>,
+}
+
+/// Node processor for Mish activation
+pub(crate) struct MishProcessor;
+
+impl NodeProcessor for MishProcessor {
+    type Config = ();
+
+    fn spec(&self) -> NodeSpec {
+        NodeSpec {
+            min_opset: 18,
+            max_opset: None,
+            inputs: InputSpec::Exact(1),
+            outputs: OutputSpec::Exact(1),
+        }
+    }
+
+    fn infer_types(
+        &self,
+        node: &mut RawNode,
+        opset: usize,
+        _output_preferences: &OutputPreferences,
+    ) -> Result<(), ProcessError> {
+        validate_opset(opset, 18)?;
+        same_as_input(node);
+        Ok(())
+    }
+
+    fn build_node(&self, builder: RawNode, _opset: usize) -> Node {
+        Node::Mish(MishNode {
+            name: builder.name,
+            inputs: builder.inputs,
+            outputs: builder.outputs,
+        })
+    }
+}

--- a/crates/onnx-ir/src/node/mod.rs
+++ b/crates/onnx-ir/src/node/mod.rs
@@ -100,6 +100,7 @@ pub mod max_pool1d;
 pub mod max_pool2d;
 pub mod mean;
 pub mod min;
+pub mod mish;
 pub mod modulo;
 pub mod nonzero;
 pub mod one_hot;

--- a/crates/onnx-ir/src/registry.rs
+++ b/crates/onnx-ir/src/registry.rs
@@ -192,6 +192,7 @@ impl ProcessorRegistry {
             Box::new(crate::node::sigmoid::SigmoidProcessor),
         );
         registry.register(NodeType::Gelu, Box::new(crate::node::gelu::GeluProcessor));
+        registry.register(NodeType::Mish, Box::new(crate::node::mish::MishProcessor));
 
         // Logical operations
         registry.register(NodeType::Not, Box::new(crate::node::not::NotProcessor));

--- a/crates/onnx-tests/build.rs
+++ b/crates/onnx-tests/build.rs
@@ -257,6 +257,7 @@ fn main() {
         .input("tests/maxpool/maxpool2d_asymmetric_padding.onnx")
         .input("tests/min/min.onnx")
         .input("tests/min/min_broadcast.onnx")
+        .input("tests/mish/mish.onnx")
         .input("tests/mean/mean.onnx")
         .input("tests/mul/mul.onnx")
         .input("tests/mul/mul_shape.onnx")

--- a/crates/onnx-tests/tests/mish/mish.onnx
+++ b/crates/onnx-tests/tests/mish/mish.onnx
@@ -1,0 +1,11 @@
+burn-onnx-test:J
+
+XYmish1"Mish	mish_testZ
+X
+
+
+b
+Y
+
+
+B

--- a/crates/onnx-tests/tests/mish/mish.py
+++ b/crates/onnx-tests/tests/mish/mish.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env -S uv run --script
+
+# /// script
+# dependencies = [
+#   "onnx==1.19.0",
+#   "numpy",
+# ]
+# ///
+
+# used to generate model: onnx-tests/tests/mish/mish.onnx
+
+import numpy as np
+import onnx
+from onnx import helper, TensorProto
+from onnx.reference import ReferenceEvaluator
+
+
+def main():
+    X = helper.make_tensor_value_info("X", TensorProto.FLOAT, [1, 4])
+    Y = helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1, 4])
+
+    mish_node = helper.make_node("Mish", inputs=["X"], outputs=["Y"], name="mish1")
+
+    graph_def = helper.make_graph([mish_node], "mish_test", [X], [Y])
+
+    model_def = helper.make_model(graph_def, producer_name="burn-onnx-test")
+    model_def.opset_import[0].version = 18
+
+    onnx.checker.check_model(model_def)
+
+    onnx_name = "mish.onnx"
+    onnx.save(model_def, onnx_name)
+    print(f"Finished exporting model to {onnx_name}")
+
+    test_input = np.array([[1.0, -1.0, 0.0, 5.0]], dtype=np.float32)
+    print(f"Test input data: {test_input}")
+
+    ref = ReferenceEvaluator(model_def)
+    output = ref.run(None, {"X": test_input})[0]
+    print(f"Test output data: {output}")
+    print(f"Output values for Rust test: {output.flatten().tolist()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/crates/onnx-tests/tests/mish/mod.rs
+++ b/crates/onnx-tests/tests/mish/mod.rs
@@ -1,0 +1,27 @@
+// Import the shared macro
+use crate::include_models;
+include_models!(mish);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use burn::tensor::{Tensor, TensorData, Tolerance, ops::FloatElem};
+
+    use crate::backend::TestBackend;
+    type FT = FloatElem<TestBackend>;
+
+    #[test]
+    fn mish() {
+        let device = Default::default();
+        let model: mish::Model<TestBackend> = mish::Model::new(&device);
+
+        let input = Tensor::<TestBackend, 2>::from_floats([[1.0, -1.0, 0.0, 5.0]], &device);
+
+        let output = model.forward(input);
+        let expected = TensorData::from([[0.8650984f32, -0.30340144, 0.0, 4.9995522]]);
+
+        output
+            .to_data()
+            .assert_approx_eq::<FT>(&expected, Tolerance::default());
+    }
+}

--- a/crates/onnx-tests/tests/test_mod.rs
+++ b/crates/onnx-tests/tests/test_mod.rs
@@ -87,6 +87,7 @@ pub mod max;
 pub mod maxpool;
 pub mod mean;
 pub mod min;
+pub mod mish;
 pub mod r#mod;
 pub mod mul;
 pub mod neg;


### PR DESCRIPTION
## Summary
- Add dedicated `MishNode`/`MishProcessor` in onnx-ir (opset 18), replacing the `ElementwiseUnaryNode` placeholder
- Implement `NodeCodegen` in burn-onnx mapping to `burn::tensor::activation::mish()`
- Add integration test with ONNX model and snapshot test

Closes #76

## Test plan
- [x] `cargo test -p onnx-ir` passes
- [x] `cargo test -p burn-onnx` passes (includes insta snapshot)
- [x] `cargo test -p onnx-tests` passes (integration test with reference values from ONNX ReferenceEvaluator)