### PR TITLE
Link CONTRIBUTING.md from README and development guide

### DIFF
--- a/DEVELOPMENT-GUIDE.md
+++ b/DEVELOPMENT-GUIDE.md
@@ -6,7 +6,8 @@ learning framework written in Rust. It converts ONNX models to Rust source code 
 `.bpk` files.
 
 For an introduction to ONNX import in Burn, see
-[this section of the Burn book](https://burn.dev/books/burn/import/onnx-model.html).
+[this section of the Burn book](https://burn.dev/books/burn/import/onnx-model.html). Before opening a
+PR, please read the [Contributing Guidelines](CONTRIBUTING.md).
 
 ## Design Overview
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,8 @@ operators.
 
 ## Contributing
 
-We welcome contributions! Please read the [Development Guide](DEVELOPMENT-GUIDE.md) to get started.
+We welcome contributions! Please read the [Contributing Guidelines](CONTRIBUTING.md) before opening
+a PR, and the [Development Guide](DEVELOPMENT-GUIDE.md) for architecture and implementation details.
 
 For questions and discussions, join us on [Discord](https://discord.gg/uPEBbYYDB6).
 


### PR DESCRIPTION
## Summary

- README: Contributing section now links to CONTRIBUTING.md first, then DEVELOPMENT-GUIDE.md
- DEVELOPMENT-GUIDE: Added a one-line pointer to CONTRIBUTING.md at the top

Follow-up to #212.

## Test plan

- [x] Verify both markdown links resolve correctly