### PR TITLE
fix: bump burn dep in model-checks and examples to match workspace

### DIFF
--- a/crates/model-checks/albert/Cargo.toml
+++ b/crates/model-checks/albert/Cargo.toml
@@ -7,8 +7,8 @@ publish = false
 [workspace]
 
 [workspace.dependencies]
-burn = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "44bbbe8c2cf10784fe3275f9a9c9933732b600e4" }
-burn-store = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "44bbbe8c2cf10784fe3275f9a9c9933732b600e4" }
+burn = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "bd991fe52c94faef0cb52dcc92816323a053ad1c" }
+burn-store = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "bd991fe52c94faef0cb52dcc92816323a053ad1c" }
 
 [features]
 default = ["tch"]

--- a/crates/model-checks/all-minilm-l6-v2/Cargo.toml
+++ b/crates/model-checks/all-minilm-l6-v2/Cargo.toml
@@ -7,8 +7,8 @@ publish = false
 [workspace]
 
 [workspace.dependencies]
-burn = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "44bbbe8c2cf10784fe3275f9a9c9933732b600e4" }
-burn-store = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "44bbbe8c2cf10784fe3275f9a9c9933732b600e4" }
+burn = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "bd991fe52c94faef0cb52dcc92816323a053ad1c" }
+burn-store = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "bd991fe52c94faef0cb52dcc92816323a053ad1c" }
 
 [features]
 default = ["tch"]

--- a/crates/model-checks/clip-vit-b-32-text/Cargo.toml
+++ b/crates/model-checks/clip-vit-b-32-text/Cargo.toml
@@ -7,8 +7,8 @@ publish = false
 [workspace]
 
 [workspace.dependencies]
-burn = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "44bbbe8c2cf10784fe3275f9a9c9933732b600e4" }
-burn-store = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "44bbbe8c2cf10784fe3275f9a9c9933732b600e4" }
+burn = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "bd991fe52c94faef0cb52dcc92816323a053ad1c" }
+burn-store = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "bd991fe52c94faef0cb52dcc92816323a053ad1c" }
 
 [features]
 default = ["tch"]

--- a/crates/model-checks/clip-vit-b-32-vision/Cargo.toml
+++ b/crates/model-checks/clip-vit-b-32-vision/Cargo.toml
@@ -7,8 +7,8 @@ publish = false
 [workspace]
 
 [workspace.dependencies]
-burn = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "44bbbe8c2cf10784fe3275f9a9c9933732b600e4" }
-burn-store = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "44bbbe8c2cf10784fe3275f9a9c9933732b600e4" }
+burn = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "bd991fe52c94faef0cb52dcc92816323a053ad1c" }
+burn-store = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "bd991fe52c94faef0cb52dcc92816323a053ad1c" }
 
 [features]
 default = ["tch"]

--- a/crates/model-checks/modernbert-base/Cargo.toml
+++ b/crates/model-checks/modernbert-base/Cargo.toml
@@ -7,8 +7,8 @@ publish = false
 [workspace]
 
 [workspace.dependencies]
-burn = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "44bbbe8c2cf10784fe3275f9a9c9933732b600e4" }
-burn-store = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "44bbbe8c2cf10784fe3275f9a9c9933732b600e4" }
+burn = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "bd991fe52c94faef0cb52dcc92816323a053ad1c" }
+burn-store = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "bd991fe52c94faef0cb52dcc92816323a053ad1c" }
 
 [features]
 default = ["tch"]

--- a/crates/model-checks/rf-detr/Cargo.toml
+++ b/crates/model-checks/rf-detr/Cargo.toml
@@ -7,8 +7,8 @@ publish = false
 [workspace]
 
 [workspace.dependencies]
-burn = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "44bbbe8c2cf10784fe3275f9a9c9933732b600e4" }
-burn-store = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "44bbbe8c2cf10784fe3275f9a9c9933732b600e4" }
+burn = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "bd991fe52c94faef0cb52dcc92816323a053ad1c" }
+burn-store = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "bd991fe52c94faef0cb52dcc92816323a053ad1c" }
 
 [features]
 default = ["ndarray"]

