### PR TITLE
chore(deps): bump burn rev to 8cc356e4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -484,7 +484,7 @@ checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 [[package]]
 name = "burn"
 version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=c33867c60a99958aafd4d05df782c68d242a6510#c33867c60a99958aafd4d05df782c68d242a6510"
+source = "git+https://github.com/tracel-ai/burn?rev=8cc356e410f6e3a5f0b63b95a09761ffd7f1550c#8cc356e410f6e3a5f0b63b95a09761ffd7f1550c"
 dependencies = [
  "burn-autodiff",
  "burn-candle",
@@ -508,7 +508,7 @@ dependencies = [
 [[package]]
 name = "burn-autodiff"
 version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=c33867c60a99958aafd4d05df782c68d242a6510#c33867c60a99958aafd4d05df782c68d242a6510"
+source = "git+https://github.com/tracel-ai/burn?rev=8cc356e410f6e3a5f0b63b95a09761ffd7f1550c#8cc356e410f6e3a5f0b63b95a09761ffd7f1550c"
 dependencies = [
  "burn-backend",
  "burn-std",
@@ -524,7 +524,7 @@ dependencies = [
 [[package]]
 name = "burn-backend"
 version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=c33867c60a99958aafd4d05df782c68d242a6510#c33867c60a99958aafd4d05df782c68d242a6510"
+source = "git+https://github.com/tracel-ai/burn?rev=8cc356e410f6e3a5f0b63b95a09761ffd7f1550c#8cc356e410f6e3a5f0b63b95a09761ffd7f1550c"
 dependencies = [
  "burn-std",
  "bytemuck",
@@ -534,7 +534,7 @@ dependencies = [
  "hashbrown 0.16.1",
  "num-traits",
  "portable-atomic-util",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rand_distr 0.6.0",
  "serde",
  "spin",
@@ -544,7 +544,7 @@ dependencies = [
 [[package]]
 name = "burn-candle"
 version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=c33867c60a99958aafd4d05df782c68d242a6510#c33867c60a99958aafd4d05df782c68d242a6510"
+source = "git+https://github.com/tracel-ai/burn?rev=8cc356e410f6e3a5f0b63b95a09761ffd7f1550c#8cc356e410f6e3a5f0b63b95a09761ffd7f1550c"
 dependencies = [
  "burn-backend",
  "burn-std",
@@ -555,7 +555,7 @@ dependencies = [
 [[package]]
 name = "burn-core"
 version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=c33867c60a99958aafd4d05df782c68d242a6510#c33867c60a99958aafd4d05df782c68d242a6510"
+source = "git+https://github.com/tracel-ai/burn?rev=8cc356e410f6e3a5f0b63b95a09761ffd7f1550c#8cc356e410f6e3a5f0b63b95a09761ffd7f1550c"
 dependencies = [
  "ahash",
  "bincode",
@@ -572,7 +572,7 @@ dependencies = [
  "num-traits",
  "portable-atomic",
  "portable-atomic-util",
- "rand 0.10.0",
+ "rand 0.10.1",
  "regex",
  "rmp-serde",
  "serde",
@@ -585,7 +585,7 @@ dependencies = [
 [[package]]
 name = "burn-cpu"
 version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=c33867c60a99958aafd4d05df782c68d242a6510#c33867c60a99958aafd4d05df782c68d242a6510"
+source = "git+https://github.com/tracel-ai/burn?rev=8cc356e410f6e3a5f0b63b95a09761ffd7f1550c#8cc356e410f6e3a5f0b63b95a09761ffd7f1550c"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -596,7 +596,7 @@ dependencies = [
 [[package]]
 name = "burn-cubecl"
 version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=c33867c60a99958aafd4d05df782c68d242a6510#c33867c60a99958aafd4d05df782c68d242a6510"
+source = "git+https://github.com/tracel-ai/burn?rev=8cc356e410f6e3a5f0b63b95a09761ffd7f1550c#8cc356e410f6e3a5f0b63b95a09761ffd7f1550c"
 dependencies = [
  "burn-backend",
  "burn-cubecl-fusion",
@@ -615,7 +615,7 @@ dependencies = [
 [[package]]
 name = "burn-cubecl-fusion"
 version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=c33867c60a99958aafd4d05df782c68d242a6510#c33867c60a99958aafd4d05df782c68d242a6510"
+source = "git+https://github.com/tracel-ai/burn?rev=8cc356e410f6e3a5f0b63b95a09761ffd7f1550c#8cc356e410f6e3a5f0b63b95a09761ffd7f1550c"
 dependencies = [
  "burn-backend",
  "burn-fusion",
@@ -630,7 +630,7 @@ dependencies = [
 [[package]]
 name = "burn-cuda"
 version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=c33867c60a99958aafd4d05df782c68d242a6510#c33867c60a99958aafd4d05df782c68d242a6510"
+source = "git+https://github.com/tracel-ai/burn?rev=8cc356e410f6e3a5f0b63b95a09761ffd7f1550c#8cc356e410f6e3a5f0b63b95a09761ffd7f1550c"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -641,7 +641,7 @@ dependencies = [
 [[package]]
 name = "burn-dataset"
 version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=c33867c60a99958aafd4d05df782c68d242a6510#c33867c60a99958aafd4d05df782c68d242a6510"
+source = "git+https://github.com/tracel-ai/burn?rev=8cc356e410f6e3a5f0b63b95a09761ffd7f1550c#8cc356e410f6e3a5f0b63b95a09761ffd7f1550c"
 dependencies = [
  "burn-std",
  "csv",
@@ -650,7 +650,7 @@ dependencies = [
  "flate2",
  "globwalk",
  "image",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rmp-serde",
  "sanitize-filename",
  "serde",
@@ -663,7 +663,7 @@ dependencies = [
 [[package]]
 name = "burn-derive"
 version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=c33867c60a99958aafd4d05df782c68d242a6510#c33867c60a99958aafd4d05df782c68d242a6510"
+source = "git+https://github.com/tracel-ai/burn?rev=8cc356e410f6e3a5f0b63b95a09761ffd7f1550c#8cc356e410f6e3a5f0b63b95a09761ffd7f1550c"
 dependencies = [
  "derive-new",
  "proc-macro2",
@@ -674,7 +674,7 @@ dependencies = [
 [[package]]
 name = "burn-dispatch"
 version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=c33867c60a99958aafd4d05df782c68d242a6510#c33867c60a99958aafd4d05df782c68d242a6510"
+source = "git+https://github.com/tracel-ai/burn?rev=8cc356e410f6e3a5f0b63b95a09761ffd7f1550c#8cc356e410f6e3a5f0b63b95a09761ffd7f1550c"
 dependencies = [
  "burn-autodiff",
  "burn-backend",
@@ -691,7 +691,7 @@ dependencies = [
 [[package]]
 name = "burn-flex"
 version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=c33867c60a99958aafd4d05df782c68d242a6510#c33867c60a99958aafd4d05df782c68d242a6510"
+source = "git+https://github.com/tracel-ai/burn?rev=8cc356e410f6e3a5f0b63b95a09761ffd7f1550c#8cc356e410f6e3a5f0b63b95a09761ffd7f1550c"
 dependencies = [
  "burn-backend",
  "burn-ir",
@@ -708,7 +708,7 @@ dependencies = [
 [[package]]
 name = "burn-fusion"
 version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=c33867c60a99958aafd4d05df782c68d242a6510#c33867c60a99958aafd4d05df782c68d242a6510"
+source = "git+https://github.com/tracel-ai/burn?rev=8cc356e410f6e3a5f0b63b95a09761ffd7f1550c#8cc356e410f6e3a5f0b63b95a09761ffd7f1550c"
 dependencies = [
  "burn-backend",
  "burn-ir",
@@ -732,7 +732,7 @@ dependencies = [
 [[package]]
 name = "burn-ir"
 version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=c33867c60a99958aafd4d05df782c68d242a6510#c33867c60a99958aafd4d05df782c68d242a6510"
+source = "git+https://github.com/tracel-ai/burn?rev=8cc356e410f6e3a5f0b63b95a09761ffd7f1550c#8cc356e410f6e3a5f0b63b95a09761ffd7f1550c"
 dependencies = [
  "burn-backend",
  "hashbrown 0.16.1",
@@ -742,7 +742,7 @@ dependencies = [
 [[package]]
 name = "burn-ndarray"
 version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=c33867c60a99958aafd4d05df782c68d242a6510#c33867c60a99958aafd4d05df782c68d242a6510"
+source = "git+https://github.com/tracel-ai/burn?rev=8cc356e410f6e3a5f0b63b95a09761ffd7f1550c#8cc356e410f6e3a5f0b63b95a09761ffd7f1550c"
 dependencies = [
  "atomic_float",
  "burn-autodiff",
@@ -758,13 +758,13 @@ dependencies = [
  "paste",
  "portable-atomic",
  "portable-atomic-util",
- "rand 0.10.0",
+ "rand 0.10.1",
 ]
 
 [[package]]
 name = "burn-nn"
 version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=c33867c60a99958aafd4d05df782c68d242a6510#c33867c60a99958aafd4d05df782c68d242a6510"
+source = "git+https://github.com/tracel-ai/burn?rev=8cc356e410f6e3a5f0b63b95a09761ffd7f1550c#8cc356e410f6e3a5f0b63b95a09761ffd7f1550c"
 dependencies = [
  "burn-core",
  "num-traits",
@@ -1054,7 +1054,7 @@ dependencies = [
 [[package]]
 name = "burn-optim"
 version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=c33867c60a99958aafd4d05df782c68d242a6510#c33867c60a99958aafd4d05df782c68d242a6510"
+source = "git+https://github.com/tracel-ai/burn?rev=8cc356e410f6e3a5f0b63b95a09761ffd7f1550c#8cc356e410f6e3a5f0b63b95a09761ffd7f1550c"
 dependencies = [
  "burn-core",
  "derive-new",
@@ -1067,7 +1067,7 @@ dependencies = [
 [[package]]
 name = "burn-rocm"
 version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=c33867c60a99958aafd4d05df782c68d242a6510#c33867c60a99958aafd4d05df782c68d242a6510"
+source = "git+https://github.com/tracel-ai/burn?rev=8cc356e410f6e3a5f0b63b95a09761ffd7f1550c#8cc356e410f6e3a5f0b63b95a09761ffd7f1550c"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -1078,7 +1078,7 @@ dependencies = [
 [[package]]
 name = "burn-router"
 version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=c33867c60a99958aafd4d05df782c68d242a6510#c33867c60a99958aafd4d05df782c68d242a6510"
+source = "git+https://github.com/tracel-ai/burn?rev=8cc356e410f6e3a5f0b63b95a09761ffd7f1550c#8cc356e410f6e3a5f0b63b95a09761ffd7f1550c"
 dependencies = [
  "burn-backend",
  "burn-ir",
@@ -1091,7 +1091,7 @@ dependencies = [
 [[package]]
 name = "burn-std"
 version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=c33867c60a99958aafd4d05df782c68d242a6510#c33867c60a99958aafd4d05df782c68d242a6510"
+source = "git+https://github.com/tracel-ai/burn?rev=8cc356e410f6e3a5f0b63b95a09761ffd7f1550c#8cc356e410f6e3a5f0b63b95a09761ffd7f1550c"
 dependencies = [
  "bytemuck",
  "bytes",
@@ -1110,7 +1110,7 @@ dependencies = [
 [[package]]
 name = "burn-store"
 version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=c33867c60a99958aafd4d05df782c68d242a6510#c33867c60a99958aafd4d05df782c68d242a6510"
+source = "git+https://github.com/tracel-ai/burn?rev=8cc356e410f6e3a5f0b63b95a09761ffd7f1550c#8cc356e410f6e3a5f0b63b95a09761ffd7f1550c"
 dependencies = [
  "burn-core",
  "burn-tensor",
@@ -1125,13 +1125,13 @@ dependencies = [
  "serde",
  "tar",
  "textdistance",
- "zip 8.4.0",
+ "zip 8.5.1",
 ]
 
 [[package]]
 name = "burn-tch"
 version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=c33867c60a99958aafd4d05df782c68d242a6510#c33867c60a99958aafd4d05df782c68d242a6510"
+source = "git+https://github.com/tracel-ai/burn?rev=8cc356e410f6e3a5f0b63b95a09761ffd7f1550c#8cc356e410f6e3a5f0b63b95a09761ffd7f1550c"
 dependencies = [
  "burn-backend",
  "cc",
@@ -1144,7 +1144,7 @@ dependencies = [
 [[package]]
 name = "burn-tensor"
 version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=c33867c60a99958aafd4d05df782c68d242a6510#c33867c60a99958aafd4d05df782c68d242a6510"
+source = "git+https://github.com/tracel-ai/burn?rev=8cc356e410f6e3a5f0b63b95a09761ffd7f1550c#8cc356e410f6e3a5f0b63b95a09761ffd7f1550c"
 dependencies = [
  "burn-backend",
  "burn-std",
@@ -1157,13 +1157,17 @@ dependencies = [
 [[package]]
 name = "burn-vision"
 version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=c33867c60a99958aafd4d05df782c68d242a6510#c33867c60a99958aafd4d05df782c68d242a6510"
+source = "git+https://github.com/tracel-ai/burn?rev=8cc356e410f6e3a5f0b63b95a09761ffd7f1550c#8cc356e410f6e3a5f0b63b95a09761ffd7f1550c"
 dependencies = [
  "aligned-vec",
  "bon",
+ "burn-cubecl",
+ "burn-fusion",
  "burn-ir",
+ "burn-tch",
  "burn-tensor",
  "bytemuck",
+ "cubecl",
  "derive-new",
  "half",
  "image",
@@ -1177,7 +1181,7 @@ dependencies = [
 [[package]]
 name = "burn-wgpu"
 version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=c33867c60a99958aafd4d05df782c68d242a6510#c33867c60a99958aafd4d05df782c68d242a6510"
+source = "git+https://github.com/tracel-ai/burn?rev=8cc356e410f6e3a5f0b63b95a09761ffd7f1550c#8cc356e410f6e3a5f0b63b95a09761ffd7f1550c"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -1459,7 +1463,7 @@ checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
 dependencies = [
  "serde",
  "termcolor",
- "unicode-width 0.2.2",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -1899,7 +1903,7 @@ dependencies = [
  "parking_lot",
  "portable-atomic",
  "portable-atomic-util",
- "rand 0.10.0",
+ "rand 0.10.1",
  "sanitize-filename",
  "serde",
  "serde_bytes",
@@ -2276,7 +2280,7 @@ dependencies = [
  "cubecl-common",
  "half",
  "num-traits",
- "rand 0.10.0",
+ "rand 0.10.1",
  "serde",
 ]
 
@@ -5803,9 +5807,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
@@ -5873,7 +5877,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d431c2703ccf129de4d45253c03f49ebb22b97d6ad79ee3ecfc7e3f4862c1d8"
 dependencies = [
  "num-traits",
- "rand 0.10.0",
+ "rand 0.10.1",
 ]
 
 [[package]]
@@ -7164,9 +7168,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.51.0"
+version = "1.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd1c4c0fc4a7ab90fc15ef6daaa3ec3b893f004f915f2392557ed23237820cd"
+checksum = "a91135f59b1cbf38c91e73cf3386fca9bb77915c45ce2771460c9d92f0f3d776"
 dependencies = [
  "bytes",
  "libc",
@@ -8773,9 +8777,9 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "8.4.0"
+version = "8.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7756d0206d058333667493c4014f545f4b9603c4330ccd6d9b3f86dcab59f7d9"
+checksum = "dcab981e19633ebcf0b001ddd37dd802996098bc1864f90b7c5d970ce76c1d59"
 dependencies = [
  "aes",
  "bzip2 0.6.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,10 +78,10 @@ memmap2 = { version = "0.9" }
 thiserror = { version = "2.0.18", default-features = false }
 toml = { version = "1.1.0", default-features = false, features = ["parse", "serde"] }
 
-burn = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "c33867c60a99958aafd4d05df782c68d242a6510" }
-burn-flex = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "c33867c60a99958aafd4d05df782c68d242a6510" }
-burn-store = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "c33867c60a99958aafd4d05df782c68d242a6510" }
-burn-tensor = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "c33867c60a99958aafd4d05df782c68d242a6510" }
+burn = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "8cc356e410f6e3a5f0b63b95a09761ffd7f1550c" }
+burn-flex = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "8cc356e410f6e3a5f0b63b95a09761ffd7f1550c" }
+burn-store = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "8cc356e410f6e3a5f0b63b95a09761ffd7f1550c" }
+burn-tensor = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "8cc356e410f6e3a5f0b63b95a09761ffd7f1550c" }
 
 ### For local development. ###
 # burn = { path = "../burn/crates/burn", default-features = false }

--- a/crates/burn-onnx/src/burn/node/det.rs
+++ b/crates/burn-onnx/src/burn/node/det.rs
@@ -23,16 +23,17 @@ impl NodeCodegen for onnx_ir::node::det::DetNode {
         match input_rank {
             2 => {
                 // 2D non-batched: compute determinant via LU decomposition with partial pivoting
-                // det(A) = sign(P) * product_of_diagonal(U), where PA = LU
+                // det(A) = sign(P) * product_of_diagonal(U), where A = P L U
                 quote! {
                     let #output = {
-                        let (lu_mat, permutations) =
-                            burn::tensor::linalg::lu_decomposition(#input);
+                        let (p, _l, u) =
+                            burn::tensor::linalg::lu::<B, 2usize, 1usize>(#input);
                         let det_u =
-                            burn::tensor::linalg::diag::<B, 2usize, 1usize, Float>(lu_mat)
+                            burn::tensor::linalg::diag::<B, 2usize, 1usize, Float>(u)
                                 .prod();
-                        let n = permutations.dims()[0];
-                        let perm_f = permutations.float().cast(burn::tensor::DType::F32);
+                        let n = p.dims()[0];
+                        let perm_vec = p.argmax(1).reshape([n]);
+                        let perm_f = perm_vec.float().cast(burn::tensor::DType::F32);
                         let perm_col = perm_f.clone().reshape([n, 1]);
                         let perm_row = perm_f.reshape([1, n]);
                         let inv_count = (perm_row - perm_col)
@@ -70,13 +71,14 @@ impl NodeCodegen for onnx_ir::node::det::DetNode {
                         for i in 0..batch_size {
                             let matrix: Tensor<B, 2, Float> =
                                 flat.clone().slice([i..(i + 1), 0..m, 0..m]).squeeze_dims::<2>(&[0]);
-                            let (lu_mat, permutations) =
-                                burn::tensor::linalg::lu_decomposition(matrix);
+                            let (p, _l, u) =
+                                burn::tensor::linalg::lu::<B, 2usize, 1usize>(matrix);
                             let det_u =
-                                burn::tensor::linalg::diag::<B, 2usize, 1usize, Float>(lu_mat)
+                                burn::tensor::linalg::diag::<B, 2usize, 1usize, Float>(u)
                                     .prod();
-                            let n = permutations.dims()[0];
-                            let perm_f = permutations.float().cast(burn::tensor::DType::F32);
+                            let n = p.dims()[0];
+                            let perm_vec = p.argmax(1).reshape([n]);
+                            let perm_f = perm_vec.float().cast(burn::tensor::DType::F32);
                             let perm_col = perm_f.clone().reshape([n, 1]);
                             let perm_row = perm_f.reshape([1, n]);
                             let inv_count = (perm_row - perm_col)
@@ -121,11 +123,11 @@ mod tests {
         assert_snapshot!(code, @r"
         pub fn forward(&self, input: Tensor<B, 2>) -> Tensor<B, 1> {
             let output = {
-                let (lu_mat, permutations) = burn::tensor::linalg::lu_decomposition(input);
-                let det_u = burn::tensor::linalg::diag::<B, 2usize, 1usize, Float>(lu_mat)
-                    .prod();
-                let n = permutations.dims()[0];
-                let perm_f = permutations.float().cast(burn::tensor::DType::F32);
+                let (p, _l, u) = burn::tensor::linalg::lu::<B, 2usize, 1usize>(input);
+                let det_u = burn::tensor::linalg::diag::<B, 2usize, 1usize, Float>(u).prod();
+                let n = p.dims()[0];
+                let perm_vec = p.argmax(1).reshape([n]);
+                let perm_f = perm_vec.float().cast(burn::tensor::DType::F32);
                 let perm_col = perm_f.clone().reshape([n, 1]);
                 let perm_row = perm_f.reshape([1, n]);
                 let inv_count = (perm_row - perm_col)
@@ -168,11 +170,11 @@ mod tests {
                         .clone()
                         .slice([i..(i + 1), 0..m, 0..m])
                         .squeeze_dims::<2>(&[0]);
-                    let (lu_mat, permutations) = burn::tensor::linalg::lu_decomposition(matrix);
-                    let det_u = burn::tensor::linalg::diag::<B, 2usize, 1usize, Float>(lu_mat)
-                        .prod();
-                    let n = permutations.dims()[0];
-                    let perm_f = permutations.float().cast(burn::tensor::DType::F32);
+                    let (p, _l, u) = burn::tensor::linalg::lu::<B, 2usize, 1usize>(matrix);
+                    let det_u = burn::tensor::linalg::diag::<B, 2usize, 1usize, Float>(u).prod();
+                    let n = p.dims()[0];
+                    let perm_vec = p.argmax(1).reshape([n]);
+                    let perm_f = perm_vec.float().cast(burn::tensor::DType::F32);
                     let perm_col = perm_f.clone().reshape([n, 1]);
                     let perm_row = perm_f.reshape([1, n]);
                     let inv_count = (perm_row - perm_col)

--- a/crates/onnx-ir/src/node/det.rs
+++ b/crates/onnx-ir/src/node/det.rs
@@ -24,7 +24,7 @@
 //! Both 2D (non-batched) and batched inputs (`[*, M, M]`) are supported. For batched inputs
 //! the determinant is computed per-matrix using a loop over batch dimensions.
 //!
-//! **Limitation**: Singular or near-singular matrices cause a panic from `lu_decomposition`
+//! **Limitation**: Singular or near-singular matrices cause a panic from `linalg::lu`
 //! when partial pivoting encounters a pivot with magnitude <= 1e-6. A native `det()` function
 //! in Burn would handle this case correctly (tracked as a separate issue in the Burn repo).
 

--- a/scoreboard/runner/Cargo.toml
+++ b/scoreboard/runner/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2024"
 [workspace]
 
 [dependencies]
-burn = { git = "https://github.com/tracel-ai/burn", default-features = false, features = ["std", "flex"], rev = "c33867c60a99958aafd4d05df782c68d242a6510" }
-burn-store = { git = "https://github.com/tracel-ai/burn", default-features = false, features = ["burnpack", "std"], rev = "c33867c60a99958aafd4d05df782c68d242a6510" }
+burn = { git = "https://github.com/tracel-ai/burn", default-features = false, features = ["std", "flex"], rev = "8cc356e410f6e3a5f0b63b95a09761ffd7f1550c" }
+burn-store = { git = "https://github.com/tracel-ai/burn", default-features = false, features = ["burnpack", "std"], rev = "8cc356e410f6e3a5f0b63b95a09761ffd7f1550c" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 


### PR DESCRIPTION
## Summary
- Bumps burn git rev from `c33867c6` to `8cc356e4` (latest `tracel-ai/burn` main) across the workspace and `scoreboard/runner`.
- Adapts `Det` codegen to burn's renamed LU API: `linalg::lu_decomposition(t) -> (lu_mat, pivot_vec)` is now `linalg::lu::<B, D, D1>(t) -> (P, L, U)`. Recover the permutation vector for sign-of-permutation via `p.argmax(1).reshape([n])`.

## Test plan
- [x] `cargo test -p burn-onnx det::` (unit + snapshot tests pass after snapshot update)
- [x] `cargo test -p onnx-tests det` (`det_2x2` and `det_batched_3x3` integration tests pass against `onnx.reference.ReferenceEvaluator` ground truth)
- [x] `cargo check -p burn-onnx -p onnx-ir -p onnx-tests` clean