### PR TITLE
Add comment on LRN evaluator bug in integration test suite

### DIFF
--- a/crates/onnx-tests/tests/lrn/lrn.py
+++ b/crates/onnx-tests/tests/lrn/lrn.py
@@ -7,7 +7,14 @@
 # ]
 # ///
 
-# used to generate model: `lrn_default_size3.onnx`, `lrn_custom_size3.onnx`, and `lrn_custom_size2.onnx`
+# Used to generate model: `lrn_default_size3.onnx`, `lrn_custom_size3.onnx`, and `lrn_custom_size2.onnx`
+# and expected values for the integration test suite in `./mod.rs`.
+#
+# NOTE: Do not regenerate the expected values using `onnx`'s stock `ReferenceEvaluator`
+#       until https://github.com/onnx/onnx/issues/7805 has been resolved.
+#       Expected values in the integration test suite were generated
+#       using a manually patched LRN op.
+# TODO: Once resolved, remove these "NOTE" and "TODO" comments.
 
 import numpy as np
 import onnx


### PR DESCRIPTION
### Checklist

- [x] Confirmed that `cargo xtask validate` command has been executed.
- [x] Confirm relevant documentation has been updated.
- [ ] ~For new/modified ONNX operators: verified implementation matches `onnx-spec/ops/<OpName>.md`.~

### Related Issues/PRs

Fixes #289.

### Changes

A quick follow up to https://github.com/tracel-ai/burn-onnx/pull/286#issuecomment-4183985962.

### Testing

N/A
