### PR TITLE
Fix latent codegen correctness issues (#317)

### DIFF
--- a/crates/burn-onnx/src/burn/graph.rs
+++ b/crates/burn-onnx/src/burn/graph.rs
@@ -1109,10 +1109,11 @@ mod tests {
         graph
     }
 
-    /// Two Clip nodes feeding into each other with independent runtime
-    /// scalar bounds. The generated `__clip_min` / `__clip_max` temporaries
-    /// must each live inside their own block so the second instance doesn't
-    /// shadow or collide with the first at the outer scope.
+    /// Two Clip nodes chained through a single intermediate tensor,
+    /// each with its own independent runtime scalar bounds. The
+    /// generated `__clip_min` / `__clip_max` temporaries must each
+    /// live inside their own per-node block so clone-tracking and
+    /// name resolution don't interleave across the two instances.
     fn build_two_clip_chain() -> BurnGraph {
         use onnx_ir::clip::{ClipConfig, ClipNodeBuilder};
         use onnx_ir::node::clip::ClipInput;
@@ -1161,9 +1162,11 @@ mod tests {
     /// nodes emit their `__clip_min` / `__clip_max` temporaries inside
     /// per-node block scopes. Both instances should be present in the
     /// generated code, each wrapped in a `let out = { let __clip_min = ... };`
-    /// block. Before the fix, a flat `let __clip_min = ...;` at the outer
-    /// scope would have shadowed the first instance and miscompiled or
-    /// silently used the wrong bound on the second Clip.
+    /// block. Without the wrapper, both `let __clip_min = ...;` bindings
+    /// would land at the outer `forward` scope — still legal Rust, but
+    /// clone-tracking for the runtime-bound inputs and variable resolution
+    /// for downstream consumers would interleave across nodes in
+    /// hard-to-debug ways.
     #[test]
     fn multi_instance_clip_scoping() {
         let graph = build_two_clip_chain();

--- a/crates/burn-onnx/src/burn/graph.rs
+++ b/crates/burn-onnx/src/burn/graph.rs
@@ -1109,6 +1109,82 @@ mod tests {
         graph
     }
 
+    /// Two Clip nodes feeding into each other with independent runtime
+    /// scalar bounds. The generated `__clip_min` / `__clip_max` temporaries
+    /// must each live inside their own block so the second instance doesn't
+    /// shadow or collide with the first at the outer scope.
+    fn build_two_clip_chain() -> BurnGraph {
+        use onnx_ir::clip::{ClipConfig, ClipNodeBuilder};
+        use onnx_ir::node::clip::ClipInput;
+
+        let mut graph = BurnGraph::default();
+
+        let mk = |name: &str, in_tensor: &str, min_name: &str, max_name: &str, out: &str| {
+            ClipNodeBuilder::new(name)
+                .input_tensor(in_tensor, 2, DType::F32)
+                .input_scalar(min_name, DType::F32)
+                .input_scalar(max_name, DType::F32)
+                .output_tensor(out, 2, DType::F32)
+                .config(ClipConfig {
+                    min: Some(ClipInput::Runtime(onnx_ir::ir::RuntimeInputRef::new(
+                        min_name.to_string(),
+                        1,
+                    ))),
+                    max: Some(ClipInput::Runtime(onnx_ir::ir::RuntimeInputRef::new(
+                        max_name.to_string(),
+                        2,
+                    ))),
+                })
+                .build()
+        };
+
+        graph.register(Node::Clip(mk("clip0", "input", "min0", "max0", "t0")));
+        graph.register(Node::Clip(mk("clip1", "t0", "min1", "max1", "t1")));
+
+        graph.register_input_output(
+            vec![
+                "input".to_string(),
+                "min0".to_string(),
+                "max0".to_string(),
+                "min1".to_string(),
+                "max1".to_string(),
+            ],
+            vec!["t1".to_string()],
+            &[],
+            &[],
+        );
+
+        graph
+    }
+
+    /// Regression test for #317, issue 6: verifies that runtime-bound Clip
+    /// nodes emit their `__clip_min` / `__clip_max` temporaries inside
+    /// per-node block scopes. Both instances should be present in the
+    /// generated code, each wrapped in a `let out = { let __clip_min = ... };`
+    /// block. Before the fix, a flat `let __clip_min = ...;` at the outer
+    /// scope would have shadowed the first instance and miscompiled or
+    /// silently used the wrong bound on the second Clip.
+    #[test]
+    fn multi_instance_clip_scoping() {
+        let graph = build_two_clip_chain();
+        let code = format_tokens(graph.codegen());
+
+        // Both clip bodies must appear in the generated forward. We count
+        // occurrences of the temporary name to pin exactly-two scoping
+        // blocks; anything less means the wrapping got dropped, anything
+        // more means a regression leaked a third temporary somewhere.
+        assert_eq!(
+            code.matches("let __clip_min = ").count(),
+            2,
+            "expected exactly two scoped __clip_min temporaries, got:\n{code}"
+        );
+        assert_eq!(
+            code.matches("let __clip_max = ").count(),
+            2,
+            "expected exactly two scoped __clip_max temporaries, got:\n{code}"
+        );
+    }
+
     #[test]
     fn small_graph_uses_flat_codegen() {
         let graph = build_abs_chain(5);

--- a/crates/burn-onnx/src/burn/graph.rs
+++ b/crates/burn-onnx/src/burn/graph.rs
@@ -1158,34 +1158,93 @@ mod tests {
         graph
     }
 
+    /// Walk the generated Rust text and return the list of innermost
+    /// `{ ... }` blocks (as substrings of `code`, without the braces).
+    /// Used by scoping regression tests: counting raw occurrences of a
+    /// `let __foo` binding is not enough because the same bindings at
+    /// the outer `forward` scope would still pass. An innermost-block
+    /// scan lets us assert that the bindings sit inside a per-node
+    /// subscope, not at the function top level.
+    ///
+    /// "Innermost" means the block contains no nested `{...}` children.
+    /// Tracked per-block on the stack so siblings don't pollute each
+    /// other (a parent with one inner child is still a parent — not
+    /// innermost — but its other children can still qualify).
+    fn innermost_blocks(code: &str) -> Vec<&str> {
+        let bytes = code.as_bytes();
+        let mut stack: Vec<(usize, bool)> = Vec::new();
+        let mut innermost: Vec<(usize, usize)> = Vec::new();
+        for (i, &b) in bytes.iter().enumerate() {
+            match b {
+                b'{' => {
+                    if let Some(last) = stack.last_mut() {
+                        last.1 = true;
+                    }
+                    stack.push((i, false));
+                }
+                b'}' => {
+                    if let Some((open, has_inner)) = stack.pop()
+                        && !has_inner
+                    {
+                        innermost.push((open + 1, i));
+                    }
+                }
+                _ => {}
+            }
+        }
+        innermost.into_iter().map(|(s, e)| &code[s..e]).collect()
+    }
+
     /// Regression test for #317, issue 6: verifies that runtime-bound Clip
     /// nodes emit their `__clip_min` / `__clip_max` temporaries inside
-    /// per-node block scopes. Both instances should be present in the
-    /// generated code, each wrapped in a `let out = { let __clip_min = ... };`
-    /// block. Without the wrapper, both `let __clip_min = ...;` bindings
-    /// would land at the outer `forward` scope — still legal Rust, but
-    /// clone-tracking for the runtime-bound inputs and variable resolution
-    /// for downstream consumers would interleave across nodes in
-    /// hard-to-debug ways.
+    /// per-node block scopes rather than at the outer `forward` scope.
+    /// Without the wrapper block, both `let __clip_min = ...;` bindings
+    /// would land at the outer scope — still legal Rust, but
+    /// clone-tracking for the runtime-bound inputs and variable
+    /// resolution for downstream consumers would interleave across nodes
+    /// in hard-to-debug ways.
+    ///
+    /// The test walks the generated code to find every innermost `{ ... }`
+    /// block and counts the ones that contain both a `let __clip_min = `
+    /// and a `let __clip_max = `. That count must be exactly two (one per
+    /// Clip node). A raw `code.matches(...).count() == 2` would also pass
+    /// if both bindings were at the outer scope, which is exactly the
+    /// regression we are trying to rule out.
     #[test]
     fn multi_instance_clip_scoping() {
         let graph = build_two_clip_chain();
         let code = format_tokens(graph.codegen());
 
-        // Both clip bodies must appear in the generated forward. We count
-        // occurrences of the temporary name to pin exactly-two scoping
-        // blocks; anything less means the wrapping got dropped, anything
-        // more means a regression leaked a third temporary somewhere.
+        let scoped_blocks: Vec<&str> = innermost_blocks(&code)
+            .into_iter()
+            .filter(|b| b.contains("let __clip_min = ") && b.contains("let __clip_max = "))
+            .collect();
+
         assert_eq!(
-            code.matches("let __clip_min = ").count(),
+            scoped_blocks.len(),
             2,
-            "expected exactly two scoped __clip_min temporaries, got:\n{code}"
+            "expected exactly two innermost blocks each containing \
+             both `let __clip_min =` and `let __clip_max =`, got \
+             {} such blocks. Full generated code:\n{code}",
+            scoped_blocks.len()
         );
-        assert_eq!(
-            code.matches("let __clip_max = ").count(),
-            2,
-            "expected exactly two scoped __clip_max temporaries, got:\n{code}"
-        );
+
+        // Belt-and-braces: each scoped block must declare exactly one
+        // `__clip_min` and one `__clip_max`. A block containing two
+        // `__clip_min` bindings would mean two clip nodes collapsed into
+        // a single scope, which is the bug we are guarding against.
+        for (idx, block) in scoped_blocks.iter().enumerate() {
+            assert_eq!(
+                block.matches("let __clip_min = ").count(),
+                1,
+                "block {idx} should declare exactly one __clip_min, got:\n{block}"
+            );
+            assert_eq!(
+                block.matches("let __clip_max = ").count(),
+                1,
+                "block {idx} should declare exactly one __clip_max, got:\n{block}"
+            );
+        }
     }
 
     #[test]

--- a/crates/burn-onnx/src/burn/node/clip.rs
+++ b/crates/burn-onnx/src/burn/node/clip.rs
@@ -1,24 +1,57 @@
 use super::prelude::*;
 
+/// Which native scalar type a runtime Clip bound should be cast to.
+/// Picked once from the input tensor's dtype so the bound stays in a
+/// type that can represent every value the input can hold:
+///
+/// - `I64` for signed integer inputs (preserves the full i64 range).
+/// - `U64` for unsigned integer inputs (preserves the full u64 range,
+///   including values above i64::MAX that would wrap through `i64`).
+/// - `F64` for float inputs.
+#[derive(Clone, Copy)]
+enum ClipBoundCast {
+    I64,
+    U64,
+    F64,
+}
+
+impl ClipBoundCast {
+    fn from_dtype(dtype: burn::tensor::DType) -> Self {
+        if dtype.is_uint() {
+            Self::U64
+        } else if dtype.is_int() {
+            Self::I64
+        } else {
+            Self::F64
+        }
+    }
+
+    fn tokens(self) -> TokenStream {
+        match self {
+            Self::I64 => quote! { i64 },
+            Self::U64 => quote! { u64 },
+            Self::F64 => quote! { f64 },
+        }
+    }
+}
+
 /// Build a token stream that evaluates to a native scalar bound at runtime
 /// for a single Clip `min`/`max` input.
 ///
 /// Static bounds are inlined as literals. Runtime bounds come from one of
 /// the node's inputs, which is either a native scalar (use directly) or a
-/// scalar tensor (extract via `into_scalar().elem()`). The scalar is
-/// then coerced via an `as` cast to either `f64` or `i64`, depending on
-/// `input_is_int`. `input_is_int` should mirror the element type of the
-/// tensor being clipped: `true` for signed/unsigned int inputs (keeps
-/// full int64 magnitude), `false` for float inputs (feeds Burn's
-/// `clamp(E, E)` without dtype mixing). Getting `input_is_int` wrong
-/// would silently emit a bound in the wrong dtype and desynchronize the
-/// clamp call, so the caller computes it once from the input tensor's
-/// dtype rather than re-deriving it here.
+/// scalar tensor (extract via `into_scalar().elem()`). The scalar is then
+/// coerced via an `as` cast to the native type selected by `bound_cast`,
+/// which mirrors the element type of the tensor being clipped. The caller
+/// computes `bound_cast` once from the input tensor's dtype so the min
+/// and max bounds agree, and so the cast is always wide enough to
+/// represent every value in the input's dtype (u64 inputs in particular
+/// need `u64`, since `i64` would wrap at i64::MAX).
 fn clip_bound_expr(
     bound: &Option<onnx_ir::node::clip::ClipInput>,
     inputs: &[Argument],
     scope: &mut ScopeAtPosition<'_>,
-    input_is_int: bool,
+    bound_cast: ClipBoundCast,
 ) -> Option<TokenStream> {
     match bound {
         None => None,
@@ -28,11 +61,7 @@ fn clip_bound_expr(
         }
         Some(onnx_ir::node::clip::ClipInput::Runtime(r)) => {
             let arg = &inputs[r.input_index];
-            let cast_ty = if input_is_int {
-                quote! { i64 }
-            } else {
-                quote! { f64 }
-            };
+            let cast_ty = bound_cast.tokens();
             match &arg.ty {
                 ArgType::ScalarNative(_) => {
                     let ident = arg_to_ident(arg);
@@ -64,16 +93,17 @@ impl NodeCodegen for onnx_ir::clip::ClipNode {
         let output = arg_to_ident(self.outputs.first().unwrap());
 
         // The input dtype determines whether runtime bounds should be
-        // carried as i64 (full int64 precision) or f64 (avoiding a needless
-        // int cast when the input is already float).
+        // carried as i64, u64, or f64. Picking the widest type that can
+        // hold every value in the input's dtype avoids silently wrapping
+        // large bounds through a narrower intermediate.
         let input_dtype = self.inputs.first().unwrap().ty.elem_type();
-        let input_is_int = input_dtype.is_int() || input_dtype.is_uint();
+        let bound_cast = ClipBoundCast::from_dtype(input_dtype);
 
         // Extract bound expressions first so the `match (min_expr, max_expr)`
         // below is a straight token-stream assembly rather than a nested
         // branch on the enum structure.
-        let min_expr = clip_bound_expr(&self.config.min, &self.inputs, scope, input_is_int);
-        let max_expr = clip_bound_expr(&self.config.max, &self.inputs, scope, input_is_int);
+        let min_expr = clip_bound_expr(&self.config.min, &self.inputs, scope, bound_cast);
+        let max_expr = clip_bound_expr(&self.config.max, &self.inputs, scope, bound_cast);
         let input = scope.arg(self.inputs.first().unwrap());
 
         match (min_expr, max_expr) {
@@ -265,6 +295,41 @@ mod tests {
         ) -> Tensor<B, 2, Int> {
             let output = {
                 let __clip_min = (min_val.into_scalar().elem::<i64>() as i64);
+                input.clamp_min(__clip_min)
+            };
+            output
+        }
+        ");
+    }
+
+    #[test]
+    fn test_clip_runtime_uint_scalar_tensor() {
+        // Clipping a U64 tensor with a runtime u64 scalar bound must keep
+        // the bound as u64. Routing a u64 bound through i64 would wrap any
+        // value above i64::MAX into a large negative number and silently
+        // produce the wrong clip result. This test pins the u64 lowering.
+        let config = ClipConfig {
+            min: Some(ClipInput::Runtime(onnx_ir::ir::RuntimeInputRef::new(
+                "min_val".to_string(),
+                1,
+            ))),
+            max: None,
+        };
+        let node = ClipNodeBuilder::new("clip1")
+            .input_tensor("input", 2, DType::U64)
+            .input_scalar_tensor("min_val", DType::U64)
+            .output_tensor("output", 2, DType::U64)
+            .config(config)
+            .build();
+        let code = codegen_forward_default(&node);
+        assert_snapshot!(code, @r"
+        pub fn forward(
+            &self,
+            input: Tensor<B, 2, Int>,
+            min_val: Tensor<B, 1, Int>,
+        ) -> Tensor<B, 2, Int> {
+            let output = {
+                let __clip_min = (min_val.into_scalar().elem::<u64>() as u64);
                 input.clamp_min(__clip_min)
             };
             output

--- a/crates/burn-onnx/src/burn/node/clip.rs
+++ b/crates/burn-onnx/src/burn/node/clip.rs
@@ -6,9 +6,14 @@ use super::prelude::*;
 /// Static bounds are inlined as literals. Runtime bounds come from one of
 /// the node's inputs, which is either a native scalar (use directly) or a
 /// scalar tensor (extract via `into_scalar().elem()`). The scalar is
-/// coerced to `f64` for float-typed clips and to `i64` for integer-typed
-/// clips, so we keep full i64 precision instead of rounding through f64
-/// (which loses magnitudes above 2^53).
+/// then coerced via an `as` cast to either `f64` or `i64`, depending on
+/// `input_is_int`. `input_is_int` should mirror the element type of the
+/// tensor being clipped: `true` for signed/unsigned int inputs (keeps
+/// full int64 magnitude), `false` for float inputs (feeds Burn's
+/// `clamp(E, E)` without dtype mixing). Getting `input_is_int` wrong
+/// would silently emit a bound in the wrong dtype and desynchronize the
+/// clamp call, so the caller computes it once from the input tensor's
+/// dtype rather than re-deriving it here.
 fn clip_bound_expr(
     bound: &Option<onnx_ir::node::clip::ClipInput>,
     inputs: &[Argument],

--- a/crates/burn-onnx/src/burn/node/clip.rs
+++ b/crates/burn-onnx/src/burn/node/clip.rs
@@ -1,17 +1,19 @@
 use super::prelude::*;
 
-/// Build a token stream that evaluates to an `f64` bound at runtime for a
-/// single Clip `min`/`max` input.
+/// Build a token stream that evaluates to a native scalar bound at runtime
+/// for a single Clip `min`/`max` input.
 ///
 /// Static bounds are inlined as literals. Runtime bounds come from one of
 /// the node's inputs, which is either a native scalar (use directly) or a
-/// scalar tensor (extract via `into_scalar().elem()`). Everything is
-/// coerced to `f64` so the caller can feed both `min` and `max` into
-/// Burn's `clamp(E, E)` without dtype mixing.
+/// scalar tensor (extract via `into_scalar().elem()`). The scalar is
+/// coerced to `f64` for float-typed clips and to `i64` for integer-typed
+/// clips, so we keep full i64 precision instead of rounding through f64
+/// (which loses magnitudes above 2^53).
 fn clip_bound_expr(
     bound: &Option<onnx_ir::node::clip::ClipInput>,
     inputs: &[Argument],
     scope: &mut ScopeAtPosition<'_>,
+    input_is_int: bool,
 ) -> Option<TokenStream> {
     match bound {
         None => None,
@@ -21,15 +23,20 @@ fn clip_bound_expr(
         }
         Some(onnx_ir::node::clip::ClipInput::Runtime(r)) => {
             let arg = &inputs[r.input_index];
+            let cast_ty = if input_is_int {
+                quote! { i64 }
+            } else {
+                quote! { f64 }
+            };
             match &arg.ty {
                 ArgType::ScalarNative(_) => {
                     let ident = arg_to_ident(arg);
-                    Some(quote! { (#ident as f64) })
+                    Some(quote! { (#ident as #cast_ty) })
                 }
                 ArgType::ScalarTensor(dtype) => {
                     let tensor = scope.arg(arg);
                     let native = on_device_to_native(quote! { #tensor }, dtype);
-                    Some(quote! { (#native as f64) })
+                    Some(quote! { (#native as #cast_ty) })
                 }
                 other => panic!(
                     "Clip min/max must be a scalar (ScalarNative or ScalarTensor), got {other:?}"
@@ -51,11 +58,17 @@ impl NodeCodegen for onnx_ir::clip::ClipNode {
     fn forward(&self, scope: &mut ScopeAtPosition<'_>) -> TokenStream {
         let output = arg_to_ident(self.outputs.first().unwrap());
 
+        // The input dtype determines whether runtime bounds should be
+        // carried as i64 (full int64 precision) or f64 (avoiding a needless
+        // int cast when the input is already float).
+        let input_dtype = self.inputs.first().unwrap().ty.elem_type();
+        let input_is_int = input_dtype.is_int() || input_dtype.is_uint();
+
         // Extract bound expressions first so the `match (min_expr, max_expr)`
         // below is a straight token-stream assembly rather than a nested
         // branch on the enum structure.
-        let min_expr = clip_bound_expr(&self.config.min, &self.inputs, scope);
-        let max_expr = clip_bound_expr(&self.config.max, &self.inputs, scope);
+        let min_expr = clip_bound_expr(&self.config.min, &self.inputs, scope, input_is_int);
+        let max_expr = clip_bound_expr(&self.config.max, &self.inputs, scope, input_is_int);
         let input = scope.arg(self.inputs.first().unwrap());
 
         match (min_expr, max_expr) {
@@ -213,6 +226,41 @@ mod tests {
                 let __clip_min = (min_val.into_scalar().elem::<f32>() as f64);
                 let __clip_max = (max_val.into_scalar().elem::<f32>() as f64);
                 input.clamp(__clip_min, __clip_max)
+            };
+            output
+        }
+        ");
+    }
+
+    #[test]
+    fn test_clip_runtime_int_scalar_tensor() {
+        // Clipping an Int tensor with a runtime int scalar bound must keep
+        // the bound as i64, not narrow it through f64. For typical int
+        // magnitudes above 2^53, an `as f64` cast would silently round and
+        // produce wrong clip results. This test pins the i64 lowering.
+        let config = ClipConfig {
+            min: Some(ClipInput::Runtime(onnx_ir::ir::RuntimeInputRef::new(
+                "min_val".to_string(),
+                1,
+            ))),
+            max: None,
+        };
+        let node = ClipNodeBuilder::new("clip1")
+            .input_tensor("input", 2, DType::I64)
+            .input_scalar_tensor("min_val", DType::I64)
+            .output_tensor("output", 2, DType::I64)
+            .config(config)
+            .build();
+        let code = codegen_forward_default(&node);
+        assert_snapshot!(code, @r"
+        pub fn forward(
+            &self,
+            input: Tensor<B, 2, Int>,
+            min_val: Tensor<B, 1, Int>,
+        ) -> Tensor<B, 2, Int> {
+            let output = {
+                let __clip_min = (min_val.into_scalar().elem::<i64>() as i64);
+                input.clamp_min(__clip_min)
             };
             output
         }

--- a/crates/burn-onnx/src/burn/node/modulo.rs
+++ b/crates/burn-onnx/src/burn/node/modulo.rs
@@ -59,11 +59,25 @@ impl NodeCodegen for onnx_ir::modulo::ModNode {
                     let #output = #lhs.#mod_op(#rhs);
                 }
             }
-            (ArgType::ScalarNative(_), ArgType::ScalarNative(_)) => {
+            (ArgType::ScalarNative(lhs_dtype), ArgType::ScalarNative(_)) => {
                 let lhs = arg_to_ident(lhs_arg);
                 let rhs = arg_to_ident(rhs_arg);
+                // ONNX Mod with fmod=0 (default) is Python-style: the result
+                // has the sign of the divisor. Rust's `%` is C-style: the
+                // result has the sign of the dividend. They coincide on
+                // non-negative integers and on floats, but diverge on signed
+                // integers with a negative operand. Use `rem_euclid` for the
+                // signed-integer fmod=0 case to get Python semantics. For
+                // floats and for fmod=1 (C-style fmod), `%` is already
+                // correct. Unsigned ints can never produce a negative result
+                // so `%` is also correct there.
+                let expr = if !self.config.fmod && lhs_dtype.is_int() {
+                    quote! { #lhs.rem_euclid(#rhs) }
+                } else {
+                    quote! { #lhs % #rhs }
+                };
                 quote! {
-                    let #output = #lhs % #rhs;
+                    let #output = #expr;
                 }
             }
             (ArgType::ScalarNative(dtype), rhs_ty) if rhs_ty.is_on_device() => {
@@ -445,6 +459,71 @@ mod tests {
                 }
                 __lhs.expand(__shape).remainder(__rhs.expand(__shape))
             };
+            output
+        }
+        ");
+    }
+
+    // --- ScalarNative + ScalarNative ---
+
+    #[test]
+    fn test_remainder_scalar_native_scalar_native_signed_int() {
+        // ONNX Mod fmod=0 on signed ints is Python-style: sign follows
+        // divisor. Rust's `%` is C-style (sign follows dividend), so we
+        // must lower to `rem_euclid` to match ONNX semantics on negative
+        // inputs. Without this fix, Mod(-7, 3) would emit `a % b`, which
+        // evaluates to -1 in Rust versus ONNX's 2.
+        let config = ModConfig::new(false);
+        let node = ModNodeBuilder::new("mod1")
+            .input_scalar("a", DType::I64)
+            .input_scalar("b", DType::I64)
+            .output_scalar("output", DType::I64)
+            .config(config)
+            .build();
+        assert_snapshot!(codegen_forward_default(&node), @r"
+        pub fn forward(&self, a: i64, b: i64) -> i64 {
+            let output = a.rem_euclid(b);
+            output
+        }
+        ");
+    }
+
+    #[test]
+    fn test_fmod_scalar_native_scalar_native_signed_int() {
+        // fmod=1 is C-style (sign follows dividend), which matches Rust's
+        // `%` directly. No `rem_euclid` call.
+        let config = ModConfig::new(true);
+        let node = ModNodeBuilder::new("mod1")
+            .input_scalar("a", DType::I64)
+            .input_scalar("b", DType::I64)
+            .output_scalar("output", DType::I64)
+            .config(config)
+            .build();
+        assert_snapshot!(codegen_forward_default(&node), @r"
+        pub fn forward(&self, a: i64, b: i64) -> i64 {
+            let output = a % b;
+            output
+        }
+        ");
+    }
+
+    #[test]
+    fn test_remainder_scalar_native_scalar_native_float() {
+        // Floats have identical semantics for Python-style mod and C-style
+        // fmod on non-negative inputs, and Rust's `%` on floats is already
+        // C-style. For `fmod=0` on float ScalarNatives we still use `%`
+        // because there is no signed-integer sign flip to worry about and
+        // `rem_euclid` on floats would silently change results.
+        let config = ModConfig::new(false);
+        let node = ModNodeBuilder::new("mod1")
+            .input_scalar("a", DType::F32)
+            .input_scalar("b", DType::F32)
+            .output_scalar("output", DType::F32)
+            .config(config)
+            .build();
+        assert_snapshot!(codegen_forward_default(&node), @r"
+        pub fn forward(&self, a: f32, b: f32) -> f32 {
+            let output = a % b;
             output
         }
         ");

--- a/crates/burn-onnx/src/burn/node/modulo.rs
+++ b/crates/burn-onnx/src/burn/node/modulo.rs
@@ -509,11 +509,15 @@ mod tests {
 
     #[test]
     fn test_remainder_scalar_native_scalar_native_float() {
-        // Floats have identical semantics for Python-style mod and C-style
-        // fmod on non-negative inputs, and Rust's `%` on floats is already
-        // C-style. For `fmod=0` on float ScalarNatives we still use `%`
-        // because there is no signed-integer sign flip to worry about and
-        // `rem_euclid` on floats would silently change results.
+        // ONNX Mod with `fmod=0` on float operands is out of spec: the
+        // ONNX Mod op requires `fmod=1` whenever the operands are
+        // floating-point, so a well-formed graph never reaches this
+        // branch with floats and `fmod=0`. We keep Rust's `%` here
+        // because it matches C-style fmod (which is what `fmod=1` asks
+        // for) and because the signed-int-only `rem_euclid` guard
+        // naturally skips floats. This test just pins that the emitted
+        // code is a plain `%` so any future refactor that conflates the
+        // float and signed-int arms shows up as a snapshot diff.
         let config = ModConfig::new(false);
         let node = ModNodeBuilder::new("mod1")
             .input_scalar("a", DType::F32)

--- a/crates/burn-onnx/src/burn/node/one_hot.rs
+++ b/crates/burn-onnx/src/burn/node/one_hot.rs
@@ -130,13 +130,17 @@ impl NodeCodegen for onnx_ir::one_hot::OneHotNode {
         // the generated code doesn't leak the backend default (CLAUDE.md).
         //
         // For the runtime-values int path we call `one_hot_fill(1.0, 0.0)`
-        // to get a 0/1 mask and scale via int64 scalar math:
+        // to get a 0/1 mask and scale via integer scalar math:
         //     result = mask * (on - off) + off
-        // The mul/add happen in the backend's default Int dtype (i64-wide
-        // on typical backends), so the full int64 range is preserved before
-        // the final narrowing cast to the ONNX-specified output dtype.
+        // The backend default IntElem can be narrower than i64 (burn-flex
+        // defaults to i32), so we force an explicit `.cast(I64)` before
+        // `mul_scalar`/`add_scalar`: the scale math then runs in i64 on
+        // every backend, and the final narrowing cast back to the ONNX
+        // output dtype happens in one place.
         let int_scale = quote! {
-            .mul_scalar(__onehot_on_i - __onehot_off_i).add_scalar(__onehot_off_i)
+            .cast(burn::tensor::DType::I64)
+                .mul_scalar(__onehot_on_i - __onehot_off_i)
+                .add_scalar(__onehot_off_i)
         };
         let maybe_scale = if runtime_int_scale {
             int_scale.clone()
@@ -409,8 +413,10 @@ mod tests {
         // int64 precision. The old code path narrowed `values` through f32,
         // which silently rounded magnitudes above 2^24. The fix reads the
         // two values as i64, calls `one_hot_fill(1.0, 0.0)` to get a 0/1
-        // mask, and scales with exact int64 scalar arithmetic before the
-        // final cast to the ONNX-specified output dtype.
+        // mask, explicitly casts that mask to I64 (burn-flex's default
+        // IntElem is i32, so an implicit `.int()` would still lose bits),
+        // then scales via i64 scalar math before the final narrowing
+        // cast to the ONNX-specified output dtype.
         let config = OneHotConfig::new(
             OneHotDepthInput::Static(5),
             OneHotValuesInput::Runtime(onnx_ir::ir::RuntimeInputRef::new("values".to_string(), 1)),
@@ -437,6 +443,52 @@ mod tests {
                 };
                 indices
                     .one_hot_fill(5usize, 1f32, 0f32, -1i64)
+                    .cast(burn::tensor::DType::I64)
+                    .mul_scalar(__onehot_on_i - __onehot_off_i)
+                    .add_scalar(__onehot_off_i)
+                    .cast(burn::tensor::DType::I64)
+            };
+            output
+        }
+        ");
+    }
+
+    #[test]
+    fn test_one_hot_runtime_values_float_indices_int_output() {
+        // Companion to test_one_hot_runtime_values_int_output but with
+        // float indices, exercising the `(Float, Int)` match arm that
+        // chains `.int()` before the int64 scale. The `.int()` narrows to
+        // the backend default IntElem (i32 on burn-flex), and the
+        // subsequent explicit `.cast(I64)` widens back to i64 so the
+        // scale math stays precise regardless of backend.
+        let config = OneHotConfig::new(
+            OneHotDepthInput::Static(5),
+            OneHotValuesInput::Runtime(onnx_ir::ir::RuntimeInputRef::new("values".to_string(), 1)),
+            -1,
+        );
+        let node = OneHotNodeBuilder::new("onehot_rt_float_to_int")
+            .input_tensor("indices", 1, DType::F32)
+            .input_tensor("values", 1, DType::I64)
+            .output_tensor("output", 2, DType::I64)
+            .config(config)
+            .build();
+        let code = codegen_forward_default(&node);
+        assert_snapshot!(code, @r"
+        pub fn forward(
+            &self,
+            indices: Tensor<B, 1>,
+            values: Tensor<B, 1, Int>,
+        ) -> Tensor<B, 2, Int> {
+            let output = {
+                let (__onehot_off_i, __onehot_on_i): (i64, i64) = {
+                    let __data = values.to_data().convert::<i64>();
+                    let __slice = __data.as_slice::<i64>().unwrap();
+                    (__slice[0], __slice[1])
+                };
+                indices
+                    .one_hot_fill(5usize, 1f32, 0f32, -1i64)
+                    .int()
+                    .cast(burn::tensor::DType::I64)
                     .mul_scalar(__onehot_on_i - __onehot_off_i)
                     .add_scalar(__onehot_off_i)
                     .cast(burn::tensor::DType::I64)

--- a/crates/burn-onnx/src/burn/node/one_hot.rs
+++ b/crates/burn-onnx/src/burn/node/one_hot.rs
@@ -31,7 +31,11 @@ impl NodeCodegen for onnx_ir::one_hot::OneHotNode {
                         // OneHot, but models in the wild occasionally emit
                         // broken graphs; letting a negative i64 wrap to a
                         // huge usize causes OOM or a cryptic deep-burn
-                        // panic, so we fail loudly upstream instead.
+                        // panic, so we clamp invalid negative depths to 0.
+                        // This silently produces a zero-class one_hot result
+                        // for broken models; adding observability
+                        // (`log::warn!` or `debug_assert!`) is tracked in
+                        // tracel-ai/burn-onnx#328.
                         prelude.extend(quote! {
                             let __onehot_depth: usize = (#ident as i64).max(0) as usize;
                         });
@@ -79,42 +83,78 @@ impl NodeCodegen for onnx_ir::one_hot::OneHotNode {
         // Runtime values widen through an intermediate scalar because Burn's
         // `one_hot_fill` pins `on_value`/`off_value` to `f32`. For a float
         // output, f32 matches the downstream dtype. For an int output, f32
-        // rounds int64 magnitudes above 2^24, so for the runtime+int case we
-        // take a different path: call `one_hot_fill(1.0, 0.0)` to produce a
-        // 0/1 mask, cast to the int output dtype, then scale via exact
-        // int64 scalar arithmetic. `one_hot_fill`'s off_value=0 / on_value=1
-        // are exactly representable in f32, and all subsequent math is
-        // integer, so the full int64 range is preserved.
-        let (on_value, off_value, runtime_int_scale) = match &self.config.values {
+        // rounds magnitudes above 2^24, so for the runtime+int case we
+        // take a different path: call `one_hot_fill(1.0, 0.0)` to produce
+        // a 0/1 mask, cast to a wide integer (i64 for signed output, u64
+        // for unsigned output), scale via `mul_scalar`/`add_scalar` using
+        // wrapping arithmetic, then narrow to the ONNX-specified output
+        // dtype. `wrapping_sub` is safe here because the mask is always
+        // 0 or 1:
+        //     mask=0: 0 * (on - off) + off = off
+        //     mask=1: (on - off) + off = on  (wrapping math cancels)
+        // Picking `U64` for unsigned outputs preserves the full u64 range;
+        // routing through `i64` would wrap values above i64::MAX.
+        #[derive(Clone, Copy, PartialEq, Eq)]
+        enum RuntimeValuesMode {
+            /// Output is floating-point; narrow values through f32.
+            Float,
+            /// Output is a signed integer; scale in i64 via wrapping math.
+            SignedInt,
+            /// Output is an unsigned integer; scale in u64 via wrapping math.
+            UnsignedInt,
+        }
+        let runtime_values_mode = match output_kind {
+            TensorKind::Int if output_dtype.is_uint() => RuntimeValuesMode::UnsignedInt,
+            TensorKind::Int => RuntimeValuesMode::SignedInt,
+            _ => RuntimeValuesMode::Float,
+        };
+
+        let (on_value, off_value) = match &self.config.values {
             onnx_ir::one_hot::OneHotValuesInput::Static(v) => {
                 let off = v[0];
                 let on = v[1];
-                (quote! { #on }, quote! { #off }, false)
+                (quote! { #on }, quote! { #off })
             }
             onnx_ir::one_hot::OneHotValuesInput::Runtime(r) => {
                 let arg = &self.inputs[r.input_index];
                 let tensor = scope.arg(arg);
-                if output_kind == TensorKind::Int {
-                    // values layout: [off_value, on_value]. Read as i64 so
-                    // the full int64 range survives.
-                    prelude.extend(quote! {
-                        let (__onehot_off_i, __onehot_on_i): (i64, i64) = {
-                            let __data = #tensor.to_data().convert::<i64>();
-                            let __slice = __data.as_slice::<i64>().unwrap();
-                            (__slice[0], __slice[1])
-                        };
-                    });
-                    // Use a 0/1 mask; the scale is applied later.
-                    (quote! { 1f32 }, quote! { 0f32 }, true)
-                } else {
-                    prelude.extend(quote! {
-                        let (__onehot_off, __onehot_on): (f32, f32) = {
-                            let __data = #tensor.to_data().convert::<f32>();
-                            let __slice = __data.as_slice::<f32>().unwrap();
-                            (__slice[0], __slice[1])
-                        };
-                    });
-                    (quote! { __onehot_on }, quote! { __onehot_off }, false)
+                match runtime_values_mode {
+                    RuntimeValuesMode::UnsignedInt => {
+                        // values layout: [off_value, on_value]. Read as
+                        // u64 so the full u64 range survives.
+                        prelude.extend(quote! {
+                            let (__onehot_off_u, __onehot_on_u): (u64, u64) = {
+                                let __data = #tensor.to_data().convert::<u64>();
+                                let __slice = __data.as_slice::<u64>().unwrap();
+                                (__slice[0], __slice[1])
+                            };
+                        });
+                        // Use a 0/1 mask; the scale is applied later.
+                        (quote! { 1f32 }, quote! { 0f32 })
+                    }
+                    RuntimeValuesMode::SignedInt => {
+                        // values layout: [off_value, on_value]. Read as
+                        // i64 so the full int64 range survives.
+                        prelude.extend(quote! {
+                            let (__onehot_off_i, __onehot_on_i): (i64, i64) = {
+                                let __data = #tensor.to_data().convert::<i64>();
+                                let __slice = __data.as_slice::<i64>().unwrap();
+                                (__slice[0], __slice[1])
+                            };
+                        });
+                        // Use a 0/1 mask; the scale is applied later.
+                        (quote! { 1f32 }, quote! { 0f32 })
+                    }
+                    RuntimeValuesMode::Float => {
+                        prelude.extend(quote! {
+                            let (__onehot_off, __onehot_on): (f32, f32) = {
+                                let __data = #tensor.to_data().convert::<f32>();
+                                let __slice = __data.as_slice::<f32>().unwrap();
+                                (__slice[0], __slice[1])
+                            };
+                        });
+                        (quote! { __onehot_on }, quote! { __onehot_off })
+                    }
                 }
             }
         };
@@ -129,21 +169,35 @@ impl NodeCodegen for onnx_ir::one_hot::OneHotNode {
         // runtime dtype. Always cast to the ONNX-specified output dtype so
         // the generated code doesn't leak the backend default (CLAUDE.md).
         //
-        // For the runtime-values int path we call `one_hot_fill(1.0, 0.0)`
+        // For the runtime-values int paths we call `one_hot_fill(1.0, 0.0)`
         // to get a 0/1 mask and scale via integer scalar math:
         //     result = mask * (on - off) + off
         // The backend default IntElem can be narrower than i64 (burn-flex
-        // defaults to i32), so we force an explicit `.cast(I64)` before
-        // `mul_scalar`/`add_scalar`: the scale math then runs in i64 on
-        // every backend, and the final narrowing cast back to the ONNX
-        // output dtype happens in one place.
-        let int_scale = quote! {
-            .cast(burn::tensor::DType::I64)
-                .mul_scalar(__onehot_on_i - __onehot_off_i)
-                .add_scalar(__onehot_off_i)
-        };
-        let maybe_scale = if runtime_int_scale {
-            int_scale.clone()
+        // defaults to i32), so we force an explicit `.cast(I64|U64)` before
+        // `mul_scalar`/`add_scalar`: the scale math then runs in a type
+        // wide enough to represent every value the output dtype can hold,
+        // and the final narrowing cast back to the ONNX output dtype
+        // happens in one place. `wrapping_sub` is used so the unsigned
+        // case computes correctly (mask=0 -> off; mask=1 -> on, with the
+        // wrap canceling out).
+        let runtime_values_is_runtime = matches!(
+            self.config.values,
+            onnx_ir::one_hot::OneHotValuesInput::Runtime(_)
+        );
+        let maybe_scale = if runtime_values_is_runtime {
+            match runtime_values_mode {
+                RuntimeValuesMode::UnsignedInt => quote! {
+                    .cast(burn::tensor::DType::U64)
+                        .mul_scalar(__onehot_on_u.wrapping_sub(__onehot_off_u))
+                        .add_scalar(__onehot_off_u)
+                },
+                RuntimeValuesMode::SignedInt => quote! {
+                    .cast(burn::tensor::DType::I64)
+                        .mul_scalar(__onehot_on_i.wrapping_sub(__onehot_off_i))
+                        .add_scalar(__onehot_off_i)
+                },
+                RuntimeValuesMode::Float => TokenStream::new(),
+            }
         } else {
             TokenStream::new()
         };
@@ -444,7 +498,7 @@ mod tests {
                 indices
                     .one_hot_fill(5usize, 1f32, 0f32, -1i64)
                     .cast(burn::tensor::DType::I64)
-                    .mul_scalar(__onehot_on_i - __onehot_off_i)
+                    .mul_scalar(__onehot_on_i.wrapping_sub(__onehot_off_i))
                     .add_scalar(__onehot_off_i)
                     .cast(burn::tensor::DType::I64)
             };
@@ -489,9 +543,54 @@ mod tests {
                     .one_hot_fill(5usize, 1f32, 0f32, -1i64)
                     .int()
                     .cast(burn::tensor::DType::I64)
-                    .mul_scalar(__onehot_on_i - __onehot_off_i)
+                    .mul_scalar(__onehot_on_i.wrapping_sub(__onehot_off_i))
                     .add_scalar(__onehot_off_i)
                     .cast(burn::tensor::DType::I64)
+            };
+            output
+        }
+        ");
+    }
+
+    #[test]
+    fn test_one_hot_runtime_values_uint_output() {
+        // Runtime values with an unsigned output dtype (U64) must read
+        // through u64 and scale in U64 so the full u64 range survives.
+        // Routing through i64 would wrap any on/off value above i64::MAX
+        // into a large negative intermediate, silently producing wrong
+        // results after the final cast. `wrapping_sub` is safe because the
+        // mask is 0 or 1: mask=0 -> 0 + off = off, mask=1 -> (on - off)
+        // + off = on under wrapping arithmetic.
+        let config = OneHotConfig::new(
+            OneHotDepthInput::Static(5),
+            OneHotValuesInput::Runtime(onnx_ir::ir::RuntimeInputRef::new("values".to_string(), 1)),
+            -1,
+        );
+        let node = OneHotNodeBuilder::new("onehot_rt_uint")
+            .input_tensor("indices", 1, DType::I64)
+            .input_tensor("values", 1, DType::U64)
+            .output_tensor("output", 2, DType::U64)
+            .config(config)
+            .build();
+        let code = codegen_forward_default(&node);
+        assert_snapshot!(code, @r"
+        pub fn forward(
+            &self,
+            indices: Tensor<B, 1, Int>,
+            values: Tensor<B, 1, Int>,
+        ) -> Tensor<B, 2, Int> {
+            let output = {
+                let (__onehot_off_u, __onehot_on_u): (u64, u64) = {
+                    let __data = values.to_data().convert::<u64>();
+                    let __slice = __data.as_slice::<u64>().unwrap();
+                    (__slice[0], __slice[1])
+                };
+                indices
+                    .one_hot_fill(5usize, 1f32, 0f32, -1i64)
+                    .cast(burn::tensor::DType::U64)
+                    .mul_scalar(__onehot_on_u.wrapping_sub(__onehot_off_u))
+                    .add_scalar(__onehot_off_u)
+                    .cast(burn::tensor::DType::U64)
             };
             output
         }

--- a/crates/burn-onnx/src/burn/node/one_hot.rs
+++ b/crates/burn-onnx/src/burn/node/one_hot.rs
@@ -26,8 +26,14 @@ impl NodeCodegen for onnx_ir::one_hot::OneHotNode {
                 match &arg.ty {
                     ArgType::ScalarNative(_) => {
                         let ident = arg_to_ident(arg);
+                        // Clamp with `max(0)` before the `as usize` cast.
+                        // A negative runtime depth is out-of-spec for ONNX
+                        // OneHot, but models in the wild occasionally emit
+                        // broken graphs; letting a negative i64 wrap to a
+                        // huge usize causes OOM or a cryptic deep-burn
+                        // panic, so we fail loudly upstream instead.
                         prelude.extend(quote! {
-                            let __onehot_depth: usize = #ident as usize;
+                            let __onehot_depth: usize = (#ident as i64).max(0) as usize;
                         });
                     }
                     ArgType::ScalarTensor(_) | ArgType::Tensor(_) => {
@@ -35,7 +41,7 @@ impl NodeCodegen for onnx_ir::one_hot::OneHotNode {
                         prelude.extend(quote! {
                             let __onehot_depth: usize = {
                                 let __data = #tensor.to_data().convert::<i64>();
-                                __data.as_slice::<i64>().unwrap()[0] as usize
+                                __data.as_slice::<i64>().unwrap()[0].max(0) as usize
                             };
                         });
                     }
@@ -44,35 +50,6 @@ impl NodeCodegen for onnx_ir::one_hot::OneHotNode {
                     }
                 }
                 quote! { __onehot_depth }
-            }
-        };
-
-        let (on_value, off_value) = match &self.config.values {
-            onnx_ir::one_hot::OneHotValuesInput::Static(v) => {
-                let off = v[0];
-                let on = v[1];
-                (quote! { #on }, quote! { #off })
-            }
-            onnx_ir::one_hot::OneHotValuesInput::Runtime(r) => {
-                let arg = &self.inputs[r.input_index];
-                let tensor = scope.arg(arg);
-                // The values input is a rank-1 tensor [off_value, on_value].
-                // Burn's `one_hot_fill` signature pins `on_value`/`off_value`
-                // to concrete `f32`, so we have to narrow to f32 here even
-                // though ONNX's T2 constraint allows any numeric dtype.
-                // This silently rounds int64 values above 2^24 - tracked in
-                // #317 as a followup; resolving it properly requires either
-                // an overload of `one_hot_fill` that's generic over
-                // `E: ElementConversion` or a tensor-input one_hot path
-                // that never materializes on/off as host scalars.
-                prelude.extend(quote! {
-                    let (__onehot_off, __onehot_on): (f32, f32) = {
-                        let __data = #tensor.to_data().convert::<f32>();
-                        let __slice = __data.as_slice::<f32>().unwrap();
-                        (__slice[0], __slice[1])
-                    };
-                });
-                (quote! { __onehot_on }, quote! { __onehot_off })
             }
         };
 
@@ -99,6 +76,49 @@ impl NodeCodegen for onnx_ir::one_hot::OneHotNode {
         let output_dtype = output_arg.ty.elem_type();
         let output_dtype_tokens = output_dtype.to_tokens();
 
+        // Runtime values widen through an intermediate scalar because Burn's
+        // `one_hot_fill` pins `on_value`/`off_value` to `f32`. For a float
+        // output, f32 matches the downstream dtype. For an int output, f32
+        // rounds int64 magnitudes above 2^24, so for the runtime+int case we
+        // take a different path: call `one_hot_fill(1.0, 0.0)` to produce a
+        // 0/1 mask, cast to the int output dtype, then scale via exact
+        // int64 scalar arithmetic. `one_hot_fill`'s off_value=0 / on_value=1
+        // are exactly representable in f32, and all subsequent math is
+        // integer, so the full int64 range is preserved.
+        let (on_value, off_value, runtime_int_scale) = match &self.config.values {
+            onnx_ir::one_hot::OneHotValuesInput::Static(v) => {
+                let off = v[0];
+                let on = v[1];
+                (quote! { #on }, quote! { #off }, false)
+            }
+            onnx_ir::one_hot::OneHotValuesInput::Runtime(r) => {
+                let arg = &self.inputs[r.input_index];
+                let tensor = scope.arg(arg);
+                if output_kind == TensorKind::Int {
+                    // values layout: [off_value, on_value]. Read as i64 so
+                    // the full int64 range survives.
+                    prelude.extend(quote! {
+                        let (__onehot_off_i, __onehot_on_i): (i64, i64) = {
+                            let __data = #tensor.to_data().convert::<i64>();
+                            let __slice = __data.as_slice::<i64>().unwrap();
+                            (__slice[0], __slice[1])
+                        };
+                    });
+                    // Use a 0/1 mask; the scale is applied later.
+                    (quote! { 1f32 }, quote! { 0f32 }, true)
+                } else {
+                    prelude.extend(quote! {
+                        let (__onehot_off, __onehot_on): (f32, f32) = {
+                            let __data = #tensor.to_data().convert::<f32>();
+                            let __slice = __data.as_slice::<f32>().unwrap();
+                            (__slice[0], __slice[1])
+                        };
+                    });
+                    (quote! { __onehot_on }, quote! { __onehot_off }, false)
+                }
+            }
+        };
+
         // Build the `one_hot_fill` call as a trailing expression (no
         // `let #output = ...;`). Wrapping the prelude + expression inside
         // a single block scopes the `__onehot_*` temporaries so multiple
@@ -108,8 +128,28 @@ impl NodeCodegen for onnx_ir::one_hot::OneHotNode {
         // backend's default Int/Float element, not from the input tensor's
         // runtime dtype. Always cast to the ONNX-specified output dtype so
         // the generated code doesn't leak the backend default (CLAUDE.md).
+        //
+        // For the runtime-values int path we call `one_hot_fill(1.0, 0.0)`
+        // to get a 0/1 mask and scale via int64 scalar math:
+        //     result = mask * (on - off) + off
+        // The mul/add happen in the backend's default Int dtype (i64-wide
+        // on typical backends), so the full int64 range is preserved before
+        // the final narrowing cast to the ONNX-specified output dtype.
+        let int_scale = quote! {
+            .mul_scalar(__onehot_on_i - __onehot_off_i).add_scalar(__onehot_off_i)
+        };
+        let maybe_scale = if runtime_int_scale {
+            int_scale.clone()
+        } else {
+            TokenStream::new()
+        };
         let body: TokenStream = match (input_kind, output_kind) {
-            (TensorKind::Int, TensorKind::Int) | (TensorKind::Float, TensorKind::Float) => {
+            (TensorKind::Int, TensorKind::Int) => {
+                quote! {
+                    #input.one_hot_fill(#num_classes, #on_value, #off_value, #axis) #maybe_scale .cast(#output_dtype_tokens)
+                }
+            }
+            (TensorKind::Float, TensorKind::Float) => {
                 quote! {
                     #input.one_hot_fill(#num_classes, #on_value, #off_value, #axis).cast(#output_dtype_tokens)
                 }
@@ -121,7 +161,7 @@ impl NodeCodegen for onnx_ir::one_hot::OneHotNode {
             }
             (TensorKind::Float, TensorKind::Int) => {
                 quote! {
-                    #input.one_hot_fill(#num_classes, #on_value, #off_value, #axis).int().cast(#output_dtype_tokens)
+                    #input.one_hot_fill(#num_classes, #on_value, #off_value, #axis).int() #maybe_scale .cast(#output_dtype_tokens)
                 }
             }
             (TensorKind::Int, TensorKind::Bool) | (TensorKind::Float, TensorKind::Bool) => {
@@ -306,7 +346,7 @@ mod tests {
             let output = {
                 let __onehot_depth: usize = {
                     let __data = depth.to_data().convert::<i64>();
-                    __data.as_slice::<i64>().unwrap()[0] as usize
+                    __data.as_slice::<i64>().unwrap()[0].max(0) as usize
                 };
                 let (__onehot_off, __onehot_on): (f32, f32) = {
                     let __data = values.to_data().convert::<f32>();
@@ -351,12 +391,55 @@ mod tests {
             let output = {
                 let __onehot_depth: usize = {
                     let __data = depth.to_data().convert::<i64>();
-                    __data.as_slice::<i64>().unwrap()[0] as usize
+                    __data.as_slice::<i64>().unwrap()[0].max(0) as usize
                 };
                 indices
                     .one_hot_fill(__onehot_depth, 1f32, 0f32, -1i64)
                     .float()
                     .cast(burn::tensor::DType::F32)
+            };
+            output
+        }
+        ");
+    }
+
+    #[test]
+    fn test_one_hot_runtime_values_int_output() {
+        // Runtime values fed into an int-typed output must preserve full
+        // int64 precision. The old code path narrowed `values` through f32,
+        // which silently rounded magnitudes above 2^24. The fix reads the
+        // two values as i64, calls `one_hot_fill(1.0, 0.0)` to get a 0/1
+        // mask, and scales with exact int64 scalar arithmetic before the
+        // final cast to the ONNX-specified output dtype.
+        let config = OneHotConfig::new(
+            OneHotDepthInput::Static(5),
+            OneHotValuesInput::Runtime(onnx_ir::ir::RuntimeInputRef::new("values".to_string(), 1)),
+            -1,
+        );
+        let node = OneHotNodeBuilder::new("onehot_rt_int")
+            .input_tensor("indices", 1, DType::I64)
+            .input_tensor("values", 1, DType::I64)
+            .output_tensor("output", 2, DType::I64)
+            .config(config)
+            .build();
+        let code = codegen_forward_default(&node);
+        assert_snapshot!(code, @r"
+        pub fn forward(
+            &self,
+            indices: Tensor<B, 1, Int>,
+            values: Tensor<B, 1, Int>,
+        ) -> Tensor<B, 2, Int> {
+            let output = {
+                let (__onehot_off_i, __onehot_on_i): (i64, i64) = {
+                    let __data = values.to_data().convert::<i64>();
+                    let __slice = __data.as_slice::<i64>().unwrap();
+                    (__slice[0], __slice[1])
+                };
+                indices
+                    .one_hot_fill(5usize, 1f32, 0f32, -1i64)
+                    .mul_scalar(__onehot_on_i - __onehot_off_i)
+                    .add_scalar(__onehot_off_i)
+                    .cast(burn::tensor::DType::I64)
             };
             output
         }

--- a/crates/burn-onnx/src/burn/node/top_k.rs
+++ b/crates/burn-onnx/src/burn/node/top_k.rs
@@ -40,14 +40,19 @@ impl NodeCodegen for onnx_ir::topk::TopKNode {
                 let prelude = match &arg.ty {
                     ArgType::ScalarNative(_) => {
                         let ident = arg_to_ident(arg);
-                        quote! { let __topk_k: usize = #ident as usize; }
+                        // Clamp with `max(0)` before `as usize`. A negative
+                        // runtime k is out-of-spec for ONNX TopK; letting a
+                        // negative i64 wrap to a huge usize causes OOM or a
+                        // cryptic deep-burn panic. Clamp to zero so the
+                        // failure surfaces as a benign empty-result instead.
+                        quote! { let __topk_k: usize = (#ident as i64).max(0) as usize; }
                     }
                     ArgType::ScalarTensor(_) | ArgType::Tensor(_) => {
                         let tensor = scope.arg(arg);
                         quote! {
                             let __topk_k: usize = {
                                 let __data = #tensor.to_data().convert::<i64>();
-                                __data.as_slice::<i64>().unwrap()[0] as usize
+                                __data.as_slice::<i64>().unwrap()[0].max(0) as usize
                             };
                         }
                     }
@@ -126,7 +131,7 @@ mod tests {
             let (values, __topk_indices_raw) = {
                 let __topk_k: usize = {
                     let __data = k.to_data().convert::<i64>();
-                    __data.as_slice::<i64>().unwrap()[0] as usize
+                    __data.as_slice::<i64>().unwrap()[0].max(0) as usize
                 };
                 input.topk_with_indices(__topk_k, 1)
             };

--- a/crates/burn-onnx/src/burn/node/top_k.rs
+++ b/crates/burn-onnx/src/burn/node/top_k.rs
@@ -43,8 +43,10 @@ impl NodeCodegen for onnx_ir::topk::TopKNode {
                         // Clamp with `max(0)` before `as usize`. A negative
                         // runtime k is out-of-spec for ONNX TopK; letting a
                         // negative i64 wrap to a huge usize causes OOM or a
-                        // cryptic deep-burn panic. Clamp to zero so the
-                        // failure surfaces as a benign empty-result instead.
+                        // cryptic deep-burn panic. Clamp to zero so a
+                        // broken model produces an empty top-k result
+                        // instead. Adding observability is tracked in
+                        // tracel-ai/burn-onnx#328.
                         quote! { let __topk_k: usize = (#ident as i64).max(0) as usize; }
                     }
                     ArgType::ScalarTensor(_) | ArgType::Tensor(_) => {

--- a/crates/onnx-ir/src/node/and.rs
+++ b/crates/onnx-ir/src/node/and.rs
@@ -50,21 +50,32 @@ impl NodeProcessor for AndProcessor {
         _output_preferences: &OutputPreferences,
     ) -> Result<(), ProcessError> {
         // Structural validation for Shape combined with an on-device tensor.
-        // burn-onnx codegen materializes the Shape as a rank-1 Int tensor and
-        // then calls `bool_and` on it, which only works if the counterpart is
-        // also rank 1. Reject mismatches here with a clean ProcessError so
-        // users don't see a cryptic deep-burn type error at generated-code
-        // compile time.
+        // burn-onnx codegen materializes the Shape as a rank-1 Int tensor,
+        // converts it to bool via `.not_equal_elem(0i64)`, and then calls
+        // `bool_and` on the counterpart. That only compiles when the other
+        // operand is a rank-1 Bool tensor. Reject anything else here with a
+        // clean ProcessError so users don't see a cryptic deep-burn type
+        // error at generated-code compile time. ONNX And already constrains
+        // T to bool, but an upstream dtype-inference bug could still let a
+        // non-bool tensor reach this arm.
         let lhs_ty = &node.inputs[0].ty;
         let rhs_ty = &node.inputs[1].ty;
         if let (ArgType::Shape(_), other) | (other, ArgType::Shape(_)) = (lhs_ty, rhs_ty)
             && other.is_on_device()
-            && other.rank() != 1
         {
-            return Err(ProcessError::Custom(format!(
-                "And: Shape combined with rank-{} tensor is not supported (expected rank 1)",
-                other.rank()
-            )));
+            let other_dtype = other.elem_type();
+            if !other_dtype.is_bool() {
+                return Err(ProcessError::TypeMismatch {
+                    expected: "bool tensor when combined with Shape".to_string(),
+                    actual: format!("{other_dtype:?}"),
+                });
+            }
+            if other.rank() != 1 {
+                return Err(ProcessError::Custom(format!(
+                    "And: Shape combined with rank-{} bool tensor is not supported (expected rank 1)",
+                    other.rank()
+                )));
+            }
         }
 
         same_as_input_broadcast(node);
@@ -77,5 +88,71 @@ impl NodeProcessor for AndProcessor {
             inputs: builder.inputs,
             outputs: builder.outputs,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ir::NodeType;
+    use crate::node::test_utils::TestNodeBuilder;
+    use crate::processor::OutputPreferences;
+
+    /// And on Shape + rank-2 bool tensor must be rejected. The codegen
+    /// arm for this combination assumes rank 1; higher ranks would
+    /// miscompile or panic deep in burn.
+    #[test]
+    fn shape_and_rank2_bool_rejected() {
+        let mut node = TestNodeBuilder::new(NodeType::And, "and_shape_rank2")
+            .input_shape("lhs", 3)
+            .input_tensor_bool("rhs", 2, None)
+            .output_tensor_bool("out", 2, None)
+            .build();
+
+        let processor = AndProcessor;
+        let prefs = OutputPreferences::new();
+        let result = processor.infer_types(&mut node, 16, &prefs);
+        match result {
+            Err(ProcessError::Custom(msg)) => assert!(
+                msg.contains("rank-2") && msg.contains("And"),
+                "expected rank-2 message, got: {msg}"
+            ),
+            other => panic!("expected Custom ProcessError, got {other:?}"),
+        }
+    }
+
+    /// And on Shape + rank-1 float tensor must be rejected because
+    /// codegen only supports the bool counterpart.
+    #[test]
+    fn shape_and_float_tensor_rejected() {
+        let mut node = TestNodeBuilder::new(NodeType::And, "and_shape_float")
+            .input_shape("lhs", 3)
+            .input_tensor_f32("rhs", 1, None)
+            .output_tensor_bool("out", 1, None)
+            .build();
+
+        let processor = AndProcessor;
+        let prefs = OutputPreferences::new();
+        let result = processor.infer_types(&mut node, 16, &prefs);
+        assert!(
+            matches!(result, Err(ProcessError::TypeMismatch { .. })),
+            "expected TypeMismatch, got {result:?}"
+        );
+    }
+
+    /// And on Shape + rank-1 bool tensor is the legitimate case and
+    /// must be accepted.
+    #[test]
+    fn shape_and_rank1_bool_accepted() {
+        let mut node = TestNodeBuilder::new(NodeType::And, "and_shape_rank1")
+            .input_shape("lhs", 3)
+            .input_tensor_bool("rhs", 1, None)
+            .output_tensor_bool("out", 1, None)
+            .build();
+
+        let processor = AndProcessor;
+        let prefs = OutputPreferences::new();
+        let result = processor.infer_types(&mut node, 16, &prefs);
+        assert!(result.is_ok(), "expected Ok, got {result:?}");
     }
 }

--- a/crates/onnx-ir/src/node/and.rs
+++ b/crates/onnx-ir/src/node/and.rs
@@ -14,7 +14,7 @@
 
 use onnx_ir_derive::NodeBuilder;
 
-use crate::ir::{Argument, Node, RawNode};
+use crate::ir::{ArgType, Argument, Node, RawNode};
 use crate::processor::{
     InputSpec, NodeProcessor, NodeSpec, OutputPreferences, OutputSpec, ProcessError,
     same_as_input_broadcast,
@@ -49,6 +49,24 @@ impl NodeProcessor for AndProcessor {
         _opset: usize,
         _output_preferences: &OutputPreferences,
     ) -> Result<(), ProcessError> {
+        // Structural validation for Shape combined with an on-device tensor.
+        // burn-onnx codegen materializes the Shape as a rank-1 Int tensor and
+        // then calls `bool_and` on it, which only works if the counterpart is
+        // also rank 1. Reject mismatches here with a clean ProcessError so
+        // users don't see a cryptic deep-burn type error at generated-code
+        // compile time.
+        let lhs_ty = &node.inputs[0].ty;
+        let rhs_ty = &node.inputs[1].ty;
+        if let (ArgType::Shape(_), other) | (other, ArgType::Shape(_)) = (lhs_ty, rhs_ty)
+            && other.is_on_device()
+            && other.rank() != 1
+        {
+            return Err(ProcessError::Custom(format!(
+                "And: Shape combined with rank-{} tensor is not supported (expected rank 1)",
+                other.rank()
+            )));
+        }
+
         same_as_input_broadcast(node);
         Ok(())
     }

--- a/crates/onnx-ir/src/node/argmax.rs
+++ b/crates/onnx-ir/src/node/argmax.rs
@@ -160,6 +160,16 @@ impl NodeProcessor for ArgMaxProcessor {
     }
 
     fn build_node(&self, builder: RawNode, opset: usize) -> Node {
+        // `build_node` runs after `infer_types`, which already calls
+        // `extract_config` and propagates errors via `?`. Any config that
+        // reaches here has therefore already been validated, so the
+        // `.expect` is only reachable if a processor is constructed
+        // out-of-pipeline or if a future validation is added to
+        // `extract_config` without being mirrored in `infer_types`. The
+        // trait signature `fn build_node(...) -> Node` can't return
+        // `Result`, so this is the least bad option; lifting the trait
+        // to `Result<Node, ProcessError>` would require a codebase-wide
+        // refactor across every processor.
         let config = self
             .extract_config(&builder, opset)
             .expect("Config extraction failed");

--- a/crates/onnx-ir/src/node/argmax.rs
+++ b/crates/onnx-ir/src/node/argmax.rs
@@ -72,10 +72,10 @@ impl NodeProcessor for ArgMaxProcessor {
             }
         };
 
-        // Get config values before mutating node
-        let config = self
-            .extract_config(node, opset)
-            .expect("Config extraction failed");
+        // Get config values before mutating node. Propagate the error so
+        // invalid attributes (e.g., select_last_index out of range) surface
+        // as a clean ProcessError rather than an `.expect` panic.
+        let config = self.extract_config(node, opset)?;
         let keepdims = config.keepdims;
 
         // For burn compatibility, argmax always outputs a tensor

--- a/crates/onnx-ir/src/node/argmin.rs
+++ b/crates/onnx-ir/src/node/argmin.rs
@@ -160,6 +160,16 @@ impl NodeProcessor for ArgMinProcessor {
     }
 
     fn build_node(&self, builder: RawNode, opset: usize) -> Node {
+        // `build_node` runs after `infer_types`, which already calls
+        // `extract_config` and propagates errors via `?`. Any config that
+        // reaches here has therefore already been validated, so the
+        // `.expect` is only reachable if a processor is constructed
+        // out-of-pipeline or if a future validation is added to
+        // `extract_config` without being mirrored in `infer_types`. The
+        // trait signature `fn build_node(...) -> Node` can't return
+        // `Result`, so this is the least bad option; lifting the trait
+        // to `Result<Node, ProcessError>` would require a codebase-wide
+        // refactor across every processor.
         let config = self
             .extract_config(&builder, opset)
             .expect("Config extraction failed");

--- a/crates/onnx-ir/src/node/argmin.rs
+++ b/crates/onnx-ir/src/node/argmin.rs
@@ -72,10 +72,10 @@ impl NodeProcessor for ArgMinProcessor {
             }
         };
 
-        // Get config values before mutating node
-        let config = self
-            .extract_config(node, opset)
-            .expect("Config extraction failed");
+        // Get config values before mutating node. Propagate the error so
+        // invalid attributes (e.g., select_last_index out of range) surface
+        // as a clean ProcessError rather than an `.expect` panic.
+        let config = self.extract_config(node, opset)?;
         let keepdims = config.keepdims;
 
         // For burn compatibility, argmin always outputs a tensor

--- a/crates/onnx-ir/src/node/modulo.rs
+++ b/crates/onnx-ir/src/node/modulo.rs
@@ -18,7 +18,7 @@
 
 use onnx_ir_derive::NodeBuilder;
 
-use crate::ir::{Argument, AttributeValue, Node, RawNode};
+use crate::ir::{ArgType, Argument, AttributeValue, Node, RawNode};
 use crate::processor::{
     InputPreferences, InputSpec, NodeProcessor, NodeSpec, OutputPreferences, OutputSpec,
     ProcessError,
@@ -116,6 +116,32 @@ impl NodeProcessor for ModuloProcessor {
         // TODO: Validate input dtypes are numeric - Integer and floating-point types supported - burn/crates/onnx-ir/src/node/modulo.rs:100
         // TODO: Validate both inputs have same dtype - Mixed types should be rejected - burn/crates/onnx-ir/src/node/modulo.rs:100
         // TODO: Add validation that fmod attribute, if present, is either 0 or 1 - Other values are undefined - burn/crates/onnx-ir/src/node/modulo.rs:100
+
+        // Structural validation for Shape combined with an on-device tensor.
+        // burn-onnx codegen for these arms always materializes the Shape as
+        // a rank-1 Int tensor, so it can only handle a rank-1 integer
+        // counterpart. Reject mismatches here (rather than panicking deep
+        // inside codegen or producing silently wrong code) so users see a
+        // clean ProcessError.
+        let lhs_ty = &node.inputs[0].ty;
+        let rhs_ty = &node.inputs[1].ty;
+        if let (ArgType::Shape(_), other) | (other, ArgType::Shape(_)) = (lhs_ty, rhs_ty)
+            && other.is_on_device()
+        {
+            let other_dtype = other.elem_type();
+            if !(other_dtype.is_int() || other_dtype.is_uint()) {
+                return Err(ProcessError::TypeMismatch {
+                    expected: "integer-typed tensor when combined with Shape".to_string(),
+                    actual: format!("{other_dtype:?}"),
+                });
+            }
+            if other.rank() != 1 {
+                return Err(ProcessError::Custom(format!(
+                    "Mod: Shape combined with rank-{} tensor is not supported (expected rank 1)",
+                    other.rank()
+                )));
+            }
+        }
 
         // Output type is same as input with broadcasting
         crate::processor::same_as_input_broadcast(node);

--- a/crates/onnx-ir/src/node/modulo.rs
+++ b/crates/onnx-ir/src/node/modulo.rs
@@ -137,7 +137,7 @@ impl NodeProcessor for ModuloProcessor {
             }
             if other.rank() != 1 {
                 return Err(ProcessError::Custom(format!(
-                    "Mod: Shape combined with rank-{} tensor is not supported (expected rank 1)",
+                    "Mod: Shape combined with rank-{} {other_dtype:?} tensor is not supported (expected rank 1)",
                     other.rank()
                 )));
             }
@@ -227,5 +227,64 @@ mod tests {
         let config = processor.extract_config(&node, 16).unwrap();
         processor.infer_types(&mut node, 16, &prefs).unwrap();
         assert_eq!(config.fmod, true);
+    }
+
+    /// Mod on Shape + float tensor must be rejected. The codegen arm
+    /// for this combination materializes the Shape as a rank-1 Int
+    /// tensor and calls `.remainder()` / `.fmod()` on it, so the
+    /// counterpart must be integer-typed.
+    #[test]
+    fn shape_mod_float_tensor_rejected() {
+        let mut node = TestNodeBuilder::new(NodeType::Mod, "mod_shape_float")
+            .input_shape("lhs", 3)
+            .input_tensor_f32("rhs", 1, None)
+            .output_tensor_f32("out", 1, None)
+            .build();
+
+        let processor = ModuloProcessor;
+        let prefs = OutputPreferences::new();
+        let result = processor.infer_types(&mut node, 16, &prefs);
+        assert!(
+            matches!(result, Err(ProcessError::TypeMismatch { .. })),
+            "expected TypeMismatch, got {result:?}"
+        );
+    }
+
+    /// Mod on Shape + rank-2 int tensor must be rejected. Codegen
+    /// assumes the counterpart is rank 1.
+    #[test]
+    fn shape_mod_rank2_int_tensor_rejected() {
+        let mut node = TestNodeBuilder::new(NodeType::Mod, "mod_shape_rank2")
+            .input_shape("lhs", 3)
+            .input_tensor_i64("rhs", 2, None)
+            .output_tensor_i64("out", 2, None)
+            .build();
+
+        let processor = ModuloProcessor;
+        let prefs = OutputPreferences::new();
+        let result = processor.infer_types(&mut node, 16, &prefs);
+        match result {
+            Err(ProcessError::Custom(msg)) => assert!(
+                msg.contains("rank-2") && msg.contains("Mod"),
+                "expected rank-2 message, got: {msg}"
+            ),
+            other => panic!("expected Custom ProcessError, got {other:?}"),
+        }
+    }
+
+    /// Mod on Shape + rank-1 int tensor is the legitimate case and
+    /// must be accepted.
+    #[test]
+    fn shape_mod_rank1_int_tensor_accepted() {
+        let mut node = TestNodeBuilder::new(NodeType::Mod, "mod_shape_rank1")
+            .input_shape("lhs", 3)
+            .input_tensor_i64("rhs", 1, None)
+            .output_tensor_i64("out", 1, None)
+            .build();
+
+        let processor = ModuloProcessor;
+        let prefs = OutputPreferences::new();
+        let result = processor.infer_types(&mut node, 16, &prefs);
+        assert!(result.is_ok(), "expected Ok, got {result:?}");
     }
 }

--- a/crates/onnx-official-tests/expectations.toml
+++ b/crates/onnx-official-tests/expectations.toml
@@ -6739,19 +6739,29 @@ reason = "Runtime repeats are not supported in burn-onnx"
 tracking = "#314"
 
 [test_top_k]
-status = "pass"
+status = "fail-compare"
+reason = "upstream burn-flex bug: int_select asserts indices must be I64 but the default IntElem is I32 (triggers inside topk_with_indices)"
+tracking = "tracel-ai/burn"
 
 [test_top_k_negative_axis]
-status = "pass"
+status = "fail-compare"
+reason = "upstream burn-flex bug: int_select asserts indices must be I64 but the default IntElem is I32 (triggers inside topk_with_indices)"
+tracking = "tracel-ai/burn"
 
 [test_top_k_same_values]
-status = "pass"
+status = "fail-compare"
+reason = "upstream burn-flex bug: int_select asserts indices must be I64 but the default IntElem is I32 (triggers inside topk_with_indices)"
+tracking = "tracel-ai/burn"
 
 [test_top_k_same_values_2d]
-status = "pass"
+status = "fail-compare"
+reason = "upstream burn-flex bug: int_select asserts indices must be I64 but the default IntElem is I32 (triggers inside topk_with_indices)"
+tracking = "tracel-ai/burn"
 
 [test_top_k_same_values_largest]
-status = "pass"
+status = "fail-compare"
+reason = "upstream burn-flex bug: int_select asserts indices must be I64 but the default IntElem is I32 (triggers inside topk_with_indices)"
+tracking = "tracel-ai/burn"
 
 [test_top_k_smallest]
 status = "skip-codegen"
@@ -6759,7 +6769,9 @@ reason = "Node 'topk1' (TopK): TopK: only largest elements is supported"
 tracking = "#314"
 
 [test_top_k_uint64]
-status = "pass"
+status = "fail-compare"
+reason = "upstream burn-flex bug: int_select asserts indices must be I64 but the default IntElem is I32 (triggers inside topk_with_indices)"
+tracking = "tracel-ai/burn"
 
 [test_training_dropout]
 status = "skip-codegen"

--- a/crates/onnx-official-tests/expectations.toml
+++ b/crates/onnx-official-tests/expectations.toml
@@ -209,129 +209,97 @@ tracking = "tracel-ai/burn#4771"
 status = "pass"
 
 [test_argmax_default_axis_example_select_last_index]
-status = "skip-codegen"
-reason = "InvalidAttribute { name: \"select_last_index\", reason: \"select_last_index=1 is not supported for argmax in burn\" }"
-tracking = "#314"
+status = "pass"
 
 [test_argmax_default_axis_random]
 status = "pass"
 
 [test_argmax_default_axis_random_select_last_index]
-status = "skip-codegen"
-reason = "InvalidAttribute { name: \"select_last_index\", reason: \"select_last_index=1 is not supported for argmax in burn\" }"
-tracking = "#314"
+status = "pass"
 
 [test_argmax_keepdims_example]
 status = "pass"
 
 [test_argmax_keepdims_example_select_last_index]
-status = "skip-codegen"
-reason = "InvalidAttribute { name: \"select_last_index\", reason: \"select_last_index=1 is not supported for argmax in burn\" }"
-tracking = "#314"
+status = "pass"
 
 [test_argmax_keepdims_random]
 status = "pass"
 
 [test_argmax_keepdims_random_select_last_index]
-status = "skip-codegen"
-reason = "InvalidAttribute { name: \"select_last_index\", reason: \"select_last_index=1 is not supported for argmax in burn\" }"
-tracking = "#314"
+status = "pass"
 
 [test_argmax_negative_axis_keepdims_example]
 status = "pass"
 
 [test_argmax_negative_axis_keepdims_example_select_last_index]
-status = "skip-codegen"
-reason = "InvalidAttribute { name: \"select_last_index\", reason: \"select_last_index=1 is not supported for argmax in burn\" }"
-tracking = "#314"
+status = "pass"
 
 [test_argmax_negative_axis_keepdims_random]
 status = "pass"
 
 [test_argmax_negative_axis_keepdims_random_select_last_index]
-status = "skip-codegen"
-reason = "InvalidAttribute { name: \"select_last_index\", reason: \"select_last_index=1 is not supported for argmax in burn\" }"
-tracking = "#314"
+status = "pass"
 
 [test_argmax_no_keepdims_example]
 status = "pass"
 
 [test_argmax_no_keepdims_example_select_last_index]
-status = "skip-codegen"
-reason = "InvalidAttribute { name: \"select_last_index\", reason: \"select_last_index=1 is not supported for argmax in burn\" }"
-tracking = "#314"
+status = "pass"
 
 [test_argmax_no_keepdims_random]
 status = "pass"
 
 [test_argmax_no_keepdims_random_select_last_index]
-status = "skip-codegen"
-reason = "InvalidAttribute { name: \"select_last_index\", reason: \"select_last_index=1 is not supported for argmax in burn\" }"
-tracking = "#314"
+status = "pass"
 
 [test_argmin_default_axis_example]
 status = "pass"
 
 [test_argmin_default_axis_example_select_last_index]
-status = "skip-codegen"
-reason = "InvalidAttribute { name: \"select_last_index\", reason: \"select_last_index=1 is not supported for argmin in burn\" }"
-tracking = "#314"
+status = "pass"
 
 [test_argmin_default_axis_random]
 status = "pass"
 
 [test_argmin_default_axis_random_select_last_index]
-status = "skip-codegen"
-reason = "InvalidAttribute { name: \"select_last_index\", reason: \"select_last_index=1 is not supported for argmin in burn\" }"
-tracking = "#314"
+status = "pass"
 
 [test_argmin_keepdims_example]
 status = "pass"
 
 [test_argmin_keepdims_example_select_last_index]
-status = "skip-codegen"
-reason = "InvalidAttribute { name: \"select_last_index\", reason: \"select_last_index=1 is not supported for argmin in burn\" }"
-tracking = "#314"
+status = "pass"
 
 [test_argmin_keepdims_random]
 status = "pass"
 
 [test_argmin_keepdims_random_select_last_index]
-status = "skip-codegen"
-reason = "InvalidAttribute { name: \"select_last_index\", reason: \"select_last_index=1 is not supported for argmin in burn\" }"
-tracking = "#314"
+status = "pass"
 
 [test_argmin_negative_axis_keepdims_example]
 status = "pass"
 
 [test_argmin_negative_axis_keepdims_example_select_last_index]
-status = "skip-codegen"
-reason = "InvalidAttribute { name: \"select_last_index\", reason: \"select_last_index=1 is not supported for argmin in burn\" }"
-tracking = "#314"
+status = "pass"
 
 [test_argmin_negative_axis_keepdims_random]
 status = "pass"
 
 [test_argmin_negative_axis_keepdims_random_select_last_index]
-status = "skip-codegen"
-reason = "InvalidAttribute { name: \"select_last_index\", reason: \"select_last_index=1 is not supported for argmin in burn\" }"
-tracking = "#314"
+status = "pass"
 
 [test_argmin_no_keepdims_example]
 status = "pass"
 
 [test_argmin_no_keepdims_example_select_last_index]
-status = "skip-codegen"
-reason = "InvalidAttribute { name: \"select_last_index\", reason: \"select_last_index=1 is not supported for argmin in burn\" }"
-tracking = "#314"
+status = "pass"
 
 [test_argmin_no_keepdims_random]
 status = "pass"
 
 [test_argmin_no_keepdims_random_select_last_index]
-status = "skip-codegen"
-reason = "InvalidAttribute { name: \"select_last_index\", reason: \"select_last_index=1 is not supported for argmin in burn\" }"
-tracking = "#314"
+status = "pass"
 
 [test_asin]
 status = "pass"
@@ -1971,9 +1939,7 @@ reason = "max: unsupported input types"
 tracking = "#314"
 
 [test_clip]
-status = "skip-codegen"
-reason = "Clip: runtime min values are not supported in burn-onnx"
-tracking = "#314"
+status = "pass"
 
 [test_clip_default_inbounds]
 status = "skip-codegen"
@@ -1994,41 +1960,31 @@ reason = "comparison against reference tensor fails (classified by M2 first-run 
 tracking = "#311"
 
 [test_clip_default_int8_max]
-status = "skip-codegen"
-reason = "Clip: runtime max values are not supported in burn-onnx"
-tracking = "#314"
+status = "pass"
 
 [test_clip_default_int8_max_expanded]
 status = "pass"
 
 [test_clip_default_int8_min]
-status = "skip-codegen"
-reason = "Clip: runtime min values are not supported in burn-onnx"
-tracking = "#314"
+status = "pass"
 
 [test_clip_default_int8_min_expanded]
 status = "pass"
 
 [test_clip_default_max]
-status = "skip-codegen"
-reason = "Clip: runtime max values are not supported in burn-onnx"
-tracking = "#314"
+status = "pass"
 
 [test_clip_default_max_expanded]
 status = "pass"
 
 [test_clip_default_min]
-status = "skip-codegen"
-reason = "Clip: runtime min values are not supported in burn-onnx"
-tracking = "#314"
+status = "pass"
 
 [test_clip_default_min_expanded]
 status = "pass"
 
 [test_clip_example]
-status = "skip-codegen"
-reason = "Clip: runtime min values are not supported in burn-onnx"
-tracking = "#314"
+status = "pass"
 
 [test_clip_example_expanded]
 status = "pass"
@@ -2037,33 +1993,25 @@ status = "pass"
 status = "pass"
 
 [test_clip_inbounds]
-status = "skip-codegen"
-reason = "Clip: runtime min values are not supported in burn-onnx"
-tracking = "#314"
+status = "pass"
 
 [test_clip_inbounds_expanded]
 status = "pass"
 
 [test_clip_min_greater_than_max]
-status = "skip-codegen"
-reason = "Clip: runtime min values are not supported in burn-onnx"
-tracking = "#314"
+status = "pass"
 
 [test_clip_min_greater_than_max_expanded]
 status = "pass"
 
 [test_clip_outbounds]
-status = "skip-codegen"
-reason = "Clip: runtime min values are not supported in burn-onnx"
-tracking = "#314"
+status = "pass"
 
 [test_clip_outbounds_expanded]
 status = "pass"
 
 [test_clip_splitbounds]
-status = "skip-codegen"
-reason = "Clip: runtime min values are not supported in burn-onnx"
-tracking = "#314"
+status = "pass"
 
 [test_clip_splitbounds_expanded]
 status = "pass"
@@ -2464,29 +2412,19 @@ reason = "comparison against reference tensor fails (classified by M2 first-run 
 tracking = "#311"
 
 [test_dropout_default]
-status = "skip-codegen"
-reason = "MissingInput(\"Dropout: missing ratio input\")"
-tracking = "#314"
+status = "pass"
 
 [test_dropout_default_mask]
-status = "skip-codegen"
-reason = "MissingInput(\"Dropout: missing ratio input\")"
-tracking = "#314"
+status = "pass"
 
 [test_dropout_default_mask_ratio]
-status = "skip-codegen"
-reason = "Runtime input is not implemented for Dropout"
-tracking = "#314"
+status = "pass"
 
 [test_dropout_default_old]
-status = "skip-codegen"
-reason = "MissingInput(\"Dropout: missing ratio input\")"
-tracking = "#314"
+status = "pass"
 
 [test_dropout_default_ratio]
-status = "skip-codegen"
-reason = "Runtime input is not implemented for Dropout"
-tracking = "#314"
+status = "pass"
 
 [test_dropout_random_old]
 status = "pass"
@@ -3931,9 +3869,7 @@ status = "pass"
 status = "pass"
 
 [test_mod_broadcast]
-status = "fail-compare"
-reason = "comparison against reference tensor fails (classified by M2 first-run sweep; root cause not yet triaged)"
-tracking = "#311"
+status = "pass"
 
 [test_mod_int64_fmod]
 status = "skip-compile"
@@ -3950,42 +3886,28 @@ status = "pass"
 status = "pass"
 
 [test_mod_mixed_sign_int16]
-status = "fail-compare"
-reason = "comparison against reference tensor fails (classified by M2 first-run sweep; root cause not yet triaged)"
-tracking = "#311"
+status = "pass"
 
 [test_mod_mixed_sign_int32]
-status = "fail-compare"
-reason = "comparison against reference tensor fails (classified by M2 first-run sweep; root cause not yet triaged)"
-tracking = "#311"
+status = "pass"
 
 [test_mod_mixed_sign_int64]
 status = "pass"
 
 [test_mod_mixed_sign_int8]
-status = "fail-compare"
-reason = "comparison against reference tensor fails (classified by M2 first-run sweep; root cause not yet triaged)"
-tracking = "#311"
+status = "pass"
 
 [test_mod_uint16]
-status = "fail-compare"
-reason = "comparison against reference tensor fails (classified by M2 first-run sweep; root cause not yet triaged)"
-tracking = "#311"
+status = "pass"
 
 [test_mod_uint32]
-status = "fail-compare"
-reason = "comparison against reference tensor fails (classified by M2 first-run sweep; root cause not yet triaged)"
-tracking = "#311"
+status = "pass"
 
 [test_mod_uint64]
-status = "fail-compare"
-reason = "mod op family comparison failure"
-tracking = "#311"
+status = "pass"
 
 [test_mod_uint8]
-status = "fail-compare"
-reason = "comparison against reference tensor fails (classified by M2 first-run sweep; root cause not yet triaged)"
-tracking = "#311"
+status = "pass"
 
 [test_momentum]
 status = "skip-codegen"
@@ -4288,24 +4210,16 @@ status = "pass"
 status = "pass"
 
 [test_onehot_negative_indices]
-status = "skip-codegen"
-reason = "OneHot with runtime depth is not supported in burn-onnx"
-tracking = "#314"
+status = "pass"
 
 [test_onehot_with_axis]
-status = "skip-codegen"
-reason = "OneHot with runtime depth is not supported in burn-onnx"
-tracking = "#314"
+status = "pass"
 
 [test_onehot_with_negative_axis]
-status = "skip-codegen"
-reason = "OneHot with runtime depth is not supported in burn-onnx"
-tracking = "#314"
+status = "pass"
 
 [test_onehot_without_axis]
-status = "skip-codegen"
-reason = "OneHot with runtime depth is not supported in burn-onnx"
-tracking = "#314"
+status = "pass"
 
 [test_optional_get_element_optional_sequence]
 status = "skip-codegen"
@@ -6825,29 +6739,19 @@ reason = "Runtime repeats are not supported in burn-onnx"
 tracking = "#314"
 
 [test_top_k]
-status = "skip-codegen"
-reason = "Runtime k value is not supported in burn-onnx"
-tracking = "#314"
+status = "pass"
 
 [test_top_k_negative_axis]
-status = "skip-codegen"
-reason = "Runtime k value is not supported in burn-onnx"
-tracking = "#314"
+status = "pass"
 
 [test_top_k_same_values]
-status = "skip-codegen"
-reason = "Runtime k value is not supported in burn-onnx"
-tracking = "#314"
+status = "pass"
 
 [test_top_k_same_values_2d]
-status = "skip-codegen"
-reason = "Runtime k value is not supported in burn-onnx"
-tracking = "#314"
+status = "pass"
 
 [test_top_k_same_values_largest]
-status = "skip-codegen"
-reason = "Runtime k value is not supported in burn-onnx"
-tracking = "#314"
+status = "pass"
 
 [test_top_k_smallest]
 status = "skip-codegen"
@@ -6855,9 +6759,7 @@ reason = "Node 'topk1' (TopK): TopK: only largest elements is supported"
 tracking = "#314"
 
 [test_top_k_uint64]
-status = "skip-codegen"
-reason = "Runtime k value is not supported in burn-onnx"
-tracking = "#314"
+status = "pass"
 
 [test_training_dropout]
 status = "skip-codegen"


### PR DESCRIPTION
## Summary

Addresses tracel-ai/burn-onnx#317, the cluster of pre-existing latent correctness issues surfaced by the PR #316 review. Each fix closes a real silent-correctness risk under specific input shapes or dtypes.

**Codegen fixes (burn-onnx)**
- `modulo.rs` ScalarNative+ScalarNative signed-integer `fmod=0` now lowers to `rem_euclid` so negative operands match ONNX Python-style semantics (`Mod(-7, 3) = 2`) instead of Rust's C-style `%` (`-1`).
- `one_hot.rs` runtime values with int output now preserve full int64 precision via a 0/1 mask from `one_hot_fill(1.0, 0.0)` plus `.cast(DType::I64)` followed by `mul_scalar`/`add_scalar`. The explicit I64 cast matters: burn-flex's default `IntElem` is i32, so without it the scale math silently narrows and defeats the fix.
- `clip.rs` runtime bounds for int-typed inputs now carry as i64 instead of rounding through f64 above 2^53.
- `one_hot.rs` and `top_k.rs` runtime `depth`/`k` are clamped with `.max(0)` before `as usize` so a negative i64 from a broken model doesn't wrap to a huge usize and OOM.

**Validation fixes (onnx-ir)**
- `modulo.rs` rejects `Shape` combined with non-rank-1 or non-integer on-device tensors as a clean `ProcessError` instead of miscompiling deep in burn.
- `and.rs` rejects `Shape` combined with non-rank-1 or non-bool on-device tensors (matching codegen's `bool_and` requirement).
- `argmax.rs` / `argmin.rs` propagate `extract_config` errors via `?` in `infer_types`. `build_node` still uses `.expect` because the trait signature returns `Node`, not `Result`; an explanatory block comment documents the asymmetry.

**Tests**
- 3 new modulo snapshot tests forming the full `(fmod, is_int)` truth table.
- 2 new one_hot snapshot tests: Int→Int and Float→Int runtime-values paths.
- 1 new clip snapshot test: int-typed input with runtime ScalarTensor bound.
- 3 new onnx-ir unit tests per file for the Mod and And validation arms (the `and.rs` file had no tests previously).
- Graph-level `multi_instance_clip_scoping` test that builds two runtime-bound Clip nodes in one forward and verifies each emits its `__clip_min`/`__clip_max` temporaries inside a per-node block.

**`onnx-official-tests` expectations**
- Promoted 43 stale `skip-codegen`/`fail-compare` classifications from PR #314 and #311 that PR #316 and this PR actually fix:
  - 16 ArgMax/ArgMin `select_last_index`
  - 10 Clip runtime bounds
  - 5 Dropout runtime ratio
  - 4 OneHot runtime depth
  - 8 Mod mixed-sign / uint
- Demoted 6 TopK tests back to `fail-compare` after runtime verification revealed an upstream burn-flex bug: `int_select` asserts indices must be I64 but burn-flex's default `IntElem` is I32, triggering inside `topk_with_indices`. Tagged `tracking = \"tracel-ai/burn\"` so the eventual upstream fix can re-promote them.
- Suite is now **484 passing / 0 failing** in both debug and release modes (baseline was 457).

## Out of scope

Follow-up hardening (silent-clamp observability, Clip `panic!` upstream migration, `NodeProcessor::build_node` Result refactor, generated-code `unused_parens` warnings, theoretical i64 overflow in OneHot scale, additional coverage gaps) is filed as tracel-ai/burn-onnx#328.

## Test plan

- [x] \`cargo test -p burn-onnx\` — 762 passing
- [x] \`cargo test -p onnx-ir\` — 920 passing
- [x] \`cargo test -p onnx-official-tests\` (release) — 484 passing, 0 failing
- [x] \`cargo test -p onnx-official-tests\` (debug) — 484 passing, 0 failing
- [x] \`cargo fmt --all --check\` — clean
- [x] \`cargo clippy -p burn-onnx -p onnx-ir -p onnx-official-tests\` — no new warnings in touched crates

Closes #317