### PR TITLE
Bump version and burn deps to 0.21.0-pre.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -483,8 +483,8 @@ checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "burn"
-version = "0.21.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=03175d123628a18f44cf1af870c082907904ee12#03175d123628a18f44cf1af870c082907904ee12"
+version = "0.21.0-pre.3"
+source = "git+https://github.com/tracel-ai/burn?rev=52998ac066953a02b5c18bfd236538235a2dac9f#52998ac066953a02b5c18bfd236538235a2dac9f"
 dependencies = [
  "burn-autodiff",
  "burn-candle",
@@ -500,13 +500,14 @@ dependencies = [
  "burn-router",
  "burn-store",
  "burn-tch",
+ "burn-vision",
  "burn-wgpu",
 ]
 
 [[package]]
 name = "burn-autodiff"
-version = "0.21.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=03175d123628a18f44cf1af870c082907904ee12#03175d123628a18f44cf1af870c082907904ee12"
+version = "0.21.0-pre.3"
+source = "git+https://github.com/tracel-ai/burn?rev=52998ac066953a02b5c18bfd236538235a2dac9f#52998ac066953a02b5c18bfd236538235a2dac9f"
 dependencies = [
  "burn-backend",
  "burn-std",
@@ -521,8 +522,8 @@ dependencies = [
 
 [[package]]
 name = "burn-backend"
-version = "0.21.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=03175d123628a18f44cf1af870c082907904ee12#03175d123628a18f44cf1af870c082907904ee12"
+version = "0.21.0-pre.3"
+source = "git+https://github.com/tracel-ai/burn?rev=52998ac066953a02b5c18bfd236538235a2dac9f#52998ac066953a02b5c18bfd236538235a2dac9f"
 dependencies = [
  "burn-std",
  "bytemuck",
@@ -541,8 +542,8 @@ dependencies = [
 
 [[package]]
 name = "burn-candle"
-version = "0.21.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=03175d123628a18f44cf1af870c082907904ee12#03175d123628a18f44cf1af870c082907904ee12"
+version = "0.21.0-pre.3"
+source = "git+https://github.com/tracel-ai/burn?rev=52998ac066953a02b5c18bfd236538235a2dac9f#52998ac066953a02b5c18bfd236538235a2dac9f"
 dependencies = [
  "burn-backend",
  "burn-std",
@@ -552,8 +553,8 @@ dependencies = [
 
 [[package]]
 name = "burn-core"
-version = "0.21.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=03175d123628a18f44cf1af870c082907904ee12#03175d123628a18f44cf1af870c082907904ee12"
+version = "0.21.0-pre.3"
+source = "git+https://github.com/tracel-ai/burn?rev=52998ac066953a02b5c18bfd236538235a2dac9f#52998ac066953a02b5c18bfd236538235a2dac9f"
 dependencies = [
  "ahash",
  "bincode",
@@ -561,7 +562,6 @@ dependencies = [
  "burn-derive",
  "burn-std",
  "burn-tensor",
- "burn-vision",
  "data-encoding",
  "derive-new",
  "flate2",
@@ -583,8 +583,8 @@ dependencies = [
 
 [[package]]
 name = "burn-cpu"
-version = "0.21.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=03175d123628a18f44cf1af870c082907904ee12#03175d123628a18f44cf1af870c082907904ee12"
+version = "0.21.0-pre.3"
+source = "git+https://github.com/tracel-ai/burn?rev=52998ac066953a02b5c18bfd236538235a2dac9f#52998ac066953a02b5c18bfd236538235a2dac9f"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -594,8 +594,8 @@ dependencies = [
 
 [[package]]
 name = "burn-cubecl"
-version = "0.21.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=03175d123628a18f44cf1af870c082907904ee12#03175d123628a18f44cf1af870c082907904ee12"
+version = "0.21.0-pre.3"
+source = "git+https://github.com/tracel-ai/burn?rev=52998ac066953a02b5c18bfd236538235a2dac9f#52998ac066953a02b5c18bfd236538235a2dac9f"
 dependencies = [
  "burn-backend",
  "burn-cubecl-fusion",
@@ -613,8 +613,8 @@ dependencies = [
 
 [[package]]
 name = "burn-cubecl-fusion"
-version = "0.21.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=03175d123628a18f44cf1af870c082907904ee12#03175d123628a18f44cf1af870c082907904ee12"
+version = "0.21.0-pre.3"
+source = "git+https://github.com/tracel-ai/burn?rev=52998ac066953a02b5c18bfd236538235a2dac9f#52998ac066953a02b5c18bfd236538235a2dac9f"
 dependencies = [
  "burn-backend",
  "burn-fusion",
@@ -628,8 +628,8 @@ dependencies = [
 
 [[package]]
 name = "burn-cuda"
-version = "0.21.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=03175d123628a18f44cf1af870c082907904ee12#03175d123628a18f44cf1af870c082907904ee12"
+version = "0.21.0-pre.3"
+source = "git+https://github.com/tracel-ai/burn?rev=52998ac066953a02b5c18bfd236538235a2dac9f#52998ac066953a02b5c18bfd236538235a2dac9f"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -639,8 +639,8 @@ dependencies = [
 
 [[package]]
 name = "burn-dataset"
-version = "0.21.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=03175d123628a18f44cf1af870c082907904ee12#03175d123628a18f44cf1af870c082907904ee12"
+version = "0.21.0-pre.3"
+source = "git+https://github.com/tracel-ai/burn?rev=52998ac066953a02b5c18bfd236538235a2dac9f#52998ac066953a02b5c18bfd236538235a2dac9f"
 dependencies = [
  "burn-std",
  "csv",
@@ -661,8 +661,8 @@ dependencies = [
 
 [[package]]
 name = "burn-derive"
-version = "0.21.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=03175d123628a18f44cf1af870c082907904ee12#03175d123628a18f44cf1af870c082907904ee12"
+version = "0.21.0-pre.3"
+source = "git+https://github.com/tracel-ai/burn?rev=52998ac066953a02b5c18bfd236538235a2dac9f#52998ac066953a02b5c18bfd236538235a2dac9f"
 dependencies = [
  "derive-new",
  "proc-macro2",
@@ -672,8 +672,8 @@ dependencies = [
 
 [[package]]
 name = "burn-dispatch"
-version = "0.21.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=03175d123628a18f44cf1af870c082907904ee12#03175d123628a18f44cf1af870c082907904ee12"
+version = "0.21.0-pre.3"
+source = "git+https://github.com/tracel-ai/burn?rev=52998ac066953a02b5c18bfd236538235a2dac9f#52998ac066953a02b5c18bfd236538235a2dac9f"
 dependencies = [
  "burn-autodiff",
  "burn-backend",
@@ -688,8 +688,8 @@ dependencies = [
 
 [[package]]
 name = "burn-fusion"
-version = "0.21.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=03175d123628a18f44cf1af870c082907904ee12#03175d123628a18f44cf1af870c082907904ee12"
+version = "0.21.0-pre.3"
+source = "git+https://github.com/tracel-ai/burn?rev=52998ac066953a02b5c18bfd236538235a2dac9f#52998ac066953a02b5c18bfd236538235a2dac9f"
 dependencies = [
  "burn-backend",
  "burn-ir",
@@ -705,15 +705,15 @@ dependencies = [
 
 [[package]]
 name = "burn-import"
-version = "0.21.0-pre.2"
+version = "0.21.0-pre.3"
 dependencies = [
  "burn-onnx",
 ]
 
 [[package]]
 name = "burn-ir"
-version = "0.21.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=03175d123628a18f44cf1af870c082907904ee12#03175d123628a18f44cf1af870c082907904ee12"
+version = "0.21.0-pre.3"
+source = "git+https://github.com/tracel-ai/burn?rev=52998ac066953a02b5c18bfd236538235a2dac9f#52998ac066953a02b5c18bfd236538235a2dac9f"
 dependencies = [
  "burn-backend",
  "hashbrown 0.16.1",
@@ -722,8 +722,8 @@ dependencies = [
 
 [[package]]
 name = "burn-ndarray"
-version = "0.21.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=03175d123628a18f44cf1af870c082907904ee12#03175d123628a18f44cf1af870c082907904ee12"
+version = "0.21.0-pre.3"
+source = "git+https://github.com/tracel-ai/burn?rev=52998ac066953a02b5c18bfd236538235a2dac9f#52998ac066953a02b5c18bfd236538235a2dac9f"
 dependencies = [
  "atomic_float",
  "burn-autodiff",
@@ -744,18 +744,16 @@ dependencies = [
 
 [[package]]
 name = "burn-nn"
-version = "0.21.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=03175d123628a18f44cf1af870c082907904ee12#03175d123628a18f44cf1af870c082907904ee12"
+version = "0.21.0-pre.3"
+source = "git+https://github.com/tracel-ai/burn?rev=52998ac066953a02b5c18bfd236538235a2dac9f#52998ac066953a02b5c18bfd236538235a2dac9f"
 dependencies = [
  "burn-core",
- "burn-std",
- "burn-store",
  "num-traits",
 ]
 
 [[package]]
 name = "burn-onnx"
-version = "0.21.0-pre.2"
+version = "0.21.0-pre.3"
 dependencies = [
  "burn",
  "burn-ndarray",
@@ -1037,8 +1035,8 @@ dependencies = [
 
 [[package]]
 name = "burn-optim"
-version = "0.21.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=03175d123628a18f44cf1af870c082907904ee12#03175d123628a18f44cf1af870c082907904ee12"
+version = "0.21.0-pre.3"
+source = "git+https://github.com/tracel-ai/burn?rev=52998ac066953a02b5c18bfd236538235a2dac9f#52998ac066953a02b5c18bfd236538235a2dac9f"
 dependencies = [
  "burn-core",
  "derive-new",
@@ -1050,8 +1048,8 @@ dependencies = [
 
 [[package]]
 name = "burn-rocm"
-version = "0.21.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=03175d123628a18f44cf1af870c082907904ee12#03175d123628a18f44cf1af870c082907904ee12"
+version = "0.21.0-pre.3"
+source = "git+https://github.com/tracel-ai/burn?rev=52998ac066953a02b5c18bfd236538235a2dac9f#52998ac066953a02b5c18bfd236538235a2dac9f"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -1061,8 +1059,8 @@ dependencies = [
 
 [[package]]
 name = "burn-router"
-version = "0.21.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=03175d123628a18f44cf1af870c082907904ee12#03175d123628a18f44cf1af870c082907904ee12"
+version = "0.21.0-pre.3"
+source = "git+https://github.com/tracel-ai/burn?rev=52998ac066953a02b5c18bfd236538235a2dac9f#52998ac066953a02b5c18bfd236538235a2dac9f"
 dependencies = [
  "burn-backend",
  "burn-ir",
@@ -1074,8 +1072,8 @@ dependencies = [
 
 [[package]]
 name = "burn-std"
-version = "0.21.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=03175d123628a18f44cf1af870c082907904ee12#03175d123628a18f44cf1af870c082907904ee12"
+version = "0.21.0-pre.3"
+source = "git+https://github.com/tracel-ai/burn?rev=52998ac066953a02b5c18bfd236538235a2dac9f#52998ac066953a02b5c18bfd236538235a2dac9f"
 dependencies = [
  "bytemuck",
  "bytes",
@@ -1093,8 +1091,8 @@ dependencies = [
 
 [[package]]
 name = "burn-store"
-version = "0.21.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=03175d123628a18f44cf1af870c082907904ee12#03175d123628a18f44cf1af870c082907904ee12"
+version = "0.21.0-pre.3"
+source = "git+https://github.com/tracel-ai/burn?rev=52998ac066953a02b5c18bfd236538235a2dac9f#52998ac066953a02b5c18bfd236538235a2dac9f"
 dependencies = [
  "burn-core",
  "burn-tensor",
@@ -1114,8 +1112,8 @@ dependencies = [
 
 [[package]]
 name = "burn-tch"
-version = "0.21.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=03175d123628a18f44cf1af870c082907904ee12#03175d123628a18f44cf1af870c082907904ee12"
+version = "0.21.0-pre.3"
+source = "git+https://github.com/tracel-ai/burn?rev=52998ac066953a02b5c18bfd236538235a2dac9f#52998ac066953a02b5c18bfd236538235a2dac9f"
 dependencies = [
  "burn-backend",
  "cc",
@@ -1127,8 +1125,8 @@ dependencies = [
 
 [[package]]
 name = "burn-tensor"
-version = "0.21.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=03175d123628a18f44cf1af870c082907904ee12#03175d123628a18f44cf1af870c082907904ee12"
+version = "0.21.0-pre.3"
+source = "git+https://github.com/tracel-ai/burn?rev=52998ac066953a02b5c18bfd236538235a2dac9f#52998ac066953a02b5c18bfd236538235a2dac9f"
 dependencies = [
  "burn-backend",
  "burn-std",
@@ -1140,8 +1138,8 @@ dependencies = [
 
 [[package]]
 name = "burn-vision"
-version = "0.21.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=03175d123628a18f44cf1af870c082907904ee12#03175d123628a18f44cf1af870c082907904ee12"
+version = "0.21.0-pre.3"
+source = "git+https://github.com/tracel-ai/burn?rev=52998ac066953a02b5c18bfd236538235a2dac9f#52998ac066953a02b5c18bfd236538235a2dac9f"
 dependencies = [
  "aligned-vec",
  "bon",
@@ -1160,8 +1158,8 @@ dependencies = [
 
 [[package]]
 name = "burn-wgpu"
-version = "0.21.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=03175d123628a18f44cf1af870c082907904ee12#03175d123628a18f44cf1af870c082907904ee12"
+version = "0.21.0-pre.3"
+source = "git+https://github.com/tracel-ai/burn?rev=52998ac066953a02b5c18bfd236538235a2dac9f#52998ac066953a02b5c18bfd236538235a2dac9f"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -1840,8 +1838,9 @@ dependencies = [
 
 [[package]]
 name = "cubecl"
-version = "0.10.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=2c59137c0295011fd656f0279eaa762261f523e1#2c59137c0295011fd656f0279eaa762261f523e1"
+version = "0.10.0-pre.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33a0c239b35656fedf416524c9e52b55e06630f810356a01b9bbe921546f9a94"
 dependencies = [
  "cubecl-core",
  "cubecl-cpu",
@@ -1856,8 +1855,9 @@ dependencies = [
 
 [[package]]
 name = "cubecl-common"
-version = "0.10.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=2c59137c0295011fd656f0279eaa762261f523e1#2c59137c0295011fd656f0279eaa762261f523e1"
+version = "0.10.0-pre.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26305086841b64e39843de5d6d62cfd61437aaf31d94d6b4adcdbf0bf54375a1"
 dependencies = [
  "backtrace",
  "bytemuck",
@@ -1896,8 +1896,9 @@ dependencies = [
 
 [[package]]
 name = "cubecl-core"
-version = "0.10.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=2c59137c0295011fd656f0279eaa762261f523e1#2c59137c0295011fd656f0279eaa762261f523e1"
+version = "0.10.0-pre.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be9fccb34ed84ebf93d96cc64f64ddf8cb2804c44a81e47486b88f476678bd2c"
 dependencies = [
  "bitflags 2.11.0",
  "bytemuck",
@@ -1923,8 +1924,9 @@ dependencies = [
 
 [[package]]
 name = "cubecl-cpp"
-version = "0.10.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=2c59137c0295011fd656f0279eaa762261f523e1#2c59137c0295011fd656f0279eaa762261f523e1"
+version = "0.10.0-pre.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48a9f6391ef7df48c60aa95f5837cda883ab1aeecf75dacbc18d31e46081340c"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1939,8 +1941,9 @@ dependencies = [
 
 [[package]]
 name = "cubecl-cpu"
-version = "0.10.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=2c59137c0295011fd656f0279eaa762261f523e1#2c59137c0295011fd656f0279eaa762261f523e1"
+version = "0.10.0-pre.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09dc2964101ff21b2ffb47028da32f1b0311be5bc58ba5fa7bae19f74fb81f29"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1960,8 +1963,9 @@ dependencies = [
 
 [[package]]
 name = "cubecl-cuda"
-version = "0.10.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=2c59137c0295011fd656f0279eaa762261f523e1#2c59137c0295011fd656f0279eaa762261f523e1"
+version = "0.10.0-pre.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c2a172799c83fd63343a641179dd447cfebf3842052389238493b54cf180eed"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1978,8 +1982,9 @@ dependencies = [
 
 [[package]]
 name = "cubecl-hip"
-version = "0.10.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=2c59137c0295011fd656f0279eaa762261f523e1#2c59137c0295011fd656f0279eaa762261f523e1"
+version = "0.10.0-pre.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b5baa8b167d4865d5481066d9d27d5133b9ab483546cbcc0f12bd4d3f232c12"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -2007,8 +2012,9 @@ dependencies = [
 
 [[package]]
 name = "cubecl-ir"
-version = "0.10.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=2c59137c0295011fd656f0279eaa762261f523e1#2c59137c0295011fd656f0279eaa762261f523e1"
+version = "0.10.0-pre.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21834fd88bfc98bbfedfff5e4e0867095bb42990617314033e9b55b1d9dce144"
 dependencies = [
  "cubecl-common",
  "cubecl-macros-internal",
@@ -2028,8 +2034,9 @@ dependencies = [
 
 [[package]]
 name = "cubecl-macros"
-version = "0.10.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=2c59137c0295011fd656f0279eaa762261f523e1#2c59137c0295011fd656f0279eaa762261f523e1"
+version = "0.10.0-pre.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c11738ffab5f0bb73e9ec8399c30a3b623ad9d0fb5158a95e45963e282e3558e"
 dependencies = [
  "cubecl-common",
  "darling 0.23.0",
@@ -2044,8 +2051,9 @@ dependencies = [
 
 [[package]]
 name = "cubecl-macros-internal"
-version = "0.10.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=2c59137c0295011fd656f0279eaa762261f523e1#2c59137c0295011fd656f0279eaa762261f523e1"
+version = "0.10.0-pre.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38590997cab4c64b41568394e205e3e55df8b08ad0a7839fe558a10013bb3fa5"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -2055,8 +2063,9 @@ dependencies = [
 
 [[package]]
 name = "cubecl-opt"
-version = "0.10.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=2c59137c0295011fd656f0279eaa762261f523e1#2c59137c0295011fd656f0279eaa762261f523e1"
+version = "0.10.0-pre.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73afc2906ab743ddcf5c7f8c209abb7afb3365e511c99625da460bfa1a09df2e"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -2072,8 +2081,9 @@ dependencies = [
 
 [[package]]
 name = "cubecl-runtime"
-version = "0.10.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=2c59137c0295011fd656f0279eaa762261f523e1#2c59137c0295011fd656f0279eaa762261f523e1"
+version = "0.10.0-pre.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "934a5bd50210166a5a395c65fb9c38b865d79e81d203c5e3161b5f4e613a2335"
 dependencies = [
  "async-channel",
  "bytemuck",
@@ -2102,8 +2112,9 @@ dependencies = [
 
 [[package]]
 name = "cubecl-std"
-version = "0.10.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=2c59137c0295011fd656f0279eaa762261f523e1#2c59137c0295011fd656f0279eaa762261f523e1"
+version = "0.10.0-pre.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db3ae86be1776e9b562b9c62ee7342ca614b268f066f152f644164978c5f0cce"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -2118,8 +2129,9 @@ dependencies = [
 
 [[package]]
 name = "cubecl-wgpu"
-version = "0.10.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=2c59137c0295011fd656f0279eaa762261f523e1#2c59137c0295011fd656f0279eaa762261f523e1"
+version = "0.10.0-pre.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b883057d3ab663303d91bb32f4038700253f7d21ffda8f1f0785bb61eccaa4ee"
 dependencies = [
  "async-channel",
  "bytemuck",
@@ -2142,8 +2154,9 @@ dependencies = [
 
 [[package]]
 name = "cubecl-zspace"
-version = "0.10.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=2c59137c0295011fd656f0279eaa762261f523e1#2c59137c0295011fd656f0279eaa762261f523e1"
+version = "0.10.0-pre.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7102db7e3f401ad08bb3fb115747573e22baa13d8b1583102fae11fbf8f82998"
 dependencies = [
  "derive-new",
  "serde",
@@ -2152,8 +2165,9 @@ dependencies = [
 
 [[package]]
 name = "cubek"
-version = "0.2.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=440064f55270a032999f0e53cfc32cf20ad0b7e1#440064f55270a032999f0e53cfc32cf20ad0b7e1"
+version = "0.2.0-pre.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "311db9db82974a527feabc6cd456280681bf70cbba92ce348b5c68f7ca2e33aa"
 dependencies = [
  "cubecl",
  "cubek-attention",
@@ -2168,8 +2182,9 @@ dependencies = [
 
 [[package]]
 name = "cubek-attention"
-version = "0.2.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=440064f55270a032999f0e53cfc32cf20ad0b7e1#440064f55270a032999f0e53cfc32cf20ad0b7e1"
+version = "0.2.0-pre.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d85ac71e50450c381aec840c9ad37111b37a78fc30472271f52ab5f84a5f440"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2182,8 +2197,9 @@ dependencies = [
 
 [[package]]
 name = "cubek-convolution"
-version = "0.2.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=440064f55270a032999f0e53cfc32cf20ad0b7e1#440064f55270a032999f0e53cfc32cf20ad0b7e1"
+version = "0.2.0-pre.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3308019366711665b13f7f9cc5b2cdf2374dedf5f206b82e973663332ae8a86"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2198,8 +2214,9 @@ dependencies = [
 
 [[package]]
 name = "cubek-fft"
-version = "0.2.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=440064f55270a032999f0e53cfc32cf20ad0b7e1#440064f55270a032999f0e53cfc32cf20ad0b7e1"
+version = "0.2.0-pre.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b284d6c96b0fd072948e3784b2615558143e296da88e311926da04391dfe6f14"
 dependencies = [
  "cubecl",
  "cubek-test-utils",
@@ -2207,8 +2224,9 @@ dependencies = [
 
 [[package]]
 name = "cubek-matmul"
-version = "0.2.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=440064f55270a032999f0e53cfc32cf20ad0b7e1#440064f55270a032999f0e53cfc32cf20ad0b7e1"
+version = "0.2.0-pre.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c9ad9a2db6852cd8177d17401c9dad49a2cb400bb3286054ca36c267e65bd81"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2220,8 +2238,9 @@ dependencies = [
 
 [[package]]
 name = "cubek-quant"
-version = "0.2.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=440064f55270a032999f0e53cfc32cf20ad0b7e1#440064f55270a032999f0e53cfc32cf20ad0b7e1"
+version = "0.2.0-pre.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "690e22564b27733bee35d185c9de82f73f36cab4555f08c3f07e9d4241f92db7"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2231,8 +2250,9 @@ dependencies = [
 
 [[package]]
 name = "cubek-random"
-version = "0.2.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=440064f55270a032999f0e53cfc32cf20ad0b7e1#440064f55270a032999f0e53cfc32cf20ad0b7e1"
+version = "0.2.0-pre.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff0699ed05120c5b89aaaa93ca7f779a1c8060972a41b080b190524243f4f8c3"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2244,8 +2264,9 @@ dependencies = [
 
 [[package]]
 name = "cubek-reduce"
-version = "0.2.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=440064f55270a032999f0e53cfc32cf20ad0b7e1#440064f55270a032999f0e53cfc32cf20ad0b7e1"
+version = "0.2.0-pre.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7a8637fc91e773eba6f946d149fd1e8f326f70ad1fbf0aee8374a91772c6a06"
 dependencies = [
  "cubecl",
  "cubek-std",
@@ -2257,8 +2278,9 @@ dependencies = [
 
 [[package]]
 name = "cubek-std"
-version = "0.2.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=440064f55270a032999f0e53cfc32cf20ad0b7e1#440064f55270a032999f0e53cfc32cf20ad0b7e1"
+version = "0.2.0-pre.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da75c710ba6aa1dba65ff864f5eb40cb6943aad8f54d554fe2ec2e7d35663a84"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2267,8 +2289,9 @@ dependencies = [
 
 [[package]]
 name = "cubek-test-utils"
-version = "0.2.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=440064f55270a032999f0e53cfc32cf20ad0b7e1#440064f55270a032999f0e53cfc32cf20ad0b7e1"
+version = "0.2.0-pre.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07a88a5dcd387d9f3485d731aa3ca6d397a2d3cd7c18e8fde312a6fe6866d2ed"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -4085,7 +4108,7 @@ dependencies = [
 
 [[package]]
 name = "image-classification-web"
-version = "0.21.0-pre.2"
+version = "0.21.0-pre.3"
 dependencies = [
  "burn",
  "burn-onnx",
@@ -5115,7 +5138,7 @@ dependencies = [
 
 [[package]]
 name = "onnx-inference"
-version = "0.21.0-pre.2"
+version = "0.21.0-pre.3"
 dependencies = [
  "burn",
  "burn-onnx",
@@ -5125,7 +5148,7 @@ dependencies = [
 
 [[package]]
 name = "onnx-ir"
-version = "0.21.0-pre.2"
+version = "0.21.0-pre.3"
 dependencies = [
  "burn-tensor",
  "bytemuck",
@@ -5147,7 +5170,7 @@ dependencies = [
 
 [[package]]
 name = "onnx-ir-derive"
-version = "0.21.0-pre.2"
+version = "0.21.0-pre.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5156,7 +5179,7 @@ dependencies = [
 
 [[package]]
 name = "onnx-official-tests"
-version = "0.21.0-pre.2"
+version = "0.21.0-pre.3"
 dependencies = [
  "burn",
  "burn-onnx",
@@ -5171,7 +5194,7 @@ dependencies = [
 
 [[package]]
 name = "onnx-tests"
-version = "0.21.0-pre.2"
+version = "0.21.0-pre.3"
 dependencies = [
  "burn",
  "burn-onnx",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -484,7 +484,8 @@ checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 [[package]]
 name = "burn"
 version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=52998ac066953a02b5c18bfd236538235a2dac9f#52998ac066953a02b5c18bfd236538235a2dac9f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "194141a65d74cf81579d13a2c956447509ceb20e4032af7d34f9d7ecc68ef2d3"
 dependencies = [
  "burn-autodiff",
  "burn-candle",
@@ -507,7 +508,8 @@ dependencies = [
 [[package]]
 name = "burn-autodiff"
 version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=52998ac066953a02b5c18bfd236538235a2dac9f#52998ac066953a02b5c18bfd236538235a2dac9f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "548660e365a1db6c97de0efce946c54ca4c6885000a461eb212bb7740d7393ec"
 dependencies = [
  "burn-backend",
  "burn-std",
@@ -523,7 +525,8 @@ dependencies = [
 [[package]]
 name = "burn-backend"
 version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=52998ac066953a02b5c18bfd236538235a2dac9f#52998ac066953a02b5c18bfd236538235a2dac9f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1628cc6713c8e2048a4f6e0b2feed2ae748b4f564150f97b75b9c491c2d7eb67"
 dependencies = [
  "burn-std",
  "bytemuck",
@@ -543,7 +546,8 @@ dependencies = [
 [[package]]
 name = "burn-candle"
 version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=52998ac066953a02b5c18bfd236538235a2dac9f#52998ac066953a02b5c18bfd236538235a2dac9f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "155e8a48cdd34f92e2790cdcc7e5f15f76218c0d37cbf678828065c99a8f7d59"
 dependencies = [
  "burn-backend",
  "burn-std",
@@ -554,7 +558,8 @@ dependencies = [
 [[package]]
 name = "burn-core"
 version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=52998ac066953a02b5c18bfd236538235a2dac9f#52998ac066953a02b5c18bfd236538235a2dac9f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c1625261e56af29b79ec0ff20f8861f1f63737ffe96f3a3d585c1404f52da06"
 dependencies = [
  "ahash",
  "bincode",
@@ -584,7 +589,8 @@ dependencies = [
 [[package]]
 name = "burn-cpu"
 version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=52998ac066953a02b5c18bfd236538235a2dac9f#52998ac066953a02b5c18bfd236538235a2dac9f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "276c671880f8b264eb794df898befcd71b6868818a56537e4151d71239b4a486"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -595,7 +601,8 @@ dependencies = [
 [[package]]
 name = "burn-cubecl"
 version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=52998ac066953a02b5c18bfd236538235a2dac9f#52998ac066953a02b5c18bfd236538235a2dac9f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80f2869a85edbb47c4b0b94d0dc373df1867105f43f50b2bb318635e5a821903"
 dependencies = [
  "burn-backend",
  "burn-cubecl-fusion",
@@ -614,7 +621,8 @@ dependencies = [
 [[package]]
 name = "burn-cubecl-fusion"
 version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=52998ac066953a02b5c18bfd236538235a2dac9f#52998ac066953a02b5c18bfd236538235a2dac9f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39eaf2904f5545b37f2a5ec7f3cbe8f311e8c00dbf9386fe78ba72abfe202f92"
 dependencies = [
  "burn-backend",
  "burn-fusion",
@@ -629,7 +637,8 @@ dependencies = [
 [[package]]
 name = "burn-cuda"
 version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=52998ac066953a02b5c18bfd236538235a2dac9f#52998ac066953a02b5c18bfd236538235a2dac9f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7150a5d4cf808e1c6422360f593b2ac937f65e1f84148444416ed734f94f5d45"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -640,7 +649,8 @@ dependencies = [
 [[package]]
 name = "burn-dataset"
 version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=52998ac066953a02b5c18bfd236538235a2dac9f#52998ac066953a02b5c18bfd236538235a2dac9f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47eb336f52cb750e1054f143ddb308586b5cbffa6b4414fd53ad664cdd8a10c"
 dependencies = [
  "burn-std",
  "csv",
@@ -662,7 +672,8 @@ dependencies = [
 [[package]]
 name = "burn-derive"
 version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=52998ac066953a02b5c18bfd236538235a2dac9f#52998ac066953a02b5c18bfd236538235a2dac9f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446b99a2bc169db54355973f5268de878a140e59a11a094f4a6fb5bae52b4114"
 dependencies = [
  "derive-new",
  "proc-macro2",
@@ -673,7 +684,8 @@ dependencies = [
 [[package]]
 name = "burn-dispatch"
 version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=52998ac066953a02b5c18bfd236538235a2dac9f#52998ac066953a02b5c18bfd236538235a2dac9f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bef057c1ee1b63c60d78890d0980bb4e6906a15837671cccbcba2ca607db2b3"
 dependencies = [
  "burn-autodiff",
  "burn-backend",
@@ -689,7 +701,8 @@ dependencies = [
 [[package]]
 name = "burn-fusion"
 version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=52998ac066953a02b5c18bfd236538235a2dac9f#52998ac066953a02b5c18bfd236538235a2dac9f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "967c42ae5fa2cb6c75d12c082da5b61d6fdd1f8c9e0a5f51c3333455bbcdc567"
 dependencies = [
  "burn-backend",
  "burn-ir",
@@ -713,7 +726,8 @@ dependencies = [
 [[package]]
 name = "burn-ir"
 version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=52998ac066953a02b5c18bfd236538235a2dac9f#52998ac066953a02b5c18bfd236538235a2dac9f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c77a90ae80a5bdc2fb7a96f768d8e340a7345f182ad6e3e99fb5bf2fe1707efb"
 dependencies = [
  "burn-backend",
  "hashbrown 0.16.1",
@@ -723,7 +737,8 @@ dependencies = [
 [[package]]
 name = "burn-ndarray"
 version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=52998ac066953a02b5c18bfd236538235a2dac9f#52998ac066953a02b5c18bfd236538235a2dac9f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e21ae84db1162cb52f871bd740de6427a0cb27e105bf256417fcb3e132dfbd67"
 dependencies = [
  "atomic_float",
  "burn-autodiff",
@@ -745,7 +760,8 @@ dependencies = [
 [[package]]
 name = "burn-nn"
 version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=52998ac066953a02b5c18bfd236538235a2dac9f#52998ac066953a02b5c18bfd236538235a2dac9f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "654f854f46c1916baa16cc88dcff10dee09b90d06453f86424ba927d9e5a73be"
 dependencies = [
  "burn-core",
  "num-traits",
@@ -1036,7 +1052,8 @@ dependencies = [
 [[package]]
 name = "burn-optim"
 version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=52998ac066953a02b5c18bfd236538235a2dac9f#52998ac066953a02b5c18bfd236538235a2dac9f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cecc1963011c3dfe385ccc3b50740f2ed785590d4faeb8487300fbde7399966"
 dependencies = [
  "burn-core",
  "derive-new",
@@ -1049,7 +1066,8 @@ dependencies = [
 [[package]]
 name = "burn-rocm"
 version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=52998ac066953a02b5c18bfd236538235a2dac9f#52998ac066953a02b5c18bfd236538235a2dac9f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2719d0df4484c8dbd6356ebd300a8e19e83f5414443fbd01a22450c506eab9f5"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -1060,7 +1078,8 @@ dependencies = [
 [[package]]
 name = "burn-router"
 version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=52998ac066953a02b5c18bfd236538235a2dac9f#52998ac066953a02b5c18bfd236538235a2dac9f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1095cadad6eff5f78949c866303cc5e0bb78edc40ad9d85af58dd3bfab836e0"
 dependencies = [
  "burn-backend",
  "burn-ir",
@@ -1073,7 +1092,8 @@ dependencies = [
 [[package]]
 name = "burn-std"
 version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=52998ac066953a02b5c18bfd236538235a2dac9f#52998ac066953a02b5c18bfd236538235a2dac9f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07958881e32465deedc91f83204c8dab01d32cc9b681a4f8469be89872ba8a17"
 dependencies = [
  "bytemuck",
  "bytes",
@@ -1092,7 +1112,8 @@ dependencies = [
 [[package]]
 name = "burn-store"
 version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=52998ac066953a02b5c18bfd236538235a2dac9f#52998ac066953a02b5c18bfd236538235a2dac9f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "481060010a0d40d6c977ba9eb2a73bb81a20298e7d20b8c9b66aa7e0df1fa9b9"
 dependencies = [
  "burn-core",
  "burn-tensor",
@@ -1113,7 +1134,8 @@ dependencies = [
 [[package]]
 name = "burn-tch"
 version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=52998ac066953a02b5c18bfd236538235a2dac9f#52998ac066953a02b5c18bfd236538235a2dac9f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f52d910f1f8737804951f72cb28b9bc753e9021febe406dac58f9e2f25e2c6a7"
 dependencies = [
  "burn-backend",
  "cc",
@@ -1126,7 +1148,8 @@ dependencies = [
 [[package]]
 name = "burn-tensor"
 version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=52998ac066953a02b5c18bfd236538235a2dac9f#52998ac066953a02b5c18bfd236538235a2dac9f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8b64d8778857f7fe7a94f8af5b82da6b42b8087f4148958d793d5b6eeea74a2"
 dependencies = [
  "burn-backend",
  "burn-std",
@@ -1139,7 +1162,8 @@ dependencies = [
 [[package]]
 name = "burn-vision"
 version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=52998ac066953a02b5c18bfd236538235a2dac9f#52998ac066953a02b5c18bfd236538235a2dac9f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa45f5cafdc43d6bec19366f5afad75f03bb681c1b6cbbe14cf89d3218d86c19"
 dependencies = [
  "aligned-vec",
  "bon",
@@ -1159,7 +1183,8 @@ dependencies = [
 [[package]]
 name = "burn-wgpu"
 version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=52998ac066953a02b5c18bfd236538235a2dac9f#52998ac066953a02b5c18bfd236538235a2dac9f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f67dcc104fc582874cd1941524c479f2736c107b053117860346e14d0701a9d2"
 dependencies = [
  "burn-backend",
  "burn-cubecl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ exclude = [
 edition = "2024"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
-version = "0.21.0-pre.2"
+version = "0.21.0-pre.3"
 
 [workspace.lints.clippy]
 
@@ -78,10 +78,10 @@ memmap2 = { version = "0.9" }
 thiserror = { version = "2.0.18", default-features = false }
 toml = { version = "0.9.8", default-features = false, features = ["parse", "serde"] }
 
-burn = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "03175d123628a18f44cf1af870c082907904ee12" }
-burn-ndarray = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "03175d123628a18f44cf1af870c082907904ee12" }
-burn-store = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "03175d123628a18f44cf1af870c082907904ee12" }
-burn-tensor = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "03175d123628a18f44cf1af870c082907904ee12" }
+burn = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "52998ac066953a02b5c18bfd236538235a2dac9f" }
+burn-ndarray = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "52998ac066953a02b5c18bfd236538235a2dac9f" }
+burn-store = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "52998ac066953a02b5c18bfd236538235a2dac9f" }
+burn-tensor = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "52998ac066953a02b5c18bfd236538235a2dac9f" }
 
 ### For local development. ###
 # burn = { path = "../burn/crates/burn", default-features = false }
@@ -90,10 +90,10 @@ burn-tensor = { git = "https://github.com/tracel-ai/burn", default-features = fa
 # burn-tensor = { path = "../burn/crates/burn-tensor", default-features = false }
 
 ### For the release. ###
-# burn = { version = "0.21.0-pre.2", default-features = false }
-# burn-ndarray = { version = "0.21.0-pre.2", default-features = false }
-# burn-store = { version = "0.21.0-pre.2", default-features = false }
-# burn-tensor = { version = "0.21.0-pre.2", default-features = false }
+# burn = { version = "0.21.0-pre.3", default-features = false }
+# burn-ndarray = { version = "0.21.0-pre.3", default-features = false }
+# burn-store = { version = "0.21.0-pre.3", default-features = false }
+# burn-tensor = { version = "0.21.0-pre.3", default-features = false }
 
 ### For xtask crate ###
 tracel-xtask = "=4.15.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,10 +78,10 @@ memmap2 = { version = "0.9" }
 thiserror = { version = "2.0.18", default-features = false }
 toml = { version = "0.9.8", default-features = false, features = ["parse", "serde"] }
 
-burn = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "52998ac066953a02b5c18bfd236538235a2dac9f" }
-burn-ndarray = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "52998ac066953a02b5c18bfd236538235a2dac9f" }
-burn-store = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "52998ac066953a02b5c18bfd236538235a2dac9f" }
-burn-tensor = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "52998ac066953a02b5c18bfd236538235a2dac9f" }
+# burn = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "52998ac066953a02b5c18bfd236538235a2dac9f" }
+# burn-ndarray = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "52998ac066953a02b5c18bfd236538235a2dac9f" }
+# burn-store = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "52998ac066953a02b5c18bfd236538235a2dac9f" }
+# burn-tensor = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "52998ac066953a02b5c18bfd236538235a2dac9f" }
 
 ### For local development. ###
 # burn = { path = "../burn/crates/burn", default-features = false }
@@ -90,10 +90,10 @@ burn-tensor = { git = "https://github.com/tracel-ai/burn", default-features = fa
 # burn-tensor = { path = "../burn/crates/burn-tensor", default-features = false }
 
 ### For the release. ###
-# burn = { version = "0.21.0-pre.3", default-features = false }
-# burn-ndarray = { version = "0.21.0-pre.3", default-features = false }
-# burn-store = { version = "0.21.0-pre.3", default-features = false }
-# burn-tensor = { version = "0.21.0-pre.3", default-features = false }
+burn = { version = "0.21.0-pre.3", default-features = false }
+burn-ndarray = { version = "0.21.0-pre.3", default-features = false }
+burn-store = { version = "0.21.0-pre.3", default-features = false }
+burn-tensor = { version = "0.21.0-pre.3", default-features = false }
 
 ### For xtask crate ###
 tracel-xtask = "=4.15.0"

--- a/crates/burn-import/Cargo.toml
+++ b/crates/burn-import/Cargo.toml
@@ -21,7 +21,7 @@ onnx = []
 mmap = ["burn-onnx/mmap"]
 
 [dependencies]
-burn-onnx = { path = "../burn-onnx", version = "=0.21.0-pre.2", default-features = false }
+burn-onnx = { path = "../burn-onnx", version = "=0.21.0-pre.3", default-features = false }
 
 [package.metadata.docs.rs]
 features = ["default"]

--- a/crates/burn-onnx/Cargo.toml
+++ b/crates/burn-onnx/Cargo.toml
@@ -22,7 +22,7 @@ default = ["mmap"]
 mmap = ["onnx-ir/mmap"]
 
 [dependencies]
-onnx-ir = { path = "../onnx-ir", version = "=0.21.0-pre.2", default-features = false }
+onnx-ir = { path = "../onnx-ir", version = "=0.21.0-pre.3", default-features = false }
 
 burn = { workspace = true, features = ["std"] }
 burn-ndarray = { workspace = true }

--- a/crates/onnx-ir/Cargo.toml
+++ b/crates/onnx-ir/Cargo.toml
@@ -20,7 +20,7 @@ default = ["mmap"]
 mmap = ["memmap2"]
 
 [dependencies]
-onnx-ir-derive = { path = "../onnx-ir-derive", version = "=0.21.0-pre.2" }
+onnx-ir-derive = { path = "../onnx-ir-derive", version = "=0.21.0-pre.3" }
 
 burn-tensor = { workspace = true }
 bytemuck = { workspace = true, features = ["extern_crate_alloc"] }

--- a/crates/onnx-tests/tests/matmul/mod.rs
+++ b/crates/onnx-tests/tests/matmul/mod.rs
@@ -9,7 +9,12 @@ mod tests {
 
     use crate::backend::TestBackend;
 
+    // Blocked on https://github.com/tracel-ai/burn/pull/4764: Burn 0.21.0-pre.3
+    // introduced an `unsqueeze_dims` regression that panics on the 4D @ 1D matmul
+    // broadcasting path. Re-enable this test once we upgrade to a Burn release
+    // containing the upstream fix.
     #[test]
+    #[ignore = "blocked on tracel-ai/burn#4764 (unsqueeze_dims duplicate-axes panic)"]
     fn matmul() {
         // Initialize the model with weights (loaded from the exported file)
         let model: matmul::Model<TestBackend> = matmul::Model::default();

--- a/scoreboard/runner/Cargo.lock
+++ b/scoreboard/runner/Cargo.lock
@@ -35,7 +35,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
+ "getrandom 0.3.4",
  "once_cell",
+ "serde",
  "version_check",
  "zerocopy",
 ]
@@ -132,6 +134,12 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -222,8 +230,8 @@ checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "burn"
-version = "0.21.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=c3917da4ea1e424e60a9a6d809dab0ef9ef39e14#c3917da4ea1e424e60a9a6d809dab0ef9ef39e14"
+version = "0.21.0-pre.3"
+source = "git+https://github.com/tracel-ai/burn?rev=52998ac066953a02b5c18bfd236538235a2dac9f#52998ac066953a02b5c18bfd236538235a2dac9f"
 dependencies = [
  "burn-autodiff",
  "burn-candle",
@@ -243,8 +251,8 @@ dependencies = [
 
 [[package]]
 name = "burn-autodiff"
-version = "0.21.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=c3917da4ea1e424e60a9a6d809dab0ef9ef39e14#c3917da4ea1e424e60a9a6d809dab0ef9ef39e14"
+version = "0.21.0-pre.3"
+source = "git+https://github.com/tracel-ai/burn?rev=52998ac066953a02b5c18bfd236538235a2dac9f#52998ac066953a02b5c18bfd236538235a2dac9f"
 dependencies = [
  "burn-backend",
  "burn-std",
@@ -259,8 +267,8 @@ dependencies = [
 
 [[package]]
 name = "burn-backend"
-version = "0.21.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=c3917da4ea1e424e60a9a6d809dab0ef9ef39e14#c3917da4ea1e424e60a9a6d809dab0ef9ef39e14"
+version = "0.21.0-pre.3"
+source = "git+https://github.com/tracel-ai/burn?rev=52998ac066953a02b5c18bfd236538235a2dac9f#52998ac066953a02b5c18bfd236538235a2dac9f"
 dependencies = [
  "burn-std",
  "bytemuck",
@@ -279,8 +287,8 @@ dependencies = [
 
 [[package]]
 name = "burn-candle"
-version = "0.21.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=c3917da4ea1e424e60a9a6d809dab0ef9ef39e14#c3917da4ea1e424e60a9a6d809dab0ef9ef39e14"
+version = "0.21.0-pre.3"
+source = "git+https://github.com/tracel-ai/burn?rev=52998ac066953a02b5c18bfd236538235a2dac9f#52998ac066953a02b5c18bfd236538235a2dac9f"
 dependencies = [
  "burn-backend",
  "burn-std",
@@ -290,8 +298,8 @@ dependencies = [
 
 [[package]]
 name = "burn-core"
-version = "0.21.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=c3917da4ea1e424e60a9a6d809dab0ef9ef39e14#c3917da4ea1e424e60a9a6d809dab0ef9ef39e14"
+version = "0.21.0-pre.3"
+source = "git+https://github.com/tracel-ai/burn?rev=52998ac066953a02b5c18bfd236538235a2dac9f#52998ac066953a02b5c18bfd236538235a2dac9f"
 dependencies = [
  "ahash",
  "bincode",
@@ -318,8 +326,8 @@ dependencies = [
 
 [[package]]
 name = "burn-cpu"
-version = "0.21.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=c3917da4ea1e424e60a9a6d809dab0ef9ef39e14#c3917da4ea1e424e60a9a6d809dab0ef9ef39e14"
+version = "0.21.0-pre.3"
+source = "git+https://github.com/tracel-ai/burn?rev=52998ac066953a02b5c18bfd236538235a2dac9f#52998ac066953a02b5c18bfd236538235a2dac9f"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -328,8 +336,8 @@ dependencies = [
 
 [[package]]
 name = "burn-cubecl"
-version = "0.21.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=c3917da4ea1e424e60a9a6d809dab0ef9ef39e14#c3917da4ea1e424e60a9a6d809dab0ef9ef39e14"
+version = "0.21.0-pre.3"
+source = "git+https://github.com/tracel-ai/burn?rev=52998ac066953a02b5c18bfd236538235a2dac9f#52998ac066953a02b5c18bfd236538235a2dac9f"
 dependencies = [
  "burn-backend",
  "burn-cubecl-fusion",
@@ -347,8 +355,8 @@ dependencies = [
 
 [[package]]
 name = "burn-cubecl-fusion"
-version = "0.21.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=c3917da4ea1e424e60a9a6d809dab0ef9ef39e14#c3917da4ea1e424e60a9a6d809dab0ef9ef39e14"
+version = "0.21.0-pre.3"
+source = "git+https://github.com/tracel-ai/burn?rev=52998ac066953a02b5c18bfd236538235a2dac9f#52998ac066953a02b5c18bfd236538235a2dac9f"
 dependencies = [
  "burn-backend",
  "burn-fusion",
@@ -362,8 +370,8 @@ dependencies = [
 
 [[package]]
 name = "burn-cuda"
-version = "0.21.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=c3917da4ea1e424e60a9a6d809dab0ef9ef39e14#c3917da4ea1e424e60a9a6d809dab0ef9ef39e14"
+version = "0.21.0-pre.3"
+source = "git+https://github.com/tracel-ai/burn?rev=52998ac066953a02b5c18bfd236538235a2dac9f#52998ac066953a02b5c18bfd236538235a2dac9f"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -372,8 +380,8 @@ dependencies = [
 
 [[package]]
 name = "burn-derive"
-version = "0.21.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=c3917da4ea1e424e60a9a6d809dab0ef9ef39e14#c3917da4ea1e424e60a9a6d809dab0ef9ef39e14"
+version = "0.21.0-pre.3"
+source = "git+https://github.com/tracel-ai/burn?rev=52998ac066953a02b5c18bfd236538235a2dac9f#52998ac066953a02b5c18bfd236538235a2dac9f"
 dependencies = [
  "derive-new",
  "proc-macro2",
@@ -383,8 +391,8 @@ dependencies = [
 
 [[package]]
 name = "burn-dispatch"
-version = "0.21.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=c3917da4ea1e424e60a9a6d809dab0ef9ef39e14#c3917da4ea1e424e60a9a6d809dab0ef9ef39e14"
+version = "0.21.0-pre.3"
+source = "git+https://github.com/tracel-ai/burn?rev=52998ac066953a02b5c18bfd236538235a2dac9f#52998ac066953a02b5c18bfd236538235a2dac9f"
 dependencies = [
  "burn-autodiff",
  "burn-backend",
@@ -399,8 +407,8 @@ dependencies = [
 
 [[package]]
 name = "burn-fusion"
-version = "0.21.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=c3917da4ea1e424e60a9a6d809dab0ef9ef39e14#c3917da4ea1e424e60a9a6d809dab0ef9ef39e14"
+version = "0.21.0-pre.3"
+source = "git+https://github.com/tracel-ai/burn?rev=52998ac066953a02b5c18bfd236538235a2dac9f#52998ac066953a02b5c18bfd236538235a2dac9f"
 dependencies = [
  "burn-backend",
  "burn-ir",
@@ -416,8 +424,8 @@ dependencies = [
 
 [[package]]
 name = "burn-ir"
-version = "0.21.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=c3917da4ea1e424e60a9a6d809dab0ef9ef39e14#c3917da4ea1e424e60a9a6d809dab0ef9ef39e14"
+version = "0.21.0-pre.3"
+source = "git+https://github.com/tracel-ai/burn?rev=52998ac066953a02b5c18bfd236538235a2dac9f#52998ac066953a02b5c18bfd236538235a2dac9f"
 dependencies = [
  "burn-backend",
  "hashbrown 0.16.1",
@@ -426,8 +434,8 @@ dependencies = [
 
 [[package]]
 name = "burn-ndarray"
-version = "0.21.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=c3917da4ea1e424e60a9a6d809dab0ef9ef39e14#c3917da4ea1e424e60a9a6d809dab0ef9ef39e14"
+version = "0.21.0-pre.3"
+source = "git+https://github.com/tracel-ai/burn?rev=52998ac066953a02b5c18bfd236538235a2dac9f#52998ac066953a02b5c18bfd236538235a2dac9f"
 dependencies = [
  "atomic_float",
  "burn-autodiff",
@@ -448,12 +456,10 @@ dependencies = [
 
 [[package]]
 name = "burn-nn"
-version = "0.21.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=c3917da4ea1e424e60a9a6d809dab0ef9ef39e14#c3917da4ea1e424e60a9a6d809dab0ef9ef39e14"
+version = "0.21.0-pre.3"
+source = "git+https://github.com/tracel-ai/burn?rev=52998ac066953a02b5c18bfd236538235a2dac9f#52998ac066953a02b5c18bfd236538235a2dac9f"
 dependencies = [
  "burn-core",
- "burn-std",
- "burn-store",
  "num-traits",
 ]
 
@@ -470,8 +476,8 @@ dependencies = [
 
 [[package]]
 name = "burn-optim"
-version = "0.21.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=c3917da4ea1e424e60a9a6d809dab0ef9ef39e14#c3917da4ea1e424e60a9a6d809dab0ef9ef39e14"
+version = "0.21.0-pre.3"
+source = "git+https://github.com/tracel-ai/burn?rev=52998ac066953a02b5c18bfd236538235a2dac9f#52998ac066953a02b5c18bfd236538235a2dac9f"
 dependencies = [
  "burn-core",
  "derive-new",
@@ -483,8 +489,8 @@ dependencies = [
 
 [[package]]
 name = "burn-rocm"
-version = "0.21.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=c3917da4ea1e424e60a9a6d809dab0ef9ef39e14#c3917da4ea1e424e60a9a6d809dab0ef9ef39e14"
+version = "0.21.0-pre.3"
+source = "git+https://github.com/tracel-ai/burn?rev=52998ac066953a02b5c18bfd236538235a2dac9f#52998ac066953a02b5c18bfd236538235a2dac9f"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -493,8 +499,8 @@ dependencies = [
 
 [[package]]
 name = "burn-router"
-version = "0.21.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=c3917da4ea1e424e60a9a6d809dab0ef9ef39e14#c3917da4ea1e424e60a9a6d809dab0ef9ef39e14"
+version = "0.21.0-pre.3"
+source = "git+https://github.com/tracel-ai/burn?rev=52998ac066953a02b5c18bfd236538235a2dac9f#52998ac066953a02b5c18bfd236538235a2dac9f"
 dependencies = [
  "burn-backend",
  "burn-ir",
@@ -506,8 +512,8 @@ dependencies = [
 
 [[package]]
 name = "burn-std"
-version = "0.21.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=c3917da4ea1e424e60a9a6d809dab0ef9ef39e14#c3917da4ea1e424e60a9a6d809dab0ef9ef39e14"
+version = "0.21.0-pre.3"
+source = "git+https://github.com/tracel-ai/burn?rev=52998ac066953a02b5c18bfd236538235a2dac9f#52998ac066953a02b5c18bfd236538235a2dac9f"
 dependencies = [
  "bytemuck",
  "bytes",
@@ -522,8 +528,8 @@ dependencies = [
 
 [[package]]
 name = "burn-store"
-version = "0.21.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=c3917da4ea1e424e60a9a6d809dab0ef9ef39e14#c3917da4ea1e424e60a9a6d809dab0ef9ef39e14"
+version = "0.21.0-pre.3"
+source = "git+https://github.com/tracel-ai/burn?rev=52998ac066953a02b5c18bfd236538235a2dac9f#52998ac066953a02b5c18bfd236538235a2dac9f"
 dependencies = [
  "burn-core",
  "burn-tensor",
@@ -541,8 +547,8 @@ dependencies = [
 
 [[package]]
 name = "burn-tch"
-version = "0.21.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=c3917da4ea1e424e60a9a6d809dab0ef9ef39e14#c3917da4ea1e424e60a9a6d809dab0ef9ef39e14"
+version = "0.21.0-pre.3"
+source = "git+https://github.com/tracel-ai/burn?rev=52998ac066953a02b5c18bfd236538235a2dac9f#52998ac066953a02b5c18bfd236538235a2dac9f"
 dependencies = [
  "burn-backend",
  "cc",
@@ -554,8 +560,8 @@ dependencies = [
 
 [[package]]
 name = "burn-tensor"
-version = "0.21.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=c3917da4ea1e424e60a9a6d809dab0ef9ef39e14#c3917da4ea1e424e60a9a6d809dab0ef9ef39e14"
+version = "0.21.0-pre.3"
+source = "git+https://github.com/tracel-ai/burn?rev=52998ac066953a02b5c18bfd236538235a2dac9f#52998ac066953a02b5c18bfd236538235a2dac9f"
 dependencies = [
  "burn-backend",
  "burn-std",
@@ -567,8 +573,8 @@ dependencies = [
 
 [[package]]
 name = "burn-wgpu"
-version = "0.21.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=c3917da4ea1e424e60a9a6d809dab0ef9ef39e14#c3917da4ea1e424e60a9a6d809dab0ef9ef39e14"
+version = "0.21.0-pre.3"
+source = "git+https://github.com/tracel-ai/burn?rev=52998ac066953a02b5c18bfd236538235a2dac9f#52998ac066953a02b5c18bfd236538235a2dac9f"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -632,12 +638,12 @@ dependencies = [
 
 [[package]]
 name = "candle-core"
-version = "0.9.2"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c15b675b80d994b2eadb20a4bbe434eabeb454eac3ee5e2b4cf6f147ee9be091"
+checksum = "6bd9895436c1ba5dc1037a19935d084b838db066ff4e15ef7dded020b7c12a4a"
 dependencies = [
  "byteorder",
- "float8 0.6.1",
+ "float8",
  "gemm",
  "half",
  "libm",
@@ -649,6 +655,7 @@ dependencies = [
  "rayon",
  "safetensors 0.7.0",
  "thiserror 2.0.18",
+ "tokenizers",
  "yoke",
  "zip 7.2.0",
 ]
@@ -660,6 +667,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6fd507454086c8edfd769ca6ada439193cdb209c7681712ef6275cccbfe5d8"
 dependencies = [
  "unicode-normalization",
+]
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -772,6 +788,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "compact_str"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "serde",
+ "static_assertions",
 ]
 
 [[package]]
@@ -923,8 +954,9 @@ dependencies = [
 
 [[package]]
 name = "cubecl"
-version = "0.10.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=e743e8f7b22b93378bab28b26916f7cf61321ccc#e743e8f7b22b93378bab28b26916f7cf61321ccc"
+version = "0.10.0-pre.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33a0c239b35656fedf416524c9e52b55e06630f810356a01b9bbe921546f9a94"
 dependencies = [
  "cubecl-core",
  "cubecl-cpu",
@@ -939,8 +971,9 @@ dependencies = [
 
 [[package]]
 name = "cubecl-common"
-version = "0.10.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=e743e8f7b22b93378bab28b26916f7cf61321ccc#e743e8f7b22b93378bab28b26916f7cf61321ccc"
+version = "0.10.0-pre.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26305086841b64e39843de5d6d62cfd61437aaf31d94d6b4adcdbf0bf54375a1"
 dependencies = [
  "backtrace",
  "bytemuck",
@@ -954,7 +987,7 @@ dependencies = [
  "embassy-futures",
  "embassy-time",
  "float4",
- "float8 0.7.0",
+ "float8",
  "futures-lite",
  "half",
  "hashbrown 0.16.1",
@@ -979,8 +1012,9 @@ dependencies = [
 
 [[package]]
 name = "cubecl-core"
-version = "0.10.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=e743e8f7b22b93378bab28b26916f7cf61321ccc#e743e8f7b22b93378bab28b26916f7cf61321ccc"
+version = "0.10.0-pre.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be9fccb34ed84ebf93d96cc64f64ddf8cb2804c44a81e47486b88f476678bd2c"
 dependencies = [
  "bitflags",
  "bytemuck",
@@ -1006,8 +1040,9 @@ dependencies = [
 
 [[package]]
 name = "cubecl-cpp"
-version = "0.10.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=e743e8f7b22b93378bab28b26916f7cf61321ccc#e743e8f7b22b93378bab28b26916f7cf61321ccc"
+version = "0.10.0-pre.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48a9f6391ef7df48c60aa95f5837cda883ab1aeecf75dacbc18d31e46081340c"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1022,8 +1057,9 @@ dependencies = [
 
 [[package]]
 name = "cubecl-cpu"
-version = "0.10.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=e743e8f7b22b93378bab28b26916f7cf61321ccc#e743e8f7b22b93378bab28b26916f7cf61321ccc"
+version = "0.10.0-pre.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09dc2964101ff21b2ffb47028da32f1b0311be5bc58ba5fa7bae19f74fb81f29"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1043,8 +1079,9 @@ dependencies = [
 
 [[package]]
 name = "cubecl-cuda"
-version = "0.10.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=e743e8f7b22b93378bab28b26916f7cf61321ccc#e743e8f7b22b93378bab28b26916f7cf61321ccc"
+version = "0.10.0-pre.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c2a172799c83fd63343a641179dd447cfebf3842052389238493b54cf180eed"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1061,8 +1098,9 @@ dependencies = [
 
 [[package]]
 name = "cubecl-hip"
-version = "0.10.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=e743e8f7b22b93378bab28b26916f7cf61321ccc#e743e8f7b22b93378bab28b26916f7cf61321ccc"
+version = "0.10.0-pre.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b5baa8b167d4865d5481066d9d27d5133b9ab483546cbcc0f12bd4d3f232c12"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1090,8 +1128,9 @@ dependencies = [
 
 [[package]]
 name = "cubecl-ir"
-version = "0.10.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=e743e8f7b22b93378bab28b26916f7cf61321ccc#e743e8f7b22b93378bab28b26916f7cf61321ccc"
+version = "0.10.0-pre.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21834fd88bfc98bbfedfff5e4e0867095bb42990617314033e9b55b1d9dce144"
 dependencies = [
  "cubecl-common",
  "cubecl-macros-internal",
@@ -1111,8 +1150,9 @@ dependencies = [
 
 [[package]]
 name = "cubecl-macros"
-version = "0.10.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=e743e8f7b22b93378bab28b26916f7cf61321ccc#e743e8f7b22b93378bab28b26916f7cf61321ccc"
+version = "0.10.0-pre.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c11738ffab5f0bb73e9ec8399c30a3b623ad9d0fb5158a95e45963e282e3558e"
 dependencies = [
  "cubecl-common",
  "darling 0.23.0",
@@ -1127,8 +1167,9 @@ dependencies = [
 
 [[package]]
 name = "cubecl-macros-internal"
-version = "0.10.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=e743e8f7b22b93378bab28b26916f7cf61321ccc#e743e8f7b22b93378bab28b26916f7cf61321ccc"
+version = "0.10.0-pre.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38590997cab4c64b41568394e205e3e55df8b08ad0a7839fe558a10013bb3fa5"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -1138,8 +1179,9 @@ dependencies = [
 
 [[package]]
 name = "cubecl-opt"
-version = "0.10.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=e743e8f7b22b93378bab28b26916f7cf61321ccc#e743e8f7b22b93378bab28b26916f7cf61321ccc"
+version = "0.10.0-pre.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73afc2906ab743ddcf5c7f8c209abb7afb3365e511c99625da460bfa1a09df2e"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -1155,8 +1197,9 @@ dependencies = [
 
 [[package]]
 name = "cubecl-runtime"
-version = "0.10.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=e743e8f7b22b93378bab28b26916f7cf61321ccc#e743e8f7b22b93378bab28b26916f7cf61321ccc"
+version = "0.10.0-pre.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "934a5bd50210166a5a395c65fb9c38b865d79e81d203c5e3161b5f4e613a2335"
 dependencies = [
  "async-channel",
  "bytemuck",
@@ -1185,8 +1228,9 @@ dependencies = [
 
 [[package]]
 name = "cubecl-std"
-version = "0.10.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=e743e8f7b22b93378bab28b26916f7cf61321ccc#e743e8f7b22b93378bab28b26916f7cf61321ccc"
+version = "0.10.0-pre.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db3ae86be1776e9b562b9c62ee7342ca614b268f066f152f644164978c5f0cce"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -1201,8 +1245,9 @@ dependencies = [
 
 [[package]]
 name = "cubecl-wgpu"
-version = "0.10.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=e743e8f7b22b93378bab28b26916f7cf61321ccc#e743e8f7b22b93378bab28b26916f7cf61321ccc"
+version = "0.10.0-pre.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b883057d3ab663303d91bb32f4038700253f7d21ffda8f1f0785bb61eccaa4ee"
 dependencies = [
  "async-channel",
  "bytemuck",
@@ -1224,8 +1269,9 @@ dependencies = [
 
 [[package]]
 name = "cubecl-zspace"
-version = "0.10.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=e743e8f7b22b93378bab28b26916f7cf61321ccc#e743e8f7b22b93378bab28b26916f7cf61321ccc"
+version = "0.10.0-pre.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7102db7e3f401ad08bb3fb115747573e22baa13d8b1583102fae11fbf8f82998"
 dependencies = [
  "derive-new",
  "serde",
@@ -1234,8 +1280,9 @@ dependencies = [
 
 [[package]]
 name = "cubek"
-version = "0.2.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=33b437859e11b77728799475351faee01af25024#33b437859e11b77728799475351faee01af25024"
+version = "0.2.0-pre.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "311db9db82974a527feabc6cd456280681bf70cbba92ce348b5c68f7ca2e33aa"
 dependencies = [
  "cubecl",
  "cubek-attention",
@@ -1250,8 +1297,9 @@ dependencies = [
 
 [[package]]
 name = "cubek-attention"
-version = "0.2.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=33b437859e11b77728799475351faee01af25024#33b437859e11b77728799475351faee01af25024"
+version = "0.2.0-pre.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d85ac71e50450c381aec840c9ad37111b37a78fc30472271f52ab5f84a5f440"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -1264,8 +1312,9 @@ dependencies = [
 
 [[package]]
 name = "cubek-convolution"
-version = "0.2.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=33b437859e11b77728799475351faee01af25024#33b437859e11b77728799475351faee01af25024"
+version = "0.2.0-pre.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3308019366711665b13f7f9cc5b2cdf2374dedf5f206b82e973663332ae8a86"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -1280,8 +1329,9 @@ dependencies = [
 
 [[package]]
 name = "cubek-fft"
-version = "0.2.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=33b437859e11b77728799475351faee01af25024#33b437859e11b77728799475351faee01af25024"
+version = "0.2.0-pre.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b284d6c96b0fd072948e3784b2615558143e296da88e311926da04391dfe6f14"
 dependencies = [
  "cubecl",
  "cubek-test-utils",
@@ -1289,8 +1339,9 @@ dependencies = [
 
 [[package]]
 name = "cubek-matmul"
-version = "0.2.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=33b437859e11b77728799475351faee01af25024#33b437859e11b77728799475351faee01af25024"
+version = "0.2.0-pre.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c9ad9a2db6852cd8177d17401c9dad49a2cb400bb3286054ca36c267e65bd81"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -1302,8 +1353,9 @@ dependencies = [
 
 [[package]]
 name = "cubek-quant"
-version = "0.2.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=33b437859e11b77728799475351faee01af25024#33b437859e11b77728799475351faee01af25024"
+version = "0.2.0-pre.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "690e22564b27733bee35d185c9de82f73f36cab4555f08c3f07e9d4241f92db7"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -1313,8 +1365,9 @@ dependencies = [
 
 [[package]]
 name = "cubek-random"
-version = "0.2.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=33b437859e11b77728799475351faee01af25024#33b437859e11b77728799475351faee01af25024"
+version = "0.2.0-pre.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff0699ed05120c5b89aaaa93ca7f779a1c8060972a41b080b190524243f4f8c3"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -1326,8 +1379,9 @@ dependencies = [
 
 [[package]]
 name = "cubek-reduce"
-version = "0.2.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=33b437859e11b77728799475351faee01af25024#33b437859e11b77728799475351faee01af25024"
+version = "0.2.0-pre.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7a8637fc91e773eba6f946d149fd1e8f326f70ad1fbf0aee8374a91772c6a06"
 dependencies = [
  "cubecl",
  "cubek-std",
@@ -1339,8 +1393,9 @@ dependencies = [
 
 [[package]]
 name = "cubek-std"
-version = "0.2.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=33b437859e11b77728799475351faee01af25024#33b437859e11b77728799475351faee01af25024"
+version = "0.2.0-pre.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da75c710ba6aa1dba65ff864f5eb40cb6943aad8f54d554fe2ec2e7d35663a84"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -1349,8 +1404,9 @@ dependencies = [
 
 [[package]]
 name = "cubek-test-utils"
-version = "0.2.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=33b437859e11b77728799475351faee01af25024#33b437859e11b77728799475351faee01af25024"
+version = "0.2.0-pre.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07a88a5dcd387d9f3485d731aa3ca6d397a2d3cd7c18e8fde312a6fe6866d2ed"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -1473,6 +1529,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dary_heap"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06d2e3287df1c007e74221c49ca10a95d557349e54b3a75dc2fb14712c751f04"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1495,6 +1560,37 @@ checksum = "2cdc8d50f426189eef89dac62fabfa0abb27d5cc008f25bf4156a0203325becc"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
  "syn",
 ]
 
@@ -1733,6 +1829,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "esaxx-rs"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
+
+[[package]]
 name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1806,23 +1908,14 @@ checksum = "9a5404bf31d22893d61cf24d4dda149d8e6b2ff07601c3cb3be651031f61a4ed"
 
 [[package]]
 name = "float8"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719a903cc23e4a89e87962c2a80fdb45cdaad0983a89bd150bb57b4c8571a7d5"
-dependencies = [
- "half",
- "num-traits",
- "rand 0.9.2",
- "rand_distr 0.5.1",
-]
-
-[[package]]
-name = "float8"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2d1f04709a8ac06e8e8042875a3c466cc4832d3c1a18dbcb9dba3c6e83046bc"
 dependencies = [
  "half",
+ "num-traits",
+ "rand 0.9.2",
+ "rand_distr 0.5.1",
 ]
 
 [[package]]
@@ -2338,7 +2431,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -2749,6 +2842,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "macro_rules_attribute"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65049d7923698040cd0b1ddcced9b0eb14dd22c5f86ae59c3740eab64a676520"
+dependencies = [
+ "macro_rules_attribute-proc_macro",
+ "paste",
+]
+
+[[package]]
+name = "macro_rules_attribute-proc_macro"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670fdfda89751bc4a84ac13eaa63e205cf0fd22b4c9a5fbfa085b63c1f1d3a30"
+
+[[package]]
 name = "matrixmultiply"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2812,6 +2921,28 @@ name = "moddef"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a0b3262dc837d2513fe2ef31ff8461352ef932dcca31ba0c0abe33547cf6b9b"
+
+[[package]]
+name = "monostate"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3341a273f6c9d5bef1908f17b7267bbab0e95c9bf69a0d4dcf8e9e1b2c76ef67"
+dependencies = [
+ "monostate-impl",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "monostate-impl"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4db6d5580af57bf992f59068d4ea26fd518574ff48d7639b255a36f9de6e7e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "naga"
@@ -3104,6 +3235,28 @@ name = "oneshot"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe21416a02c693fb9f980befcb230ecc70b0b3d1cc4abf88b9675c4c1457f0c"
+
+[[package]]
+name = "onig"
+version = "6.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "336b9c63443aceef14bea841b899035ae3abe89b7c486aaf4c5bd8aafedac3f0"
+dependencies = [
+ "bitflags",
+ "libc",
+ "once_cell",
+ "onig_sys",
+]
+
+[[package]]
+name = "onig_sys"
+version = "69.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f86c6eef3d6df15f23bcfb6af487cbd2fed4e5581d58d5bf1f5f8b7f6727dc"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "option-ext"
@@ -3532,6 +3685,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon-cond"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2964d0cf57a3e7a06e8183d14a8b527195c706b7983549cd5462d5aa3747438f"
+dependencies = [
+ "either",
+ "itertools 0.14.0",
+ "rayon",
+]
+
+[[package]]
 name = "rayon-core"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3617,7 +3781,7 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-core",
@@ -4002,6 +4166,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "spm_precompiled"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5851699c4033c63636f7ea4cf7b7c1f1bf06d0cc03cfb42e711de5a5c46cf326"
+dependencies = [
+ "base64 0.13.1",
+ "nom 7.1.3",
+ "serde",
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "stable-vec"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4236,6 +4412,39 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokenizers"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b238e22d44a15349529690fb07bd645cf58149a1b1e44d6cb5bd1641ff1a6223"
+dependencies = [
+ "ahash",
+ "aho-corasick",
+ "compact_str",
+ "dary_heap",
+ "derive_builder",
+ "esaxx-rs",
+ "getrandom 0.3.4",
+ "itertools 0.14.0",
+ "log",
+ "macro_rules_attribute",
+ "monostate",
+ "onig",
+ "paste",
+ "rand 0.9.2",
+ "rayon",
+ "rayon-cond",
+ "regex",
+ "regex-syntax",
+ "serde",
+ "serde_json",
+ "spm_precompiled",
+ "thiserror 2.0.18",
+ "unicode-normalization-alignments",
+ "unicode-segmentation",
+ "unicode_categories",
+]
 
 [[package]]
 name = "tokio"
@@ -4541,6 +4750,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-normalization-alignments"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43f613e4fa046e69818dd287fdc4bc78175ff20331479dab6e1b0f98d57062de"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4588,7 +4806,7 @@ version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "flate2",
  "log",
  "once_cell",

--- a/scoreboard/runner/Cargo.toml
+++ b/scoreboard/runner/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2024"
 [workspace]
 
 [dependencies]
-burn = { git = "https://github.com/tracel-ai/burn", default-features = false, features = ["std"], rev = "c3917da4ea1e424e60a9a6d809dab0ef9ef39e14" }
-burn-ndarray = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "c3917da4ea1e424e60a9a6d809dab0ef9ef39e14" }
-burn-store = { git = "https://github.com/tracel-ai/burn", default-features = false, features = ["burnpack", "std"], rev = "c3917da4ea1e424e60a9a6d809dab0ef9ef39e14" }
+burn = { git = "https://github.com/tracel-ai/burn", default-features = false, features = ["std"], rev = "52998ac066953a02b5c18bfd236538235a2dac9f" }
+burn-ndarray = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "52998ac066953a02b5c18bfd236538235a2dac9f" }
+burn-store = { git = "https://github.com/tracel-ai/burn", default-features = false, features = ["burnpack", "std"], rev = "52998ac066953a02b5c18bfd236538235a2dac9f" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 


### PR DESCRIPTION
## Summary

- Bump workspace version from `0.21.0-pre.2` to `0.21.0-pre.3`
- Update sibling crate pins (`burn-import` → `burn-onnx`, `burn-onnx` → `onnx-ir`, `onnx-ir` → `onnx-ir-derive`) to `=0.21.0-pre.3`
- Point burn git dependencies at `52998ac0` (tag `v0.21.0-pre.3`, 4 commits ahead of previous rev, clean fast-forward)
- Sync `scoreboard/runner` burn rev to match (12 commits behind, clean fast-forward)
- Temporarily ignore `matmul::tests::matmul` with a comment referencing the upstream blocker

## Blocker: matmul 4D @ 1D regression

Burn `0.21.0-pre.3` shipped with an `unsqueeze_dims` regression introduced by tracel-ai/burn#4755 ("Fix `unsqueeze_dims` panic") that panics with an out-of-bounds read when axes contain duplicates after sorting. This is triggered by `burn-onnx`'s matmul codegen for the `4D @ 1D` broadcasting path, which emits `unsqueeze_dims(&[-1, 0, 0])` to lift a 1D vector to rank 4.

I filed the upstream fix at **tracel-ai/burn#4764**, which includes:
- A minimal normalization pass that bumps sorted duplicates to the next slot (`[0, 0, 3]` → `[0, 1, 3]`), matching the documented semantic
- Three regression tests covering the real-world `[-1, 0, 0]` pattern plus pure and interior duplicates

Until that merges and Burn cuts a release containing it, `matmul::tests::matmul` is marked `#[ignore]` with a clear pointer to the upstream PR. All other matmul tests (`matmul_ranks`, `matmul_scalar_add`, `matmulinteger::*`, and the attention QK-matmul suite) still pass.

## Test plan

- [x] `cargo check` (workspace default-members) passes
- [x] `cargo check` in `scoreboard/runner/` passes
- [x] `cargo test -p onnx-tests --test test_mod matmul` → 10 passed, 1 ignored, 0 failed
- [ ] Full `cargo test` / `cargo xtask validate` before merge

## Follow-ups

1. Once tracel-ai/burn#4764 merges and a new Burn release ships, bump `burn` deps again and remove the `#[ignore]` on `matmul::tests::matmul`.
2. Consider whether to additionally harden `burn-onnx`'s matmul codegen to emit distinct indices (`[0, 1, -1]` instead of `[-1, 0, 0]`) as a defensive measure against similar regressions.