--- a/crates/model-checks/silero-vad/Cargo.toml
+++ b/crates/model-checks/silero-vad/Cargo.toml
@@ -7,8 +7,8 @@ publish = false
 [workspace]
 
 [workspace.dependencies]
-burn = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "44bbbe8c2cf10784fe3275f9a9c9933732b600e4" }
-burn-store = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "44bbbe8c2cf10784fe3275f9a9c9933732b600e4" }
+burn = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "bd991fe52c94faef0cb52dcc92816323a053ad1c" }
+burn-store = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "bd991fe52c94faef0cb52dcc92816323a053ad1c" }
 
 [features]
 default = ["ndarray"]

--- a/crates/model-checks/yolo/Cargo.toml
+++ b/crates/model-checks/yolo/Cargo.toml
@@ -7,8 +7,8 @@ publish = false
 [workspace]
 
 [workspace.dependencies]
-burn = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "44bbbe8c2cf10784fe3275f9a9c9933732b600e4" }
-burn-store = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "44bbbe8c2cf10784fe3275f9a9c9933732b600e4" }
+burn = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "bd991fe52c94faef0cb52dcc92816323a053ad1c" }
+burn-store = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "bd991fe52c94faef0cb52dcc92816323a053ad1c" }
 
 [features]
 default = ["tch"]

--- a/examples/raspberry-pi-pico/Cargo.lock
+++ b/examples/raspberry-pi-pico/Cargo.lock
@@ -260,7 +260,7 @@ checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 [[package]]
 name = "burn"
 version = "0.21.0"
