### PR TITLE
Fix Mod node broadcasting for YOLO models

### DIFF
--- a/crates/burn-onnx/src/burn/node/broadcast_helpers.rs
+++ b/crates/burn-onnx/src/burn/node/broadcast_helpers.rs
@@ -16,6 +16,38 @@ pub(crate) fn leading_broadcast(
     quote! { (#expr).unsqueeze_dims(&[#(#dims),*]) }
 }
 
+/// Generates numpy-style broadcasting for a binary operation.
+///
+/// Expands both operands to a common shape (per-dimension max) before applying `op`.
+/// Both operands must already have the same rank (apply `leading_broadcast` first).
+///
+/// Use this for operations where Burn does not guarantee internal broadcasting
+/// (e.g. `remainder`, see <https://github.com/tracel-ai/burn/issues/4712>).
+/// For `add`/`mul`/`sub`/`div`, Burn handles broadcasting natively, so this
+/// is not needed.
+pub(crate) fn broadcast_binary_op(
+    lhs: TokenStream,
+    rhs: TokenStream,
+    output_rank: usize,
+    op: TokenStream,
+) -> TokenStream {
+    let rank_lit = proc_macro2::Literal::usize_suffixed(output_rank);
+    quote! {
+        {
+            let __lhs = #lhs;
+            let __rhs = #rhs;
+            let __lhs_dims: [usize; #rank_lit] = __lhs.dims();
+            let __rhs_dims: [usize; #rank_lit] = __rhs.dims();
+            let mut __shape = [0i64; #rank_lit];
+            #[allow(clippy::needless_range_loop)]
+            for __i in 0..#rank_lit {
+                __shape[__i] = core::cmp::max(__lhs_dims[__i] as i64, __rhs_dims[__i] as i64);
+            }
+            __lhs.expand(__shape).#op(__rhs.expand(__shape))
+        }
+    }
+}
+
 pub(crate) fn align_rhs_for_lhs_rank(
     rhs_expr: TokenStream,
     lhs_rank: usize,

--- a/crates/burn-onnx/src/burn/node/modulo.rs
+++ b/crates/burn-onnx/src/burn/node/modulo.rs
@@ -24,17 +24,25 @@ impl NodeCodegen for onnx_ir::modulo::ModNode {
                 let lhs_rank = lhs_ty.rank();
                 let rhs_rank = rhs_ty.rank();
 
-                let mod_op = if self.config.fmod {
-                    quote! { fmod }
-                } else {
-                    quote! { remainder }
-                };
                 let lhs_bc =
                     broadcast_helpers::leading_broadcast(quote! { #lhs }, lhs_rank, rhs_rank);
                 let rhs_bc =
                     broadcast_helpers::leading_broadcast(quote! { #rhs }, rhs_rank, lhs_rank);
+
+                let expr = if self.config.fmod {
+                    quote! { #lhs_bc.fmod(#rhs_bc) }
+                } else {
+                    // Burn's remainder does not broadcast internally
+                    let output_rank = lhs_rank.max(rhs_rank);
+                    broadcast_helpers::broadcast_binary_op(
+                        lhs_bc,
+                        rhs_bc,
+                        output_rank,
+                        quote! { remainder },
+                    )
+                };
                 quote! {
-                    let #output = #lhs_bc.#mod_op(#rhs_bc);
+                    let #output = #expr;
                 }
             }
             (lhs_ty, ArgType::ScalarNative(_)) if lhs_ty.is_on_device() => {
@@ -63,11 +71,6 @@ impl NodeCodegen for onnx_ir::modulo::ModNode {
                 let rhs = scope.arg(rhs_arg);
                 let dtype_tokens = dtype.to_tokens();
                 let rhs_rank = rhs_ty.rank();
-                let mod_op = if self.config.fmod {
-                    quote! { fmod }
-                } else {
-                    quote! { remainder }
-                };
 
                 let (tensor_type, cast_as) = if dtype.is_float() {
                     (quote! { Tensor::<B, 1> }, quote! { f64 })
@@ -75,21 +78,35 @@ impl NodeCodegen for onnx_ir::modulo::ModNode {
                     (quote! { Tensor::<B, 1, burn::tensor::Int> }, quote! { i64 })
                 };
 
-                if rhs_rank > 1 {
+                let lhs_tensor = if rhs_rank > 1 {
                     let dims: Vec<isize> = (0..rhs_rank - 1).map(|i| i as isize).collect();
                     quote! {
-                        let #output = #tensor_type::from_data(
+                        #tensor_type::from_data(
                             burn::tensor::TensorData::from([#lhs as #cast_as]),
                             (&*self.device, #dtype_tokens)
-                        ).unsqueeze_dims(&[#(#dims),*]).#mod_op(#rhs);
+                        ).unsqueeze_dims(&[#(#dims),*])
                     }
                 } else {
                     quote! {
-                        let #output = #tensor_type::from_data(
+                        #tensor_type::from_data(
                             burn::tensor::TensorData::from([#lhs as #cast_as]),
                             (&*self.device, #dtype_tokens)
-                        ).#mod_op(#rhs);
+                        )
                     }
+                };
+
+                let expr = if self.config.fmod {
+                    quote! { #lhs_tensor.fmod(#rhs) }
+                } else {
+                    broadcast_helpers::broadcast_binary_op(
+                        lhs_tensor,
+                        quote! { #rhs },
+                        rhs_rank,
+                        quote! { remainder },
+                    )
+                };
+                quote! {
+                    let #output = #expr;
                 }
             }
             _ => panic!(
@@ -120,7 +137,21 @@ mod tests {
             .build();
         assert_snapshot!(codegen_forward_default(&node), @r"
         pub fn forward(&self, a: Tensor<B, 2>, b: Tensor<B, 2>) -> Tensor<B, 2> {
-            let output = a.remainder(b);
+            let output = {
+                let __lhs = a;
+                let __rhs = b;
+                let __lhs_dims: [usize; 2usize] = __lhs.dims();
+                let __rhs_dims: [usize; 2usize] = __rhs.dims();
+                let mut __shape = [0i64; 2usize];
+                #[allow(clippy::needless_range_loop)]
+                for __i in 0..2usize {
+                    __shape[__i] = core::cmp::max(
+                        __lhs_dims[__i] as i64,
+                        __rhs_dims[__i] as i64,
+                    );
+                }
+                __lhs.expand(__shape).remainder(__rhs.expand(__shape))
+            };
             output
         }
         ");
@@ -156,7 +187,21 @@ mod tests {
             .build();
         assert_snapshot!(codegen_forward_default(&node), @r"
         pub fn forward(&self, a: Tensor<B, 2>, b: Tensor<B, 3>) -> Tensor<B, 3> {
-            let output = (a).unsqueeze_dims(&[0isize]).remainder(b);
+            let output = {
+                let __lhs = (a).unsqueeze_dims(&[0isize]);
+                let __rhs = b;
+                let __lhs_dims: [usize; 3usize] = __lhs.dims();
+                let __rhs_dims: [usize; 3usize] = __rhs.dims();
+                let mut __shape = [0i64; 3usize];
+                #[allow(clippy::needless_range_loop)]
+                for __i in 0..3usize {
+                    __shape[__i] = core::cmp::max(
+                        __lhs_dims[__i] as i64,
+                        __rhs_dims[__i] as i64,
+                    );
+                }
+                __lhs.expand(__shape).remainder(__rhs.expand(__shape))
+            };
             output
         }
         ");
@@ -173,7 +218,21 @@ mod tests {
             .build();
         assert_snapshot!(codegen_forward_default(&node), @r"
         pub fn forward(&self, a: Tensor<B, 3>, b: Tensor<B, 2>) -> Tensor<B, 3> {
-            let output = a.remainder((b).unsqueeze_dims(&[0isize]));
+            let output = {
+                let __lhs = a;
+                let __rhs = (b).unsqueeze_dims(&[0isize]);
+                let __lhs_dims: [usize; 3usize] = __lhs.dims();
+                let __rhs_dims: [usize; 3usize] = __rhs.dims();
+                let mut __shape = [0i64; 3usize];
+                #[allow(clippy::needless_range_loop)]
+                for __i in 0..3usize {
+                    __shape[__i] = core::cmp::max(
+                        __lhs_dims[__i] as i64,
+                        __rhs_dims[__i] as i64,
+                    );
+                }
+                __lhs.expand(__shape).remainder(__rhs.expand(__shape))
+            };
             output
         }
         ");
@@ -226,7 +285,21 @@ mod tests {
             .build();
         assert_snapshot!(codegen_forward_default(&node), @r"
         pub fn forward(&self, a: Tensor<B, 3>, b: Tensor<B, 1>) -> Tensor<B, 3> {
-            let output = a.remainder((b).unsqueeze_dims(&[0isize, 1isize]));
+            let output = {
+                let __lhs = a;
+                let __rhs = (b).unsqueeze_dims(&[0isize, 1isize]);
+                let __lhs_dims: [usize; 3usize] = __lhs.dims();
+                let __rhs_dims: [usize; 3usize] = __rhs.dims();
+                let mut __shape = [0i64; 3usize];
+                #[allow(clippy::needless_range_loop)]
+                for __i in 0..3usize {
+                    __shape[__i] = core::cmp::max(
+                        __lhs_dims[__i] as i64,
+                        __rhs_dims[__i] as i64,
+                    );
+                }
+                __lhs.expand(__shape).remainder(__rhs.expand(__shape))
+            };
             output
         }
         ");
@@ -260,7 +333,21 @@ mod tests {
             .build();
         assert_snapshot!(codegen_forward_default(&node), @r"
         pub fn forward(&self, a: Tensor<B, 1>, b: Tensor<B, 1>) -> Tensor<B, 1> {
-            let output = a.remainder(b);
+            let output = {
+                let __lhs = a;
+                let __rhs = b;
+                let __lhs_dims: [usize; 1usize] = __lhs.dims();
+                let __rhs_dims: [usize; 1usize] = __rhs.dims();
+                let mut __shape = [0i64; 1usize];
+                #[allow(clippy::needless_range_loop)]
+                for __i in 0..1usize {
+                    __shape[__i] = core::cmp::max(
+                        __lhs_dims[__i] as i64,
+                        __rhs_dims[__i] as i64,
+                    );
+                }
+                __lhs.expand(__shape).remainder(__rhs.expand(__shape))
+            };
             output
         }
         ");
@@ -315,15 +402,28 @@ mod tests {
             .build();
         assert_snapshot!(codegen_forward_default(&node), @r"
         pub fn forward(&self, a: f32, b: Tensor<B, 2>) -> Tensor<B, 2> {
-            let output = Tensor::<
-                B,
-                1,
-            >::from_data(
-                    burn::tensor::TensorData::from([a as f64]),
-                    (&*self.device, burn::tensor::DType::F32),
-                )
-                .unsqueeze_dims(&[0isize])
-                .remainder(b);
+            let output = {
+                let __lhs = Tensor::<
+                    B,
+                    1,
+                >::from_data(
+                        burn::tensor::TensorData::from([a as f64]),
+                        (&*self.device, burn::tensor::DType::F32),
+                    )
+                    .unsqueeze_dims(&[0isize]);
+                let __rhs = b;
+                let __lhs_dims: [usize; 2usize] = __lhs.dims();
+                let __rhs_dims: [usize; 2usize] = __rhs.dims();
+                let mut __shape = [0i64; 2usize];
+                #[allow(clippy::needless_range_loop)]
+                for __i in 0..2usize {
+                    __shape[__i] = core::cmp::max(
+                        __lhs_dims[__i] as i64,
+                        __rhs_dims[__i] as i64,
+                    );
+                }
+                __lhs.expand(__shape).remainder(__rhs.expand(__shape))
+            };
             output
         }
         ");

--- a/crates/model-checks/yolo/build.rs
+++ b/crates/model-checks/yolo/build.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 fn main() {
     // Supported models
     let supported_models = vec![
-        "yolov5s", "yolov8n", "yolov8s", "yolov10n", "yolo11x", "yolo12x",
+        "yolov5s", "yolov8n", "yolov8s", "yolov10n", "yolo11x", "yolo12x", "yolo26x",
     ];
 
     // Get the model name from environment variable (required)

--- a/crates/model-checks/yolo/get_model.py
+++ b/crates/model-checks/yolo/get_model.py
@@ -29,6 +29,7 @@ SUPPORTED_MODELS = {
     'yolov10n': {'download_name': 'yolov10n.pt', 'display_name': 'YOLOv10n'},
     'yolo11x': {'download_name': 'yolo11x.pt', 'display_name': 'YOLO11x'},
     'yolo12x': {'download_name': 'yolo12x.pt', 'display_name': 'YOLO12x'},
+    'yolo26x': {'download_name': 'yolo26x.pt', 'display_name': 'YOLO26x'},
 }
 
 

--- a/crates/model-checks/yolo/src/main.rs
+++ b/crates/model-checks/yolo/src/main.rs
@@ -14,6 +14,7 @@ include!(concat!(env!("OUT_DIR"), "/model_info.rs"));
 // Use the yolo_model module from model_info.rs
 use yolo_model::Model;
 
+/// Standard YOLO output: [1, 84, 8400] (v5, v8, v11, v12)
 #[derive(Debug, Module)]
 struct TestData<B: Backend> {
     input: Param<Tensor<B, 4>>,
@@ -22,12 +23,32 @@ struct TestData<B: Backend> {
 
 impl<B: Backend> TestData<B> {
     fn new(device: &B::Device) -> Self {
-        // YOLO: input 640x640, output [1, 84, 8400]
         Self {
             input: Initializer::Zeros.init([1, 3, 640, 640], device),
             output: Initializer::Zeros.init([1, 84, 8400], device),
         }
     }
+}
+
+/// End-to-end YOLO output: [1, 300, 6] (v10, v26)
+#[derive(Debug, Module)]
+struct TestDataE2E<B: Backend> {
+    input: Param<Tensor<B, 4>>,
+    output: Param<Tensor<B, 3>>,
+}
+
+impl<B: Backend> TestDataE2E<B> {
+    fn new(device: &B::Device) -> Self {
+        Self {
+            input: Initializer::Zeros.init([1, 3, 640, 640], device),
+            output: Initializer::Zeros.init([1, 300, 6], device),
+        }
+    }
+}
+
+/// Returns true for models with end-to-end detection output [1, 300, 6].
+fn is_e2e_model(model_name: &str) -> bool {
+    matches!(model_name, "yolov10n" | "yolo26x")
 }
 
 fn get_model_display_name(model_name: &str) -> &str {
@@ -38,6 +59,7 @@ fn get_model_display_name(model_name: &str) -> &str {
         "yolov10n" => "YOLOv10n",
         "yolo11x" => "YOLO11x",
         "yolo12x" => "YOLO12x",
+        "yolo26x" => "YOLO26x",
         _ => model_name,
     }
 }
@@ -80,6 +102,7 @@ fn main() {
         eprintln!("  - yolov10n");
         eprintln!("  - yolo11x");
         eprintln!("  - yolo12x");
+        eprintln!("  - yolo26x");
         std::process::exit(1);
     }
 
@@ -104,28 +127,30 @@ fn main() {
     // Load test data from PyTorch file
     println!("\nLoading test data from {}...", test_data_file.display());
     let start = Instant::now();
-    let mut test_data = TestData::<MyBackend>::new(&device);
-    let mut store = PytorchStore::from_file(&test_data_file);
-    test_data
-        .load_from(&mut store)
-        .expect("Failed to load test data");
+    let (input, reference_output) = if is_e2e_model(model_name) {
+        let mut test_data = TestDataE2E::<MyBackend>::new(&device);
+        let mut store = PytorchStore::from_file(&test_data_file);
+        test_data
+            .load_from(&mut store)
+            .expect("Failed to load test data");
+        (test_data.input.val(), test_data.output.val())
+    } else {
+        let mut test_data = TestData::<MyBackend>::new(&device);
+        let mut store = PytorchStore::from_file(&test_data_file);
+        test_data
+            .load_from(&mut store)
+            .expect("Failed to load test data");
+        (test_data.input.val(), test_data.output.val())
+    };
     let load_time = start.elapsed();
     println!("  Data loaded in {:.2?}", load_time);
-
-    // Get the input tensor from test data
-    let input = test_data.input.val();
-    let input_shape = input.shape();
     println!(
         "  Loaded input tensor with shape: {:?}",
-        input_shape.as_slice()
+        input.shape().as_slice()
     );
-
-    // Get the reference output from test data
-    let reference_output = test_data.output.val();
-    let reference_shape = reference_output.shape();
     println!(
         "  Loaded reference output with shape: {:?}",
-        reference_shape.as_slice()
+        reference_output.shape().as_slice()
     );
 
     // Warmup run (compiles GPU shaders, allocates buffers)
@@ -145,13 +170,17 @@ fn main() {
     let shape = output.shape();
     println!("\n  Model output shape: {:?}", shape.as_slice());
 
-    // Verify expected output shape (most YOLO models use [1, 84, 8400])
-    let expected_shape = [1, 84, 8400];
+    // Verify expected output shape
+    let expected_shape: &[usize] = if is_e2e_model(model_name) {
+        &[1, 300, 6]
+    } else {
+        &[1, 84, 8400]
+    };
     if shape.as_slice() == expected_shape {
         println!("  ✓ Output shape matches expected: {:?}", expected_shape);
     } else {
         println!(
-            "  ⚠ Note: Shape is {:?} (expected {:?} for most YOLO models)",
+            "  ⚠ Note: Shape is {:?} (expected {:?})",
             shape.as_slice(),
             expected_shape
         );


### PR DESCRIPTION
## Summary

- Fix runtime crash in ONNX `Mod` operator when operands have same rank but different dimension sizes (e.g. `[1, 300]` and `[1, 1]`)
- Add YOLO26x to model checks and fix test harness to handle end-to-end detection output shape `[1, 300, 6]`

## Root cause

Burn's ndarray `remainder` uses `Zip` without broadcasting (tracel-ai/burn#4712). When the codegen produces `a.remainder(b)` and the operands need dimension-wise broadcasting, the `Zip` panics. Other binary ops (`add`, `mul`, `sub`, `div`) are unaffected because they use ndarray's native operators which broadcast internally. CubeCL backends are also unaffected since `launch_binop` handles broadcasting for all ops.

## Fix

Add `broadcast_binary_op` helper that generates explicit `.expand()` calls to match tensor shapes before the operation. The Mod codegen now uses this for `remainder` (not needed for `fmod`, which is implemented using broadcasting-compatible tensor ops).

## Verified

- YOLO26x (exported via Ultralytics, output `[1, 300, 6]`): builds and runs successfully
- YOLOv10n (same output format): builds and runs successfully  
- YOLO12x (standard output `[1, 84, 8400]`): still works, matches reference within 1e-4
- All 2,655 existing tests pass

Closes #281