### PR TITLE
fix panic when converting fp16 model

### DIFF
--- a/crates/burn-onnx/src/burn/node_traits.rs
+++ b/crates/burn-onnx/src/burn/node_traits.rs
@@ -42,6 +42,7 @@ impl From<onnx_ir::ir::DType> for TensorKind {
         use onnx_ir::ir::DType;
 
         match dtype {
+            DType::F16 => TensorKind::Float,
             DType::F32 => TensorKind::Float,
             DType::F64 => TensorKind::Float,
             DType::I32 => TensorKind::Int,


### PR DESCRIPTION
Got `Unsupported tensor type` panic when tried to convert ISNet and RMBG-1.4 fp16 ONNX models.
After this fix they converted and worked.