### PR TITLE
fix(ci): disable persist-credentials in bump-burn workflow

### DIFF
--- a/.github/workflows/bump-burn.yml
+++ b/.github/workflows/bump-burn.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Get latest burn commit
         id: latest


### PR DESCRIPTION
## Summary

- Fixes the bump-burn CI workflow failing with `fatal: could not read Username for 'https://github.com'` ([failed run](https://github.com/tracel-ai/burn-onnx/actions/runs/22339330293/job/64735050315))
- Adds `persist-credentials: false` to the checkout step so `peter-evans/create-pull-request` can fully manage authentication with its `GH_BOT_TOKEN`

## Test plan

- [ ] Re-run the bump-burn workflow manually via `workflow_dispatch` after merging