### PR TITLE
Refactor onnx-ir config structs to remove Burn-derived fields

### DIFF
--- a/crates/burn-onnx/src/burn/node/avg_pool1d.rs
+++ b/crates/burn-onnx/src/burn/node/avg_pool1d.rs
@@ -16,7 +16,8 @@ impl NodeCodegen for onnx_ir::node::avg_pool1d::AveragePool1dNode {
         let count_include_pad = self.config.count_include_pad;
         let ceil_mode = self.config.ceil_mode;
 
-        let input_spatial = self.inputs[0].ty.static_shape().map(|s| &s[2..]);
+        let shape = self.inputs[0].ty.static_shape_known();
+        let input_spatial = shape.as_deref().map(|s| &s[2..]);
         let padding = crate::burn::codegen::resolve_auto_pad_1d(
             &self.config.auto_pad,
             &self.config.padding,
@@ -159,7 +160,15 @@ mod tests {
 
     #[test]
     fn test_avg_pool1d_field_init_auto_pad_same_upper() {
-        let config = AvgPool1dConfig::new(3, 1, PaddingConfig1d::Valid, false, 1, false, AutoPad::SameUpper);
+        let config = AvgPool1dConfig::new(
+            3,
+            1,
+            PaddingConfig1d::Valid,
+            false,
+            1,
+            false,
+            AutoPad::SameUpper,
+        );
         let node = AveragePool1dNodeBuilder::new("pool1")
             .input_tensor_shape("input", vec![1, 3, 7], DType::F32)
             .output_tensor("output", 3, DType::F32)

--- a/crates/burn-onnx/src/burn/node/avg_pool2d.rs
+++ b/crates/burn-onnx/src/burn/node/avg_pool2d.rs
@@ -16,7 +16,8 @@ impl NodeCodegen for onnx_ir::node::avg_pool2d::AveragePool2dNode {
         let count_include_pad = self.config.count_include_pad;
         let ceil_mode = self.config.ceil_mode;
 
-        let input_spatial = self.inputs[0].ty.static_shape().map(|s| &s[2..]);
+        let shape = self.inputs[0].ty.static_shape_known();
+        let input_spatial = shape.as_deref().map(|s| &s[2..]);
         let padding = crate::burn::codegen::resolve_auto_pad_2d(
             &self.config.auto_pad,
             &self.config.padding,
@@ -160,7 +161,13 @@ mod tests {
     #[test]
     fn test_avg_pool2d_field_init_auto_pad_same_upper() {
         let config = AvgPool2dConfig::new(
-            [3, 3], [1, 1], PaddingConfig2d::Valid, false, [1, 1], false, AutoPad::SameUpper,
+            [3, 3],
+            [1, 1],
+            PaddingConfig2d::Valid,
+            false,
+            [1, 1],
+            false,
+            AutoPad::SameUpper,
         );
         let node = AveragePool2dNodeBuilder::new("pool1")
             .input_tensor_shape("input", vec![1, 3, 7, 7], DType::F32)

--- a/crates/burn-onnx/src/burn/node/conv_transpose_2d.rs
+++ b/crates/burn-onnx/src/burn/node/conv_transpose_2d.rs
@@ -13,14 +13,19 @@ impl NodeCodegen for onnx_ir::node::conv_transpose2d::ConvTranspose2dNode {
 
     fn field(&self) -> Option<Field> {
         let name = Ident::new(&self.name, Span::call_site());
-        let channels = self.config.channels.to_tokens();
+        let weight_shape = self.inputs[1]
+            .ty
+            .static_shape_known()
+            .expect("ConvTranspose2d: weight tensor shape must be known at codegen time");
+        let groups = self.config.groups;
+        let channels = [weight_shape[0], weight_shape[1] * groups].to_tokens();
         let kernel_size = self.config.kernel_size.to_tokens();
         let stride = self.config.stride.to_tokens();
         let dilation = self.config.dilation.to_tokens();
-        let groups = self.config.groups.to_tokens();
+        let groups = groups.to_tokens();
         let padding = self.config.padding.to_tokens();
         let padding_out = self.config.padding_out.to_tokens();
-        let bias = self.config.bias;
+        let bias = self.inputs.len() == 3;
 
         Some(Field::new(
             self.name.clone(),
@@ -73,7 +78,7 @@ impl NodeCodegen for onnx_ir::node::conv_transpose2d::ConvTranspose2dNode {
         }
 
         // Bias tensor (input index 2, optional)
-        if self.config.bias
+        if self.inputs.len() > 2
             && let Some(bias_input) = self.inputs.get(2)
         {
             let bias_path = format!("{}.bias", field_name);
@@ -97,11 +102,12 @@ mod tests {
     };
 
     fn create_conv_transpose_2d_node(name: &str) -> ConvTranspose2dNode {
-        let config =
-            ConvTranspose2dConfig::new([3, 64], [3, 3], [1, 1], [1, 1], [1, 1], [0, 0], 1, true);
+        let config = ConvTranspose2dConfig::new([3, 3], [1, 1], [1, 1], [1, 1], [0, 0], 1);
 
         ConvTranspose2dNodeBuilder::new(name)
             .input_tensor("input", 4, DType::F32)
+            .input_static_tensor_shape("weight", vec![3, 64, 3, 3], DType::F32)
+            .input_static_tensor_shape("bias", vec![64], DType::F32)
             .output_tensor("output", 4, DType::F32)
             .config(config)
             .build()

--- a/crates/burn-onnx/src/burn/node/conv_transpose_3d.rs
+++ b/crates/burn-onnx/src/burn/node/conv_transpose_3d.rs
@@ -13,14 +13,19 @@ impl NodeCodegen for onnx_ir::node::conv_transpose3d::ConvTranspose3dNode {
 
     fn field(&self) -> Option<Field> {
         let name = Ident::new(&self.name, Span::call_site());
-        let channels = self.config.channels.to_tokens();
+        let weight_shape = self.inputs[1]
+            .ty
+            .static_shape_known()
+            .expect("ConvTranspose3d: weight tensor shape must be known at codegen time");
+        let groups = self.config.groups;
+        let channels = [weight_shape[0], weight_shape[1] * groups].to_tokens();
         let kernel_size = self.config.kernel_size.to_tokens();
         let stride = self.config.stride.to_tokens();
         let dilation = self.config.dilation.to_tokens();
-        let groups = self.config.groups.to_tokens();
+        let groups = groups.to_tokens();
         let padding = self.config.padding.to_tokens();
         let padding_out = self.config.padding_out.to_tokens();
-        let bias = self.config.bias;
+        let bias = self.inputs.len() == 3;
 
         Some(Field::new(
             self.name.clone(),
@@ -73,7 +78,7 @@ impl NodeCodegen for onnx_ir::node::conv_transpose3d::ConvTranspose3dNode {
         }
 
         // Bias tensor (input index 2, optional)
-        if self.config.bias
+        if self.inputs.len() > 2
             && let Some(bias_input) = self.inputs.get(2)
         {
             let bias_path = format!("{}.bias", field_name);
@@ -97,19 +102,13 @@ mod tests {
     };
 
     fn create_conv_transpose_3d_node(name: &str) -> ConvTranspose3dNode {
-        let config = ConvTranspose3dConfig::new(
-            [3, 64],
-            [3, 3, 3],
-            [1, 1, 1],
-            [1, 1, 1],
-            [1, 1, 1],
-            [0, 0, 0],
-            1,
-            true,
-        );
+        let config =
+            ConvTranspose3dConfig::new([3, 3, 3], [1, 1, 1], [1, 1, 1], [1, 1, 1], [0, 0, 0], 1);
 
         ConvTranspose3dNodeBuilder::new(name)
             .input_tensor("input", 5, DType::F32)
+            .input_static_tensor_shape("weight", vec![3, 64, 3, 3, 3], DType::F32)
+            .input_static_tensor_shape("bias", vec![64], DType::F32)
             .output_tensor("output", 5, DType::F32)
             .config(config)
             .build()

--- a/crates/burn-onnx/src/burn/node/max_pool1d.rs
+++ b/crates/burn-onnx/src/burn/node/max_pool1d.rs
@@ -16,7 +16,8 @@ impl NodeCodegen for onnx_ir::max_pool1d::MaxPool1dNode {
         let dilation = self.config.dilation.to_tokens();
         let ceil_mode = self.config.ceil_mode;
 
-        let input_spatial = self.inputs[0].ty.static_shape().map(|s| &s[2..]);
+        let shape = self.inputs[0].ty.static_shape_known();
+        let input_spatial = shape.as_deref().map(|s| &s[2..]);
         let padding = crate::burn::codegen::resolve_auto_pad_1d(
             &self.config.auto_pad,
             &self.config.padding,
@@ -164,7 +165,8 @@ mod tests {
 
     #[test]
     fn test_max_pool1d_field_init_auto_pad_same_upper() {
-        let config = MaxPool1dConfig::new(3, 1, 1, PaddingConfig1d::Valid, false, AutoPad::SameUpper);
+        let config =
+            MaxPool1dConfig::new(3, 1, 1, PaddingConfig1d::Valid, false, AutoPad::SameUpper);
         let node = MaxPool1dNodeBuilder::new("pool1")
             .input_tensor_shape("input", vec![1, 3, 7], DType::F32)
             .output_tensor("output", 3, DType::F32)

--- a/crates/burn-onnx/src/burn/node/max_pool2d.rs
+++ b/crates/burn-onnx/src/burn/node/max_pool2d.rs
@@ -16,7 +16,8 @@ impl NodeCodegen for onnx_ir::max_pool2d::MaxPool2dNode {
         let dilation = self.config.dilation.to_tokens();
         let ceil_mode = self.config.ceil_mode;
 
-        let input_spatial = self.inputs[0].ty.static_shape().map(|s| &s[2..]);
+        let shape = self.inputs[0].ty.static_shape_known();
+        let input_spatial = shape.as_deref().map(|s| &s[2..]);
         let padding = crate::burn::codegen::resolve_auto_pad_2d(
             &self.config.auto_pad,
             &self.config.padding,
@@ -171,7 +172,12 @@ mod tests {
     #[test]
     fn test_max_pool2d_field_init_auto_pad_same_upper() {
         let config = MaxPool2dConfig::new(
-            [3, 3], [1, 1], PaddingConfig2d::Valid, [1, 1], false, AutoPad::SameUpper,
+            [3, 3],
+            [1, 1],
+            PaddingConfig2d::Valid,
+            [1, 1],
+            false,
+            AutoPad::SameUpper,
         );
         let node = MaxPool2dNodeBuilder::new("pool1")
             .input_tensor_shape("input", vec![1, 3, 7, 7], DType::F32)

--- a/crates/burn-onnx/src/burn/node/test_helpers.rs
+++ b/crates/burn-onnx/src/burn/node/test_helpers.rs
@@ -44,6 +44,9 @@ where
     // Register all inputs as variables
     for input in node.inputs().iter() {
         // Skip non-dynamic inputs (constants, initializers)
+        if !(input.is_dynamic() || input.is_constant()) {
+            continue;
+        }
         if !matches!(
             input.ty,
             ArgType::Tensor(_) | ArgType::Scalar(_) | ArgType::Shape(_)
@@ -67,11 +70,12 @@ where
     let dynamic_inputs: Vec<_> = node
         .inputs()
         .iter()
+        .filter(|arg| arg.is_dynamic() || arg.is_constant())
         .filter(|arg| {
             matches!(
                 arg.ty,
                 ArgType::Tensor(_) | ArgType::Scalar(_) | ArgType::Shape(_)
-            ) && arg.value().is_none()
+            )
         })
         .cloned()
         .collect();

--- a/crates/onnx-ir-derive/src/lib.rs
+++ b/crates/onnx-ir-derive/src/lib.rs
@@ -154,6 +154,23 @@ pub fn node_builder_derive(input: TokenStream) -> TokenStream {
                 self
             }
 
+            /// Add a static tensor input with fully-known shape (not a forward parameter)
+            pub fn input_static_tensor_shape(
+                mut self,
+                name: &str,
+                shape: Vec<usize>,
+                dtype: burn_tensor::DType,
+            ) -> Self {
+                use crate::ir::{Argument, ArgType, TensorType, ValueSource};
+                let mut arg = Argument::new(
+                    name,
+                    ArgType::Tensor(TensorType::new_known(dtype, shape)),
+                );
+                arg.value_source = ValueSource::Static(0);
+                self.inputs.push(arg);
+                self
+            }
+
             /// Add a scalar input
             pub fn input_scalar(mut self, name: &str, dtype: burn_tensor::DType) -> Self {
                 use crate::ir::{Argument, ArgType};


### PR DESCRIPTION
## Summary

- Remove pre-computed fields from onnx-ir config structs (channels, dimensions, bias flags, num_features) that were derived from tensor shapes. These are now derived in burn-onnx codegen from input tensor shapes at code generation time.
- Affected operators: Conv1d/2d/3d, ConvTranspose1d/2d/3d, BatchNorm, LayerNorm, InstanceNorm, GroupNorm, Linear
- Fix `static_shape()` callers to use `static_shape_known()` after upstream API change

Closes #84

## Test plan

- [x] `cargo test -p onnx-ir` (547 tests pass)
- [x] `cargo test -p burn-onnx` (448 tests pass)
- [x] `cargo test -p onnx-tests` (417 integration tests pass)
- [x] `cargo xtask validate` passes (format, clippy, tests)