-source = "git+https://github.com/tracel-ai/burn?rev=44bbbe8c2cf10784fe3275f9a9c9933732b600e4#44bbbe8c2cf10784fe3275f9a9c9933732b600e4"
+source = "git+https://github.com/tracel-ai/burn?rev=bd991fe52c94faef0cb52dcc92816323a053ad1c#bd991fe52c94faef0cb52dcc92816323a053ad1c"
 dependencies = [
  "burn-autodiff",
  "burn-candle",
@@ -279,7 +279,7 @@ dependencies = [
 [[package]]
 name = "burn-autodiff"
 version = "0.21.0"
-source = "git+https://github.com/tracel-ai/burn?rev=44bbbe8c2cf10784fe3275f9a9c9933732b600e4#44bbbe8c2cf10784fe3275f9a9c9933732b600e4"
+source = "git+https://github.com/tracel-ai/burn?rev=bd991fe52c94faef0cb52dcc92816323a053ad1c#bd991fe52c94faef0cb52dcc92816323a053ad1c"
 dependencies = [
  "burn-backend",
  "burn-std",
@@ -295,7 +295,7 @@ dependencies = [
 [[package]]
 name = "burn-backend"
 version = "0.21.0"
-source = "git+https://github.com/tracel-ai/burn?rev=44bbbe8c2cf10784fe3275f9a9c9933732b600e4#44bbbe8c2cf10784fe3275f9a9c9933732b600e4"
+source = "git+https://github.com/tracel-ai/burn?rev=bd991fe52c94faef0cb52dcc92816323a053ad1c#bd991fe52c94faef0cb52dcc92816323a053ad1c"
 dependencies = [
  "burn-std",
  "bytemuck",
@@ -312,7 +312,7 @@ dependencies = [
 [[package]]
 name = "burn-candle"
 version = "0.21.0"
-source = "git+https://github.com/tracel-ai/burn?rev=44bbbe8c2cf10784fe3275f9a9c9933732b600e4#44bbbe8c2cf10784fe3275f9a9c9933732b600e4"
+source = "git+https://github.com/tracel-ai/burn?rev=bd991fe52c94faef0cb52dcc92816323a053ad1c#bd991fe52c94faef0cb52dcc92816323a053ad1c"
 dependencies = [
  "burn-backend",
  "burn-std",
@@ -323,7 +323,7 @@ dependencies = [
 [[package]]
 name = "burn-core"
 version = "0.21.0"
-source = "git+https://github.com/tracel-ai/burn?rev=44bbbe8c2cf10784fe3275f9a9c9933732b600e4#44bbbe8c2cf10784fe3275f9a9c9933732b600e4"
+source = "git+https://github.com/tracel-ai/burn?rev=bd991fe52c94faef0cb52dcc92816323a053ad1c#bd991fe52c94faef0cb52dcc92816323a053ad1c"
 dependencies = [
  "ahash",
  "bincode",
@@ -351,7 +351,7 @@ dependencies = [
 [[package]]
 name = "burn-cpu"
 version = "0.21.0"
-source = "git+https://github.com/tracel-ai/burn?rev=44bbbe8c2cf10784fe3275f9a9c9933732b600e4#44bbbe8c2cf10784fe3275f9a9c9933732b600e4"
+source = "git+https://github.com/tracel-ai/burn?rev=bd991fe52c94faef0cb52dcc92816323a053ad1c#bd991fe52c94faef0cb52dcc92816323a053ad1c"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -361,7 +361,7 @@ dependencies = [
 [[package]]
 name = "burn-cubecl"
 version = "0.21.0"
-source = "git+https://github.com/tracel-ai/burn?rev=44bbbe8c2cf10784fe3275f9a9c9933732b600e4#44bbbe8c2cf10784fe3275f9a9c9933732b600e4"
+source = "git+https://github.com/tracel-ai/burn?rev=bd991fe52c94faef0cb52dcc92816323a053ad1c#bd991fe52c94faef0cb52dcc92816323a053ad1c"
 dependencies = [
  "burn-backend",
  "burn-cubecl-fusion",
@@ -380,7 +380,7 @@ dependencies = [
 [[package]]
 name = "burn-cubecl-fusion"
 version = "0.21.0"
-source = "git+https://github.com/tracel-ai/burn?rev=44bbbe8c2cf10784fe3275f9a9c9933732b600e4#44bbbe8c2cf10784fe3275f9a9c9933732b600e4"
+source = "git+https://github.com/tracel-ai/burn?rev=bd991fe52c94faef0cb52dcc92816323a053ad1c#bd991fe52c94faef0cb52dcc92816323a053ad1c"
 dependencies = [
  "burn-backend",
  "burn-fusion",
@@ -395,7 +395,7 @@ dependencies = [
 [[package]]
 name = "burn-cuda"
 version = "0.21.0"
-source = "git+https://github.com/tracel-ai/burn?rev=44bbbe8c2cf10784fe3275f9a9c9933732b600e4#44bbbe8c2cf10784fe3275f9a9c9933732b600e4"
+source = "git+https://github.com/tracel-ai/burn?rev=bd991fe52c94faef0cb52dcc92816323a053ad1c#bd991fe52c94faef0cb52dcc92816323a053ad1c"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -405,7 +405,7 @@ dependencies = [
 [[package]]
 name = "burn-derive"
 version = "0.21.0"
-source = "git+https://github.com/tracel-ai/burn?rev=44bbbe8c2cf10784fe3275f9a9c9933732b600e4#44bbbe8c2cf10784fe3275f9a9c9933732b600e4"
+source = "git+https://github.com/tracel-ai/burn?rev=bd991fe52c94faef0cb52dcc92816323a053ad1c#bd991fe52c94faef0cb52dcc92816323a053ad1c"
 dependencies = [
  "derive-new",
  "proc-macro2",
@@ -416,7 +416,7 @@ dependencies = [
 [[package]]
 name = "burn-fusion"
 version = "0.21.0"
-source = "git+https://github.com/tracel-ai/burn?rev=44bbbe8c2cf10784fe3275f9a9c9933732b600e4#44bbbe8c2cf10784fe3275f9a9c9933732b600e4"
+source = "git+https://github.com/tracel-ai/burn?rev=bd991fe52c94faef0cb52dcc92816323a053ad1c#bd991fe52c94faef0cb52dcc92816323a053ad1c"
 dependencies = [
  "burn-backend",
  "burn-ir",
@@ -431,7 +431,7 @@ dependencies = [
 [[package]]
 name = "burn-ir"
 version = "0.21.0"
-source = "git+https://github.com/tracel-ai/burn?rev=44bbbe8c2cf10784fe3275f9a9c9933732b600e4#44bbbe8c2cf10784fe3275f9a9c9933732b600e4"
+source = "git+https://github.com/tracel-ai/burn?rev=bd991fe52c94faef0cb52dcc92816323a053ad1c#bd991fe52c94faef0cb52dcc92816323a053ad1c"
 dependencies = [
  "burn-backend",
  "hashbrown 0.16.1",
@@ -441,7 +441,7 @@ dependencies = [
 [[package]]
 name = "burn-ndarray"
 version = "0.21.0"
-source = "git+https://github.com/tracel-ai/burn?rev=44bbbe8c2cf10784fe3275f9a9c9933732b600e4#44bbbe8c2cf10784fe3275f9a9c9933732b600e4"
+source = "git+https://github.com/tracel-ai/burn?rev=bd991fe52c94faef0cb52dcc92816323a053ad1c#bd991fe52c94faef0cb52dcc92816323a053ad1c"
 dependencies = [
  "atomic_float",
  "burn-autodiff",
@@ -463,7 +463,7 @@ dependencies = [
 [[package]]
 name = "burn-nn"
 version = "0.21.0"
-source = "git+https://github.com/tracel-ai/burn?rev=44bbbe8c2cf10784fe3275f9a9c9933732b600e4#44bbbe8c2cf10784fe3275f9a9c9933732b600e4"
+source = "git+https://github.com/tracel-ai/burn?rev=bd991fe52c94faef0cb52dcc92816323a053ad1c#bd991fe52c94faef0cb52dcc92816323a053ad1c"
 dependencies = [
  "burn-core",
  "num-traits",
@@ -490,7 +490,7 @@ dependencies = [
 [[package]]
 name = "burn-optim"
 version = "0.21.0"
-source = "git+https://github.com/tracel-ai/burn?rev=44bbbe8c2cf10784fe3275f9a9c9933732b600e4#44bbbe8c2cf10784fe3275f9a9c9933732b600e4"
+source = "git+https://github.com/tracel-ai/burn?rev=bd991fe52c94faef0cb52dcc92816323a053ad1c#bd991fe52c94faef0cb52dcc92816323a053ad1c"
 dependencies = [
  "burn-core",
  "derive-new",
@@ -503,7 +503,7 @@ dependencies = [
 [[package]]
 name = "burn-rocm"
 version = "0.21.0"
-source = "git+https://github.com/tracel-ai/burn?rev=44bbbe8c2cf10784fe3275f9a9c9933732b600e4#44bbbe8c2cf10784fe3275f9a9c9933732b600e4"
+source = "git+https://github.com/tracel-ai/burn?rev=bd991fe52c94faef0cb52dcc92816323a053ad1c#bd991fe52c94faef0cb52dcc92816323a053ad1c"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -513,7 +513,7 @@ dependencies = [
 [[package]]
 name = "burn-router"
 version = "0.21.0"
-source = "git+https://github.com/tracel-ai/burn?rev=44bbbe8c2cf10784fe3275f9a9c9933732b600e4#44bbbe8c2cf10784fe3275f9a9c9933732b600e4"
+source = "git+https://github.com/tracel-ai/burn?rev=bd991fe52c94faef0cb52dcc92816323a053ad1c#bd991fe52c94faef0cb52dcc92816323a053ad1c"
 dependencies = [
  "burn-backend",
  "burn-ir",
@@ -526,7 +526,7 @@ dependencies = [
 [[package]]
 name = "burn-std"
 version = "0.21.0"
-source = "git+https://github.com/tracel-ai/burn?rev=44bbbe8c2cf10784fe3275f9a9c9933732b600e4#44bbbe8c2cf10784fe3275f9a9c9933732b600e4"
+source = "git+https://github.com/tracel-ai/burn?rev=bd991fe52c94faef0cb52dcc92816323a053ad1c#bd991fe52c94faef0cb52dcc92816323a053ad1c"
 dependencies = [
  "bytemuck",
  "bytes",
@@ -540,7 +540,7 @@ dependencies = [
 [[package]]
 name = "burn-store"
 version = "0.21.0"
-source = "git+https://github.com/tracel-ai/burn?rev=44bbbe8c2cf10784fe3275f9a9c9933732b600e4#44bbbe8c2cf10784fe3275f9a9c9933732b600e4"
+source = "git+https://github.com/tracel-ai/burn?rev=bd991fe52c94faef0cb52dcc92816323a053ad1c#bd991fe52c94faef0cb52dcc92816323a053ad1c"
 dependencies = [
  "burn-core",
  "burn-nn",
@@ -560,7 +560,7 @@ dependencies = [
 [[package]]
 name = "burn-tensor"
 version = "0.21.0"
-source = "git+https://github.com/tracel-ai/burn?rev=44bbbe8c2cf10784fe3275f9a9c9933732b600e4#44bbbe8c2cf10784fe3275f9a9c9933732b600e4"
+source = "git+https://github.com/tracel-ai/burn?rev=bd991fe52c94faef0cb52dcc92816323a053ad1c#bd991fe52c94faef0cb52dcc92816323a053ad1c"
 dependencies = [
  "burn-backend",
  "burn-std",
@@ -573,7 +573,7 @@ dependencies = [
 [[package]]
 name = "burn-wgpu"
 version = "0.21.0"
-source = "git+https://github.com/tracel-ai/burn?rev=44bbbe8c2cf10784fe3275f9a9c9933732b600e4#44bbbe8c2cf10784fe3275f9a9c9933732b600e4"
+source = "git+https://github.com/tracel-ai/burn?rev=bd991fe52c94faef0cb52dcc92816323a053ad1c#bd991fe52c94faef0cb52dcc92816323a053ad1c"
 dependencies = [
  "burn-backend",
  "burn-cubecl",

--- a/examples/raspberry-pi-pico/Cargo.toml
+++ b/examples/raspberry-pi-pico/Cargo.toml
@@ -29,8 +29,8 @@ panic-probe = { version = "1.0.0", features = ["print-defmt"] }
 portable-atomic = { version = "1.7", features = ["critical-section"] }
 embedded-alloc = "0.6.0"
 
-burn = { git = "https://github.com/tracel-ai/burn", rev = "44bbbe8c2cf10784fe3275f9a9c9933732b600e4", default-features = false, features = ["ndarray"] }
-burn-store = { git = "https://github.com/tracel-ai/burn", rev = "44bbbe8c2cf10784fe3275f9a9c9933732b600e4", default-features = false, features = ["burnpack"] }
+burn = { git = "https://github.com/tracel-ai/burn", rev = "bd991fe52c94faef0cb52dcc92816323a053ad1c", default-features = false, features = ["ndarray"] }
+burn-store = { git = "https://github.com/tracel-ai/burn", rev = "bd991fe52c94faef0cb52dcc92816323a053ad1c", default-features = false, features = ["burnpack"] }
 
 [build-dependencies]
 burn-onnx = { path = "../../crates/burn-onnx" }


### PR DESCRIPTION
## Summary
- Bump burn dependency in all model-checks crates and the raspberry-pi-pico example from `44bbbe8c` to `bd991fe52c94` (matching the main workspace)
- The old revision predates the asymmetric padding API change (burn#4263), causing codegen output to fail compilation against the outdated burn types

## Test plan
- [x] `cargo test -p burn-onnx -p onnx-ir -p onnx-tests` passes
- [ ] Verify `cargo build` in `crates/model-checks/rf-detr` succeeds
- [ ] Verify `cargo build` in `crates/model-checks/silero-vad` succeeds

Fixes #137