### PR TITLE
fix(ci): pin onnxsim>=0.6.2 to fix model-checks RF-DETR download

### DIFF
--- a/crates/model-checks/rf-detr/get_model.py
+++ b/crates/model-checks/rf-detr/get_model.py
@@ -8,6 +8,7 @@
 #   "onnx<1.17",
 #   "onnxruntime",
 #   "numpy",
+#   "onnxsim>=0.6.2",
 #   "rfdetr[onnxexport]",
 # ]
 # ///


### PR DESCRIPTION
## Summary

- Pin `onnxsim>=0.6.2` in RF-DETR's `get_model.py` to work around `onnxsim 0.6.1` packaging bug (metadata reports version `0.4.36`, causing `uv` to refuse installation)

Fixes #226

## Test plan

- [ ] Verify `model-checks` CI job passes (RF-DETR download succeeds)