### PR TITLE
fix(ci): pass GH_BOT_TOKEN to checkout step in bump-burn workflow

### DIFF
--- a/.github/workflows/bump-burn.yml
+++ b/.github/workflows/bump-burn.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          persist-credentials: false
+          token: ${{ secrets.GH_BOT_TOKEN }}
 
       - name: Get latest burn commit
         id: latest


### PR DESCRIPTION
## Summary

- Follow-up to #220 which only added `persist-credentials: false` but didn't fix the push failure
- Passes `GH_BOT_TOKEN` directly to the checkout step so the remote URL is configured with valid credentials that `peter-evans/create-pull-request` inherits for push operations

## Test plan

- [ ] Merge and trigger the bump-burn workflow manually via `workflow_dispatch`