### PR TITLE
Fix DTypeMismatch panic on GPU backends for argmax, argmin, and range

### DIFF
--- a/crates/burn-onnx/src/burn/node/argmax.rs
+++ b/crates/burn-onnx/src/burn/node/argmax.rs
@@ -18,30 +18,31 @@ impl NodeCodegen for onnx_ir::node::argmax::ArgMaxNode {
         let input = scope.arg(input_arg);
         let output = arg_to_ident(output_arg);
 
+        // argmax uses the backend's default int element type (I32 on GPU, I64 on NdArray).
+        // Cast to the ONNX-specified dtype to avoid DTypeMismatch on GPU backends.
         match &output_arg.ty {
             onnx_ir::ir::ArgType::Tensor(tensor) => {
+                let output_dtype = tensor.dtype.to_tokens();
                 if self.config.keepdims {
-                    // keepdims=True: Burn's argmax keeps dimensions by default
                     quote! {
-                        let #output = #input.argmax(#axis);
+                        let #output = #input.argmax(#axis).cast(#output_dtype);
                     }
                 } else {
-                    // keepdims=False: use argmax followed by squeeze to remove the kept dimension
                     let output_rank = tensor.rank;
                     quote! {
                         let argmax_result = #input.argmax(#axis);
-                        let #output = argmax_result.squeeze_dim::<#output_rank>(#axis);
+                        let #output = argmax_result.squeeze_dim::<#output_rank>(#axis).cast(#output_dtype);
                     }
                 }
             }
-            onnx_ir::ir::ArgType::ScalarTensor(_) => {
-                // 1D tensor with keepdims=false -> keep as Tensor<B, 1> on device
+            onnx_ir::ir::ArgType::ScalarTensor(dtype) => {
+                let output_dtype = dtype.to_tokens();
                 quote! {
-                    let #output = #input.argmax(#axis).reshape([1]);
+                    let #output = #input.argmax(#axis).reshape([1]).cast(#output_dtype);
                 }
             }
             onnx_ir::ir::ArgType::ScalarNative(_) => {
-                // 1D tensor with keepdims=false -> extract to native scalar
+                // Extracted to native scalar, no cast needed
                 quote! {
                     let argmax_result = #input.argmax(#axis);
                     let #output = argmax_result.into_scalar().elem::<i64>();
@@ -70,7 +71,7 @@ mod tests {
         let code = codegen_forward_default(&node);
         assert_snapshot!(code, @r"
         pub fn forward(&self, input: Tensor<B, 3>) -> Tensor<B, 3, Int> {
-            let output = input.argmax(1);
+            let output = input.argmax(1).cast(burn::tensor::DType::I64);
             output
         }
         ");
@@ -88,7 +89,7 @@ mod tests {
         assert_snapshot!(code, @r"
         pub fn forward(&self, input: Tensor<B, 4>) -> Tensor<B, 3, Int> {
             let argmax_result = input.argmax(2);
-            let output = argmax_result.squeeze_dim::<3usize>(2);
+            let output = argmax_result.squeeze_dim::<3usize>(2).cast(burn::tensor::DType::I64);
             output
         }
         ");
@@ -105,7 +106,7 @@ mod tests {
         let code = codegen_forward_default(&node);
         assert_snapshot!(code, @r"
         pub fn forward(&self, input: Tensor<B, 1>) -> Tensor<B, 1, Int> {
-            let output = input.argmax(0).reshape([1]);
+            let output = input.argmax(0).reshape([1]).cast(burn::tensor::DType::I64);
             output
         }
         ");

--- a/crates/burn-onnx/src/burn/node/argmin.rs
+++ b/crates/burn-onnx/src/burn/node/argmin.rs
@@ -18,30 +18,31 @@ impl NodeCodegen for onnx_ir::node::argmin::ArgMinNode {
         let input = scope.arg(input_arg);
         let output = arg_to_ident(output_arg);
 
+        // argmin uses the backend's default int element type (I32 on GPU, I64 on NdArray).
+        // Cast to the ONNX-specified dtype to avoid DTypeMismatch on GPU backends.
         match &output_arg.ty {
             onnx_ir::ir::ArgType::Tensor(tensor) => {
+                let output_dtype = tensor.dtype.to_tokens();
                 if self.config.keepdims {
-                    // keepdims=True: Burn's argmin keeps dimensions by default
                     quote! {
-                        let #output = #input.argmin(#axis);
+                        let #output = #input.argmin(#axis).cast(#output_dtype);
                     }
                 } else {
-                    // keepdims=False: use argmin followed by squeeze to remove the kept dimension
                     let output_rank = tensor.rank;
                     quote! {
                         let argmin_result = #input.argmin(#axis);
-                        let #output = argmin_result.squeeze_dim::<#output_rank>(#axis);
+                        let #output = argmin_result.squeeze_dim::<#output_rank>(#axis).cast(#output_dtype);
                     }
                 }
             }
-            onnx_ir::ir::ArgType::ScalarTensor(_) => {
-                // 1D tensor with keepdims=false -> keep as Tensor<B, 1> on device
+            onnx_ir::ir::ArgType::ScalarTensor(dtype) => {
+                let output_dtype = dtype.to_tokens();
                 quote! {
-                    let #output = #input.argmin(#axis).reshape([1]);
+                    let #output = #input.argmin(#axis).reshape([1]).cast(#output_dtype);
                 }
             }
             onnx_ir::ir::ArgType::ScalarNative(_) => {
-                // 1D tensor with keepdims=false -> extract to native scalar
+                // Extracted to native scalar, no cast needed
                 quote! {
                     let argmin_result = #input.argmin(#axis);
                     let #output = argmin_result.into_scalar().elem::<i64>();
@@ -70,7 +71,7 @@ mod tests {
         let code = codegen_forward_default(&node);
         assert_snapshot!(code, @r"
         pub fn forward(&self, input: Tensor<B, 3>) -> Tensor<B, 3, Int> {
-            let output = input.argmin(1);
+            let output = input.argmin(1).cast(burn::tensor::DType::I64);
             output
         }
         ");
@@ -88,7 +89,7 @@ mod tests {
         assert_snapshot!(code, @r"
         pub fn forward(&self, input: Tensor<B, 2>) -> Tensor<B, 1, Int> {
             let argmin_result = input.argmin(0);
-            let output = argmin_result.squeeze_dim::<1usize>(0);
+            let output = argmin_result.squeeze_dim::<1usize>(0).cast(burn::tensor::DType::I64);
             output
         }
         ");
@@ -105,7 +106,7 @@ mod tests {
         let code = codegen_forward_default(&node);
         assert_snapshot!(code, @r"
         pub fn forward(&self, input: Tensor<B, 1>) -> Tensor<B, 1, Int> {
-            let output = input.argmin(0).reshape([1]);
+            let output = input.argmin(0).reshape([1]).cast(burn::tensor::DType::I64);
             output
         }
         ");

--- a/crates/burn-onnx/src/burn/node/range.rs
+++ b/crates/burn-onnx/src/burn/node/range.rs
@@ -45,8 +45,13 @@ impl NodeCodegen for onnx_ir::node::range::RangeNode {
         let limit = range_param_tokens(&self.config.limit, &self.inputs, scope);
         let delta = range_param_tokens(&self.config.delta, &self.inputs, scope);
 
+        // arange_step uses the backend's default int element type (I32 on GPU, I64 on NdArray).
+        // Cast to the ONNX-specified dtype to avoid DTypeMismatch on GPU backends.
+        let output_dtype = self.outputs.first().unwrap().ty.elem_type().to_tokens();
+
         quote! {
-            let #output = Tensor::arange_step(#start..#limit, #delta as usize, &*self.device);
+            let #output = Tensor::arange_step(#start..#limit, #delta as usize, &*self.device)
+                .cast(#output_dtype);
         }
     }
 }
@@ -72,7 +77,8 @@ mod tests {
         let code = codegen_forward_default(&node);
         assert_snapshot!(code, @r"
         pub fn forward(&self) -> Tensor<B, 1, Int> {
-            let output = Tensor::arange_step(0i64..10i64, 2i64 as usize, &*self.device);
+            let output = Tensor::arange_step(0i64..10i64, 2i64 as usize, &*self.device)
+                .cast(burn::tensor::DType::I64);
             output
         }
         ");


### PR DESCRIPTION
## Summary

- Fix `DTypeMismatch` panic when running models on GPU backends (Metal, WGPU, Vulkan) that use `argmax`, `argmin`, or `Range` ops
- Add explicit `.cast(output_dtype)` after `argmax()`, `argmin()`, and `arange_step()` in codegen to match the ONNX-specified output dtype
- Verified fix with CLIP ViT-B-32-text model on Metal backend with batch_size > 1

## Root cause

Burn's `argmax()`, `argmin()`, and `arange_step()` create Int tensors using the backend's default int element type (I64 on NdArray, I32 on Metal/WGPU/Vulkan). When these tensors are used in arithmetic with constants loaded from ONNX weights (which preserve their original I64 dtype), GPU backends panic with `DTypeMismatch`.

On NdArray (CPU), the default IntElem is already I64, so no mismatch occurs. This is why the bug only manifests on GPU backends.

## Test plan

- [x] All 687 burn-onnx unit tests pass
- [x] All 496 onnx-tests integration tests pass
- [x] CLIP ViT-B-32-text model runs successfully on Metal with batch_size=2
- [x] Audited all other codegen nodes for similar issues (none found)

## Related

- Closes #94
- Pre-existing Range `delta as usize` issue tracked in #235