### PR TITLE
fix: handle all DType variants in TensorKind conversion

### DIFF
--- a/crates/burn-onnx/src/burn/node_traits.rs
+++ b/crates/burn-onnx/src/burn/node_traits.rs
@@ -237,3 +237,38 @@ pub fn create_lazy_snapshot(
         ParamId::new(),
     ))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use onnx_ir::ir::DType;
+
+    #[test]
+    fn tensor_kind_from_dtype_float_types() {
+        assert_eq!(TensorKind::from(DType::F16), TensorKind::Float);
+        assert_eq!(TensorKind::from(DType::BF16), TensorKind::Float);
+        assert_eq!(TensorKind::from(DType::F32), TensorKind::Float);
+        assert_eq!(TensorKind::from(DType::F64), TensorKind::Float);
+    }
+
+    #[test]
+    fn tensor_kind_from_dtype_signed_int_types() {
+        assert_eq!(TensorKind::from(DType::I8), TensorKind::Int);
+        assert_eq!(TensorKind::from(DType::I16), TensorKind::Int);
+        assert_eq!(TensorKind::from(DType::I32), TensorKind::Int);
+        assert_eq!(TensorKind::from(DType::I64), TensorKind::Int);
+    }
+
+    #[test]
+    fn tensor_kind_from_dtype_unsigned_int_types() {
+        assert_eq!(TensorKind::from(DType::U8), TensorKind::Int);
+        assert_eq!(TensorKind::from(DType::U16), TensorKind::Int);
+        assert_eq!(TensorKind::from(DType::U32), TensorKind::Int);
+        assert_eq!(TensorKind::from(DType::U64), TensorKind::Int);
+    }
+
+    #[test]
+    fn tensor_kind_from_dtype_bool() {
+        assert_eq!(TensorKind::from(DType::Bool), TensorKind::Bool);
+    }
+}


### PR DESCRIPTION
## Summary

- Fix panic when converting FP16 ONNX models (e.g., ISNet, RMBG-1.4)
- Refactor to use `DType` helper methods (`is_float()`, `is_int()`, `is_uint()`, `is_bool()`) instead of explicit variant matching
- This handles all numeric types including BF16, Flex32, I16, U16, U32, U64 that were previously unhandled

## Test plan

- [x] Builds successfully
- [ ] Test with FP16 ONNX model

## Credits

Based on #92 by @gorynich2048 - thank you for identifying and initially fixing this issue!