### PR TITLE
Bump burn rev to 421535d9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -473,7 +473,7 @@ checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 [[package]]
 name = "burn"
 version = "0.21.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=5923b1e7587e4c76a5d35035147e775ec4002919#5923b1e7587e4c76a5d35035147e775ec4002919"
+source = "git+https://github.com/tracel-ai/burn?rev=421535d9662a7ab4d63078a2ef85831973c3c20c#421535d9662a7ab4d63078a2ef85831973c3c20c"
 dependencies = [
  "burn-autodiff",
  "burn-candle",
@@ -494,7 +494,7 @@ dependencies = [
 [[package]]
 name = "burn-autodiff"
 version = "0.21.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=5923b1e7587e4c76a5d35035147e775ec4002919#5923b1e7587e4c76a5d35035147e775ec4002919"
+source = "git+https://github.com/tracel-ai/burn?rev=421535d9662a7ab4d63078a2ef85831973c3c20c#421535d9662a7ab4d63078a2ef85831973c3c20c"
 dependencies = [
  "burn-backend",
  "burn-std",
@@ -510,7 +510,7 @@ dependencies = [
 [[package]]
 name = "burn-backend"
 version = "0.21.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=5923b1e7587e4c76a5d35035147e775ec4002919#5923b1e7587e4c76a5d35035147e775ec4002919"
+source = "git+https://github.com/tracel-ai/burn?rev=421535d9662a7ab4d63078a2ef85831973c3c20c#421535d9662a7ab4d63078a2ef85831973c3c20c"
 dependencies = [
  "burn-std",
  "bytemuck",
@@ -528,7 +528,7 @@ dependencies = [
 [[package]]
 name = "burn-candle"
 version = "0.21.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=5923b1e7587e4c76a5d35035147e775ec4002919#5923b1e7587e4c76a5d35035147e775ec4002919"
+source = "git+https://github.com/tracel-ai/burn?rev=421535d9662a7ab4d63078a2ef85831973c3c20c#421535d9662a7ab4d63078a2ef85831973c3c20c"
 dependencies = [
  "burn-backend",
  "burn-std",
@@ -539,7 +539,7 @@ dependencies = [
 [[package]]
 name = "burn-core"
 version = "0.21.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=5923b1e7587e4c76a5d35035147e775ec4002919#5923b1e7587e4c76a5d35035147e775ec4002919"
+source = "git+https://github.com/tracel-ai/burn?rev=421535d9662a7ab4d63078a2ef85831973c3c20c#421535d9662a7ab4d63078a2ef85831973c3c20c"
 dependencies = [
  "ahash",
  "bincode",
@@ -570,7 +570,7 @@ dependencies = [
 [[package]]
 name = "burn-cpu"
 version = "0.21.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=5923b1e7587e4c76a5d35035147e775ec4002919#5923b1e7587e4c76a5d35035147e775ec4002919"
+source = "git+https://github.com/tracel-ai/burn?rev=421535d9662a7ab4d63078a2ef85831973c3c20c#421535d9662a7ab4d63078a2ef85831973c3c20c"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -581,7 +581,7 @@ dependencies = [
 [[package]]
 name = "burn-cubecl"
 version = "0.21.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=5923b1e7587e4c76a5d35035147e775ec4002919#5923b1e7587e4c76a5d35035147e775ec4002919"
+source = "git+https://github.com/tracel-ai/burn?rev=421535d9662a7ab4d63078a2ef85831973c3c20c#421535d9662a7ab4d63078a2ef85831973c3c20c"
 dependencies = [
  "burn-backend",
  "burn-cubecl-fusion",
@@ -600,7 +600,7 @@ dependencies = [
 [[package]]
 name = "burn-cubecl-fusion"
 version = "0.21.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=5923b1e7587e4c76a5d35035147e775ec4002919#5923b1e7587e4c76a5d35035147e775ec4002919"
+source = "git+https://github.com/tracel-ai/burn?rev=421535d9662a7ab4d63078a2ef85831973c3c20c#421535d9662a7ab4d63078a2ef85831973c3c20c"
 dependencies = [
  "burn-backend",
  "burn-fusion",
@@ -615,7 +615,7 @@ dependencies = [
 [[package]]
 name = "burn-cuda"
 version = "0.21.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=5923b1e7587e4c76a5d35035147e775ec4002919#5923b1e7587e4c76a5d35035147e775ec4002919"
+source = "git+https://github.com/tracel-ai/burn?rev=421535d9662a7ab4d63078a2ef85831973c3c20c#421535d9662a7ab4d63078a2ef85831973c3c20c"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -626,7 +626,7 @@ dependencies = [
 [[package]]
 name = "burn-dataset"
 version = "0.21.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=5923b1e7587e4c76a5d35035147e775ec4002919#5923b1e7587e4c76a5d35035147e775ec4002919"
+source = "git+https://github.com/tracel-ai/burn?rev=421535d9662a7ab4d63078a2ef85831973c3c20c#421535d9662a7ab4d63078a2ef85831973c3c20c"
 dependencies = [
  "burn-std",
  "csv",
@@ -648,7 +648,7 @@ dependencies = [
 [[package]]
 name = "burn-derive"
 version = "0.21.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=5923b1e7587e4c76a5d35035147e775ec4002919#5923b1e7587e4c76a5d35035147e775ec4002919"
+source = "git+https://github.com/tracel-ai/burn?rev=421535d9662a7ab4d63078a2ef85831973c3c20c#421535d9662a7ab4d63078a2ef85831973c3c20c"
 dependencies = [
  "derive-new",
  "proc-macro2",
@@ -659,7 +659,7 @@ dependencies = [
 [[package]]
 name = "burn-fusion"
 version = "0.21.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=5923b1e7587e4c76a5d35035147e775ec4002919#5923b1e7587e4c76a5d35035147e775ec4002919"
+source = "git+https://github.com/tracel-ai/burn?rev=421535d9662a7ab4d63078a2ef85831973c3c20c#421535d9662a7ab4d63078a2ef85831973c3c20c"
 dependencies = [
  "burn-backend",
  "burn-ir",
@@ -681,7 +681,7 @@ dependencies = [
 [[package]]
 name = "burn-ir"
 version = "0.21.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=5923b1e7587e4c76a5d35035147e775ec4002919#5923b1e7587e4c76a5d35035147e775ec4002919"
+source = "git+https://github.com/tracel-ai/burn?rev=421535d9662a7ab4d63078a2ef85831973c3c20c#421535d9662a7ab4d63078a2ef85831973c3c20c"
 dependencies = [
  "burn-backend",
  "hashbrown 0.16.1",
@@ -691,7 +691,7 @@ dependencies = [
 [[package]]
 name = "burn-ndarray"
 version = "0.21.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=5923b1e7587e4c76a5d35035147e775ec4002919#5923b1e7587e4c76a5d35035147e775ec4002919"
+source = "git+https://github.com/tracel-ai/burn?rev=421535d9662a7ab4d63078a2ef85831973c3c20c#421535d9662a7ab4d63078a2ef85831973c3c20c"
 dependencies = [
  "atomic_float",
  "burn-autodiff",
@@ -713,7 +713,7 @@ dependencies = [
 [[package]]
 name = "burn-nn"
 version = "0.21.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=5923b1e7587e4c76a5d35035147e775ec4002919#5923b1e7587e4c76a5d35035147e775ec4002919"
+source = "git+https://github.com/tracel-ai/burn?rev=421535d9662a7ab4d63078a2ef85831973c3c20c#421535d9662a7ab4d63078a2ef85831973c3c20c"
 dependencies = [
  "burn-core",
  "num-traits",
@@ -863,7 +863,7 @@ dependencies = [
 [[package]]
 name = "burn-optim"
 version = "0.21.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=5923b1e7587e4c76a5d35035147e775ec4002919#5923b1e7587e4c76a5d35035147e775ec4002919"
+source = "git+https://github.com/tracel-ai/burn?rev=421535d9662a7ab4d63078a2ef85831973c3c20c#421535d9662a7ab4d63078a2ef85831973c3c20c"
 dependencies = [
  "burn-core",
  "derive-new",
@@ -876,7 +876,7 @@ dependencies = [
 [[package]]
 name = "burn-rocm"
 version = "0.21.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=5923b1e7587e4c76a5d35035147e775ec4002919#5923b1e7587e4c76a5d35035147e775ec4002919"
+source = "git+https://github.com/tracel-ai/burn?rev=421535d9662a7ab4d63078a2ef85831973c3c20c#421535d9662a7ab4d63078a2ef85831973c3c20c"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -887,7 +887,7 @@ dependencies = [
 [[package]]
 name = "burn-router"
 version = "0.21.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=5923b1e7587e4c76a5d35035147e775ec4002919#5923b1e7587e4c76a5d35035147e775ec4002919"
+source = "git+https://github.com/tracel-ai/burn?rev=421535d9662a7ab4d63078a2ef85831973c3c20c#421535d9662a7ab4d63078a2ef85831973c3c20c"
 dependencies = [
  "burn-backend",
  "burn-ir",
@@ -900,7 +900,7 @@ dependencies = [
 [[package]]
 name = "burn-std"
 version = "0.21.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=5923b1e7587e4c76a5d35035147e775ec4002919#5923b1e7587e4c76a5d35035147e775ec4002919"
+source = "git+https://github.com/tracel-ai/burn?rev=421535d9662a7ab4d63078a2ef85831973c3c20c#421535d9662a7ab4d63078a2ef85831973c3c20c"
 dependencies = [
  "bytemuck",
  "bytes",
@@ -919,7 +919,7 @@ dependencies = [
 [[package]]
 name = "burn-store"
 version = "0.21.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=5923b1e7587e4c76a5d35035147e775ec4002919#5923b1e7587e4c76a5d35035147e775ec4002919"
+source = "git+https://github.com/tracel-ai/burn?rev=421535d9662a7ab4d63078a2ef85831973c3c20c#421535d9662a7ab4d63078a2ef85831973c3c20c"
 dependencies = [
  "burn-core",
  "burn-nn",
@@ -940,7 +940,7 @@ dependencies = [
 [[package]]
 name = "burn-tch"
 version = "0.21.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=5923b1e7587e4c76a5d35035147e775ec4002919#5923b1e7587e4c76a5d35035147e775ec4002919"
+source = "git+https://github.com/tracel-ai/burn?rev=421535d9662a7ab4d63078a2ef85831973c3c20c#421535d9662a7ab4d63078a2ef85831973c3c20c"
 dependencies = [
  "burn-backend",
  "cc",
@@ -953,7 +953,7 @@ dependencies = [
 [[package]]
 name = "burn-tensor"
 version = "0.21.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=5923b1e7587e4c76a5d35035147e775ec4002919#5923b1e7587e4c76a5d35035147e775ec4002919"
+source = "git+https://github.com/tracel-ai/burn?rev=421535d9662a7ab4d63078a2ef85831973c3c20c#421535d9662a7ab4d63078a2ef85831973c3c20c"
 dependencies = [
  "burn-backend",
  "burn-std",
@@ -970,7 +970,7 @@ dependencies = [
 [[package]]
 name = "burn-vision"
 version = "0.21.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=5923b1e7587e4c76a5d35035147e775ec4002919#5923b1e7587e4c76a5d35035147e775ec4002919"
+source = "git+https://github.com/tracel-ai/burn?rev=421535d9662a7ab4d63078a2ef85831973c3c20c#421535d9662a7ab4d63078a2ef85831973c3c20c"
 dependencies = [
  "aligned-vec",
  "bon",
@@ -990,7 +990,7 @@ dependencies = [
 [[package]]
 name = "burn-wgpu"
 version = "0.21.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=5923b1e7587e4c76a5d35035147e775ec4002919#5923b1e7587e4c76a5d35035147e775ec4002919"
+source = "git+https://github.com/tracel-ai/burn?rev=421535d9662a7ab4d63078a2ef85831973c3c20c#421535d9662a7ab4d63078a2ef85831973c3c20c"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -1251,7 +1251,7 @@ checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
 dependencies = [
  "serde",
  "termcolor",
- "unicode-width 0.2.2",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -1272,7 +1272,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1664,7 +1664,7 @@ dependencies = [
 [[package]]
 name = "cubecl"
 version = "0.10.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=b19859ee693bb02a25e4da2ca53797bb164be140#b19859ee693bb02a25e4da2ca53797bb164be140"
+source = "git+https://github.com/tracel-ai/cubecl?rev=074fb0473a9441565844cfdfe5a4d8f7d62aa299#074fb0473a9441565844cfdfe5a4d8f7d62aa299"
 dependencies = [
  "cubecl-core",
  "cubecl-cpu",
@@ -1680,7 +1680,7 @@ dependencies = [
 [[package]]
 name = "cubecl-common"
 version = "0.10.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=b19859ee693bb02a25e4da2ca53797bb164be140#b19859ee693bb02a25e4da2ca53797bb164be140"
+source = "git+https://github.com/tracel-ai/cubecl?rev=074fb0473a9441565844cfdfe5a4d8f7d62aa299#074fb0473a9441565844cfdfe5a4d8f7d62aa299"
 dependencies = [
  "backtrace",
  "bincode",
@@ -1718,7 +1718,7 @@ dependencies = [
 [[package]]
 name = "cubecl-core"
 version = "0.10.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=b19859ee693bb02a25e4da2ca53797bb164be140#b19859ee693bb02a25e4da2ca53797bb164be140"
+source = "git+https://github.com/tracel-ai/cubecl?rev=074fb0473a9441565844cfdfe5a4d8f7d62aa299#074fb0473a9441565844cfdfe5a4d8f7d62aa299"
 dependencies = [
  "bitflags 2.10.0",
  "bytemuck",
@@ -1745,7 +1745,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpp"
 version = "0.10.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=b19859ee693bb02a25e4da2ca53797bb164be140#b19859ee693bb02a25e4da2ca53797bb164be140"
+source = "git+https://github.com/tracel-ai/cubecl?rev=074fb0473a9441565844cfdfe5a4d8f7d62aa299#074fb0473a9441565844cfdfe5a4d8f7d62aa299"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1761,7 +1761,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpu"
 version = "0.10.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=b19859ee693bb02a25e4da2ca53797bb164be140#b19859ee693bb02a25e4da2ca53797bb164be140"
+source = "git+https://github.com/tracel-ai/cubecl?rev=074fb0473a9441565844cfdfe5a4d8f7d62aa299#074fb0473a9441565844cfdfe5a4d8f7d62aa299"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1782,7 +1782,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cuda"
 version = "0.10.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=b19859ee693bb02a25e4da2ca53797bb164be140#b19859ee693bb02a25e4da2ca53797bb164be140"
+source = "git+https://github.com/tracel-ai/cubecl?rev=074fb0473a9441565844cfdfe5a4d8f7d62aa299#074fb0473a9441565844cfdfe5a4d8f7d62aa299"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1800,7 +1800,7 @@ dependencies = [
 [[package]]
 name = "cubecl-hip"
 version = "0.10.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=b19859ee693bb02a25e4da2ca53797bb164be140#b19859ee693bb02a25e4da2ca53797bb164be140"
+source = "git+https://github.com/tracel-ai/cubecl?rev=074fb0473a9441565844cfdfe5a4d8f7d62aa299#074fb0473a9441565844cfdfe5a4d8f7d62aa299"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1829,7 +1829,7 @@ dependencies = [
 [[package]]
 name = "cubecl-ir"
 version = "0.10.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=b19859ee693bb02a25e4da2ca53797bb164be140#b19859ee693bb02a25e4da2ca53797bb164be140"
+source = "git+https://github.com/tracel-ai/cubecl?rev=074fb0473a9441565844cfdfe5a4d8f7d62aa299#074fb0473a9441565844cfdfe5a4d8f7d62aa299"
 dependencies = [
  "cubecl-common",
  "cubecl-macros-internal",
@@ -1850,7 +1850,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros"
 version = "0.10.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=b19859ee693bb02a25e4da2ca53797bb164be140#b19859ee693bb02a25e4da2ca53797bb164be140"
+source = "git+https://github.com/tracel-ai/cubecl?rev=074fb0473a9441565844cfdfe5a4d8f7d62aa299#074fb0473a9441565844cfdfe5a4d8f7d62aa299"
 dependencies = [
  "cubecl-common",
  "darling 0.23.0",
@@ -1865,7 +1865,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros-internal"
 version = "0.10.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=b19859ee693bb02a25e4da2ca53797bb164be140#b19859ee693bb02a25e4da2ca53797bb164be140"
+source = "git+https://github.com/tracel-ai/cubecl?rev=074fb0473a9441565844cfdfe5a4d8f7d62aa299#074fb0473a9441565844cfdfe5a4d8f7d62aa299"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -1876,7 +1876,7 @@ dependencies = [
 [[package]]
 name = "cubecl-opt"
 version = "0.10.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=b19859ee693bb02a25e4da2ca53797bb164be140#b19859ee693bb02a25e4da2ca53797bb164be140"
+source = "git+https://github.com/tracel-ai/cubecl?rev=074fb0473a9441565844cfdfe5a4d8f7d62aa299#074fb0473a9441565844cfdfe5a4d8f7d62aa299"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -1893,7 +1893,7 @@ dependencies = [
 [[package]]
 name = "cubecl-runtime"
 version = "0.10.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=b19859ee693bb02a25e4da2ca53797bb164be140#b19859ee693bb02a25e4da2ca53797bb164be140"
+source = "git+https://github.com/tracel-ai/cubecl?rev=074fb0473a9441565844cfdfe5a4d8f7d62aa299#074fb0473a9441565844cfdfe5a4d8f7d62aa299"
 dependencies = [
  "async-channel",
  "bytemuck",
@@ -1923,7 +1923,7 @@ dependencies = [
 [[package]]
 name = "cubecl-std"
 version = "0.10.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=b19859ee693bb02a25e4da2ca53797bb164be140#b19859ee693bb02a25e4da2ca53797bb164be140"
+source = "git+https://github.com/tracel-ai/cubecl?rev=074fb0473a9441565844cfdfe5a4d8f7d62aa299#074fb0473a9441565844cfdfe5a4d8f7d62aa299"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -1939,7 +1939,7 @@ dependencies = [
 [[package]]
 name = "cubecl-wgpu"
 version = "0.10.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=b19859ee693bb02a25e4da2ca53797bb164be140#b19859ee693bb02a25e4da2ca53797bb164be140"
+source = "git+https://github.com/tracel-ai/cubecl?rev=074fb0473a9441565844cfdfe5a4d8f7d62aa299#074fb0473a9441565844cfdfe5a4d8f7d62aa299"
 dependencies = [
  "async-channel",
  "bytemuck",
@@ -1963,7 +1963,7 @@ dependencies = [
 [[package]]
 name = "cubecl-zspace"
 version = "0.10.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=b19859ee693bb02a25e4da2ca53797bb164be140#b19859ee693bb02a25e4da2ca53797bb164be140"
+source = "git+https://github.com/tracel-ai/cubecl?rev=074fb0473a9441565844cfdfe5a4d8f7d62aa299#074fb0473a9441565844cfdfe5a4d8f7d62aa299"
 dependencies = [
  "derive-new",
  "serde",
@@ -1973,7 +1973,7 @@ dependencies = [
 [[package]]
 name = "cubek"
 version = "0.2.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=1161040639c1b9819820b337236bd0d265701b5b#1161040639c1b9819820b337236bd0d265701b5b"
+source = "git+https://github.com/tracel-ai/cubek?rev=312ee613666a1847f87a232b7b1e589ca2995015#312ee613666a1847f87a232b7b1e589ca2995015"
 dependencies = [
  "cubecl",
  "cubek-attention",
@@ -1987,7 +1987,7 @@ dependencies = [
 [[package]]
 name = "cubek-attention"
 version = "0.2.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=1161040639c1b9819820b337236bd0d265701b5b#1161040639c1b9819820b337236bd0d265701b5b"
+source = "git+https://github.com/tracel-ai/cubek?rev=312ee613666a1847f87a232b7b1e589ca2995015#312ee613666a1847f87a232b7b1e589ca2995015"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2001,7 +2001,7 @@ dependencies = [
 [[package]]
 name = "cubek-convolution"
 version = "0.2.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=1161040639c1b9819820b337236bd0d265701b5b#1161040639c1b9819820b337236bd0d265701b5b"
+source = "git+https://github.com/tracel-ai/cubek?rev=312ee613666a1847f87a232b7b1e589ca2995015#312ee613666a1847f87a232b7b1e589ca2995015"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2016,7 +2016,7 @@ dependencies = [
 [[package]]
 name = "cubek-matmul"
 version = "0.2.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=1161040639c1b9819820b337236bd0d265701b5b#1161040639c1b9819820b337236bd0d265701b5b"
+source = "git+https://github.com/tracel-ai/cubek?rev=312ee613666a1847f87a232b7b1e589ca2995015#312ee613666a1847f87a232b7b1e589ca2995015"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2028,7 +2028,7 @@ dependencies = [
 [[package]]
 name = "cubek-quant"
 version = "0.2.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=1161040639c1b9819820b337236bd0d265701b5b#1161040639c1b9819820b337236bd0d265701b5b"
+source = "git+https://github.com/tracel-ai/cubek?rev=312ee613666a1847f87a232b7b1e589ca2995015#312ee613666a1847f87a232b7b1e589ca2995015"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2039,7 +2039,7 @@ dependencies = [
 [[package]]
 name = "cubek-random"
 version = "0.2.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=1161040639c1b9819820b337236bd0d265701b5b#1161040639c1b9819820b337236bd0d265701b5b"
+source = "git+https://github.com/tracel-ai/cubek?rev=312ee613666a1847f87a232b7b1e589ca2995015#312ee613666a1847f87a232b7b1e589ca2995015"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2052,7 +2052,7 @@ dependencies = [
 [[package]]
 name = "cubek-reduce"
 version = "0.2.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=1161040639c1b9819820b337236bd0d265701b5b#1161040639c1b9819820b337236bd0d265701b5b"
+source = "git+https://github.com/tracel-ai/cubek?rev=312ee613666a1847f87a232b7b1e589ca2995015#312ee613666a1847f87a232b7b1e589ca2995015"
 dependencies = [
  "cubecl",
  "half",
@@ -2322,7 +2322,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2823,7 +2823,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4528,7 +4528,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5289,7 +5289,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5822,7 +5822,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6440,7 +6440,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6449,7 +6449,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7623,7 +7623,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,10 +74,10 @@ strum = { version = "0.28.0", features = ["derive"] }
 bytes = { version = "1.11.1", default-features = false }
 memmap2 = { version = "0.9" }
 
-burn = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "5923b1e7587e4c76a5d35035147e775ec4002919" }
-burn-ndarray = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "5923b1e7587e4c76a5d35035147e775ec4002919" }
-burn-store = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "5923b1e7587e4c76a5d35035147e775ec4002919" }
-burn-tensor = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "5923b1e7587e4c76a5d35035147e775ec4002919" }
+burn = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "421535d9662a7ab4d63078a2ef85831973c3c20c" }
+burn-ndarray = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "421535d9662a7ab4d63078a2ef85831973c3c20c" }
+burn-store = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "421535d9662a7ab4d63078a2ef85831973c3c20c" }
+burn-tensor = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "421535d9662a7ab4d63078a2ef85831973c3c20c" }
 
 ### For local development. ###
 # burn = { path = "../burn/crates/burn", default-features = false }


### PR DESCRIPTION
## Summary
- Update burn dependency from `5923b1e7` to `421535d9` (latest main)

## Test plan
- [x] `cargo check` passes
- [ ] CI passes