### PR TITLE
Centralize internal crates in [workspace.dependencies]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,18 @@ broken_intra_doc_links = "deny"
 invalid_html_tags = "deny"
 
 [workspace.dependencies]
+### Internal crates ###
+# Declared here so each consumer Cargo.toml can use `workspace = true` instead of
+# repeating the path and version. Workspace deps pin `default-features = false`
+# (Cargo forbids consumers from overriding default-features when inheriting via
+# `workspace = true`); consumers that previously had defaults ON now opt in via
+# `features = ["default"]`.
+burn-import = { path = "crates/burn-import", version = "=0.21.0-pre.3", default-features = false }
+burn-onnx = { path = "crates/burn-onnx", version = "=0.21.0-pre.3", default-features = false }
+onnx-ir = { path = "crates/onnx-ir", version = "=0.21.0-pre.3", default-features = false }
+onnx-ir-derive = { path = "crates/onnx-ir-derive", version = "=0.21.0-pre.3" }
+model-checks-common = { path = "crates/model-checks/common" }
+
 bytemuck = "1.25.0"
 derive-new = { version = "0.7.0", default-features = false }
 float-cmp = "0.10.0"

--- a/crates/burn-import/Cargo.toml
+++ b/crates/burn-import/Cargo.toml
@@ -21,7 +21,7 @@ onnx = []
 mmap = ["burn-onnx/mmap"]
 
 [dependencies]
-burn-onnx = { path = "../burn-onnx", version = "=0.21.0-pre.3", default-features = false }
+burn-onnx = { workspace = true }
 
 [package.metadata.docs.rs]
 features = ["default"]

--- a/crates/burn-onnx/Cargo.toml
+++ b/crates/burn-onnx/Cargo.toml
@@ -22,7 +22,7 @@ default = ["mmap"]
 mmap = ["onnx-ir/mmap"]
 
 [dependencies]
-onnx-ir = { path = "../onnx-ir", version = "=0.21.0-pre.3", default-features = false }
+onnx-ir = { workspace = true }
 
 burn = { workspace = true, features = ["std", "flex"] }
 burn-store = { workspace = true, features = [

--- a/crates/model-checks/albert/Cargo.toml
+++ b/crates/model-checks/albert/Cargo.toml
@@ -15,8 +15,8 @@ metal = ["burn/metal", "burn/autotune", "burn/fusion"]
 [dependencies]
 burn = { workspace = true }
 burn-store = { workspace = true, features = ["std", "burnpack", "pytorch"] }
-model-checks-common = { path = "../common" }
+model-checks-common = { workspace = true }
 
 [build-dependencies]
-burn-onnx = { path = "../../burn-onnx" }
-model-checks-common = { path = "../common" }
+burn-onnx = { workspace = true, features = ["default"] }
+model-checks-common = { workspace = true }

--- a/crates/model-checks/alexnet/Cargo.toml
+++ b/crates/model-checks/alexnet/Cargo.toml
@@ -14,8 +14,8 @@ metal = ["burn/metal", "burn/autotune", "burn/fusion"]
 [dependencies]
 burn = { workspace = true }
 burn-store = { workspace = true, features = ["std", "burnpack", "pytorch"] }
-model-checks-common = { path = "../common" }
+model-checks-common = { workspace = true }
 
 [build-dependencies]
-burn-onnx = { path = "../../burn-onnx" }
-model-checks-common = { path = "../common" }
+burn-onnx = { workspace = true, features = ["default"] }
+model-checks-common = { workspace = true }

--- a/crates/model-checks/all-minilm-l6-v2/Cargo.toml
+++ b/crates/model-checks/all-minilm-l6-v2/Cargo.toml
@@ -15,8 +15,8 @@ metal = ["burn/metal", "burn/autotune", "burn/fusion"]
 [dependencies]
 burn = { workspace = true }
 burn-store = { workspace = true, features = ["std", "burnpack", "pytorch"] }
-model-checks-common = { path = "../common" }
+model-checks-common = { workspace = true }
 
 [build-dependencies]
-burn-onnx = { path = "../../burn-onnx" }
-model-checks-common = { path = "../common" }
+burn-onnx = { workspace = true, features = ["default"] }
+model-checks-common = { workspace = true }

--- a/crates/model-checks/arcface/Cargo.toml
+++ b/crates/model-checks/arcface/Cargo.toml
@@ -15,8 +15,8 @@ metal = ["burn/metal", "burn/autotune", "burn/fusion"]
 [dependencies]
 burn = { workspace = true }
 burn-store = { workspace = true, features = ["std", "burnpack", "pytorch"] }
-model-checks-common = { path = "../common" }
+model-checks-common = { workspace = true }
 
 [build-dependencies]
-burn-onnx = { path = "../../burn-onnx" }
-model-checks-common = { path = "../common" }
+burn-onnx = { workspace = true, features = ["default"] }
+model-checks-common = { workspace = true }

--- a/crates/model-checks/clip-vit-b-32-text/Cargo.toml
+++ b/crates/model-checks/clip-vit-b-32-text/Cargo.toml
@@ -15,8 +15,8 @@ metal = ["burn/metal", "burn/autotune", "burn/fusion"]
 [dependencies]
 burn = { workspace = true }
 burn-store = { workspace = true, features = ["std", "burnpack", "pytorch"] }
-model-checks-common = { path = "../common" }
+model-checks-common = { workspace = true }
 
 [build-dependencies]
-burn-onnx = { path = "../../burn-onnx" }
-model-checks-common = { path = "../common" }
+burn-onnx = { workspace = true, features = ["default"] }
+model-checks-common = { workspace = true }

--- a/crates/model-checks/clip-vit-b-32-vision/Cargo.toml
+++ b/crates/model-checks/clip-vit-b-32-vision/Cargo.toml
@@ -15,8 +15,8 @@ metal = ["burn/metal", "burn/autotune", "burn/fusion"]
 [dependencies]
 burn = { workspace = true }
 burn-store = { workspace = true, features = ["std", "burnpack", "pytorch"] }
-model-checks-common = { path = "../common" }
+model-checks-common = { workspace = true }
 
 [build-dependencies]
-burn-onnx = { path = "../../burn-onnx" }
-model-checks-common = { path = "../common" }
+burn-onnx = { workspace = true, features = ["default"] }
+model-checks-common = { workspace = true }

--- a/crates/model-checks/densenet121/Cargo.toml
+++ b/crates/model-checks/densenet121/Cargo.toml
@@ -14,8 +14,8 @@ metal = ["burn/metal", "burn/autotune", "burn/fusion"]
 [dependencies]
 burn = { workspace = true }
 burn-store = { workspace = true, features = ["std", "burnpack", "pytorch"] }
-model-checks-common = { path = "../common" }
+model-checks-common = { workspace = true }
 
 [build-dependencies]
-burn-onnx = { path = "../../burn-onnx" }
-model-checks-common = { path = "../common" }
+burn-onnx = { workspace = true, features = ["default"] }
+model-checks-common = { workspace = true }

--- a/crates/model-checks/depth-anything-v2/Cargo.toml
+++ b/crates/model-checks/depth-anything-v2/Cargo.toml
@@ -15,8 +15,8 @@ metal = ["burn/metal", "burn/autotune", "burn/fusion"]
 [dependencies]
 burn = { workspace = true }
 burn-store = { workspace = true, features = ["std", "burnpack", "pytorch"] }
-model-checks-common = { path = "../common" }
+model-checks-common = { workspace = true }
 
 [build-dependencies]
-burn-onnx = { path = "../../burn-onnx" }
-model-checks-common = { path = "../common" }
+burn-onnx = { workspace = true, features = ["default"] }
+model-checks-common = { workspace = true }

--- a/crates/model-checks/depth-pro/Cargo.toml
+++ b/crates/model-checks/depth-pro/Cargo.toml
@@ -15,8 +15,8 @@ metal = ["burn/metal", "burn/autotune", "burn/fusion"]
 [dependencies]
 burn = { workspace = true }
 burn-store = { workspace = true, features = ["std", "burnpack", "pytorch"] }
-model-checks-common = { path = "../common" }
+model-checks-common = { workspace = true }
 
 [build-dependencies]
-burn-onnx = { path = "../../burn-onnx" }
-model-checks-common = { path = "../common" }
+burn-onnx = { workspace = true, features = ["default"] }
+model-checks-common = { workspace = true }

--- a/crates/model-checks/inception-v1/Cargo.toml
+++ b/crates/model-checks/inception-v1/Cargo.toml
@@ -14,8 +14,8 @@ metal = ["burn/metal", "burn/autotune", "burn/fusion"]
 [dependencies]
 burn = { workspace = true }
 burn-store = { workspace = true, features = ["std", "burnpack", "pytorch"] }
-model-checks-common = { path = "../common" }
+model-checks-common = { workspace = true }
 
 [build-dependencies]
-burn-onnx = { path = "../../burn-onnx" }
-model-checks-common = { path = "../common" }
+burn-onnx = { workspace = true, features = ["default"] }
+model-checks-common = { workspace = true }

--- a/crates/model-checks/inception-v2/Cargo.toml
+++ b/crates/model-checks/inception-v2/Cargo.toml
@@ -14,8 +14,8 @@ metal = ["burn/metal", "burn/autotune", "burn/fusion"]
 [dependencies]
 burn = { workspace = true }
 burn-store = { workspace = true, features = ["std", "burnpack", "pytorch"] }
-model-checks-common = { path = "../common" }
+model-checks-common = { workspace = true }
 
 [build-dependencies]
-burn-onnx = { path = "../../burn-onnx" }
-model-checks-common = { path = "../common" }
+burn-onnx = { workspace = true, features = ["default"] }
+model-checks-common = { workspace = true }

--- a/crates/model-checks/kokoro/Cargo.toml
+++ b/crates/model-checks/kokoro/Cargo.toml
@@ -19,13 +19,13 @@ bisect = []
 [dependencies]
 burn = { workspace = true }
 burn-store = { workspace = true, features = ["std", "burnpack"] }
-model-checks-common = { path = "../common" }
+model-checks-common = { workspace = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
 [build-dependencies]
-burn-onnx = { path = "../../burn-onnx" }
-model-checks-common = { path = "../common" }
+burn-onnx = { workspace = true, features = ["default"] }
+model-checks-common = { workspace = true }
 
 [[bin]]
 name = "burn-onnx-model-checks-kokoro"

--- a/crates/model-checks/mediapipe-face-detector/Cargo.toml
+++ b/crates/model-checks/mediapipe-face-detector/Cargo.toml
@@ -15,8 +15,8 @@ metal = ["burn/metal", "burn/autotune", "burn/fusion"]
 [dependencies]
 burn = { workspace = true }
 burn-store = { workspace = true, features = ["std", "burnpack", "pytorch"] }
-model-checks-common = { path = "../common" }
+model-checks-common = { workspace = true }
 
 [build-dependencies]
-burn-onnx = { path = "../../burn-onnx" }
-model-checks-common = { path = "../common" }
+burn-onnx = { workspace = true, features = ["default"] }
+model-checks-common = { workspace = true }

--- a/crates/model-checks/mobilenet-v2/Cargo.toml
+++ b/crates/model-checks/mobilenet-v2/Cargo.toml
@@ -14,8 +14,8 @@ metal = ["burn/metal", "burn/autotune", "burn/fusion"]
 [dependencies]
 burn = { workspace = true }
 burn-store = { workspace = true, features = ["std", "burnpack", "pytorch"] }
-model-checks-common = { path = "../common" }
+model-checks-common = { workspace = true }
 
 [build-dependencies]
-burn-onnx = { path = "../../burn-onnx" }
-model-checks-common = { path = "../common" }
+burn-onnx = { workspace = true, features = ["default"] }
+model-checks-common = { workspace = true }

--- a/crates/model-checks/modernbert-base/Cargo.toml
+++ b/crates/model-checks/modernbert-base/Cargo.toml
@@ -15,8 +15,8 @@ metal = ["burn/metal", "burn/autotune", "burn/fusion"]
 [dependencies]
 burn = { workspace = true }
 burn-store = { workspace = true, features = ["std", "burnpack", "pytorch"] }
-model-checks-common = { path = "../common" }
+model-checks-common = { workspace = true }
 
 [build-dependencies]
-burn-onnx = { path = "../../burn-onnx" }
-model-checks-common = { path = "../common" }
+burn-onnx = { workspace = true, features = ["default"] }
+model-checks-common = { workspace = true }

--- a/crates/model-checks/qwen/Cargo.toml
+++ b/crates/model-checks/qwen/Cargo.toml
@@ -15,8 +15,8 @@ metal = ["burn/metal", "burn/autotune", "burn/fusion"]
 [dependencies]
 burn = { workspace = true }
 burn-store = { workspace = true, features = ["std", "burnpack", "pytorch"] }
-model-checks-common = { path = "../common" }
+model-checks-common = { workspace = true }
 
 [build-dependencies]
-burn-onnx = { path = "../../burn-onnx" }
-model-checks-common = { path = "../common" }
+burn-onnx = { workspace = true, features = ["default"] }
+model-checks-common = { workspace = true }

--- a/crates/model-checks/resnet50/Cargo.toml
+++ b/crates/model-checks/resnet50/Cargo.toml
@@ -14,8 +14,8 @@ metal = ["burn/metal", "burn/autotune", "burn/fusion"]
 [dependencies]
 burn = { workspace = true }
 burn-store = { workspace = true, features = ["std", "burnpack", "pytorch"] }
-model-checks-common = { path = "../common" }
+model-checks-common = { workspace = true }
 
 [build-dependencies]
-burn-onnx = { path = "../../burn-onnx" }
-model-checks-common = { path = "../common" }
+burn-onnx = { workspace = true, features = ["default"] }
+model-checks-common = { workspace = true }

--- a/crates/model-checks/rf-detr/Cargo.toml
+++ b/crates/model-checks/rf-detr/Cargo.toml
@@ -15,8 +15,8 @@ metal = ["burn/metal", "burn/autotune", "burn/fusion"]
 [dependencies]
 burn = { workspace = true }
 burn-store = { workspace = true, features = ["std", "burnpack", "pytorch"] }
-model-checks-common = { path = "../common" }
+model-checks-common = { workspace = true }
 
 [build-dependencies]
-burn-onnx = { path = "../../burn-onnx" }
-model-checks-common = { path = "../common" }
+burn-onnx = { workspace = true, features = ["default"] }
+model-checks-common = { workspace = true }

--- a/crates/model-checks/rtmw3d/Cargo.toml
+++ b/crates/model-checks/rtmw3d/Cargo.toml
@@ -15,8 +15,8 @@ metal = ["burn/metal", "burn/autotune", "burn/fusion"]
 [dependencies]
 burn = { workspace = true }
 burn-store = { workspace = true, features = ["std", "burnpack", "pytorch"] }
-model-checks-common = { path = "../common" }
+model-checks-common = { workspace = true }
 
 [build-dependencies]
-burn-onnx = { path = "../../burn-onnx" }
-model-checks-common = { path = "../common" }
+burn-onnx = { workspace = true, features = ["default"] }
+model-checks-common = { workspace = true }

--- a/crates/model-checks/shufflenet/Cargo.toml
+++ b/crates/model-checks/shufflenet/Cargo.toml
@@ -14,8 +14,8 @@ metal = ["burn/metal", "burn/autotune", "burn/fusion"]
 [dependencies]
 burn = { workspace = true }
 burn-store = { workspace = true, features = ["std", "burnpack", "pytorch"] }
-model-checks-common = { path = "../common" }
+model-checks-common = { workspace = true }
 
 [build-dependencies]
-burn-onnx = { path = "../../burn-onnx" }
-model-checks-common = { path = "../common" }
+burn-onnx = { workspace = true, features = ["default"] }
+model-checks-common = { workspace = true }

--- a/crates/model-checks/silero-vad/Cargo.toml
+++ b/crates/model-checks/silero-vad/Cargo.toml
@@ -15,10 +15,10 @@ metal = ["burn/metal", "burn/autotune", "burn/fusion"]
 [dependencies]
 burn = { workspace = true }
 burn-store = { workspace = true, features = ["std", "burnpack"] }
-model-checks-common = { path = "../common" }
+model-checks-common = { workspace = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
 [build-dependencies]
-burn-onnx = { path = "../../burn-onnx" }
-model-checks-common = { path = "../common" }
+burn-onnx = { workspace = true, features = ["default"] }
+model-checks-common = { workspace = true }

--- a/crates/model-checks/smollm/Cargo.toml
+++ b/crates/model-checks/smollm/Cargo.toml
@@ -15,8 +15,8 @@ metal = ["burn/metal", "burn/autotune", "burn/fusion"]
 [dependencies]
 burn = { workspace = true }
 burn-store = { workspace = true, features = ["std", "burnpack", "pytorch"] }
-model-checks-common = { path = "../common" }
+model-checks-common = { workspace = true }
 
 [build-dependencies]
-burn-onnx = { path = "../../burn-onnx" }
-model-checks-common = { path = "../common" }
+burn-onnx = { workspace = true, features = ["default"] }
+model-checks-common = { workspace = true }

--- a/crates/model-checks/squeezenet/Cargo.toml
+++ b/crates/model-checks/squeezenet/Cargo.toml
@@ -14,8 +14,8 @@ metal = ["burn/metal", "burn/autotune", "burn/fusion"]
 [dependencies]
 burn = { workspace = true }
 burn-store = { workspace = true, features = ["std", "burnpack", "pytorch"] }
-model-checks-common = { path = "../common" }
+model-checks-common = { workspace = true }
 
 [build-dependencies]
-burn-onnx = { path = "../../burn-onnx" }
-model-checks-common = { path = "../common" }
+burn-onnx = { workspace = true, features = ["default"] }
+model-checks-common = { workspace = true }

--- a/crates/model-checks/stable-diffusion-xl/Cargo.toml
+++ b/crates/model-checks/stable-diffusion-xl/Cargo.toml
@@ -15,8 +15,8 @@ metal = ["burn/metal", "burn/autotune", "burn/fusion"]
 [dependencies]
 burn = { workspace = true }
 burn-store = { workspace = true, features = ["std", "burnpack", "pytorch"] }
-model-checks-common = { path = "../common" }
+model-checks-common = { workspace = true }
 
 [build-dependencies]
-burn-onnx = { path = "../../burn-onnx" }
-model-checks-common = { path = "../common" }
+burn-onnx = { workspace = true, features = ["default"] }
+model-checks-common = { workspace = true }

--- a/crates/model-checks/vgg19/Cargo.toml
+++ b/crates/model-checks/vgg19/Cargo.toml
@@ -14,8 +14,8 @@ metal = ["burn/metal", "burn/autotune", "burn/fusion"]
 [dependencies]
 burn = { workspace = true }
 burn-store = { workspace = true, features = ["std", "burnpack", "pytorch"] }
-model-checks-common = { path = "../common" }
+model-checks-common = { workspace = true }
 
 [build-dependencies]
-burn-onnx = { path = "../../burn-onnx" }
-model-checks-common = { path = "../common" }
+burn-onnx = { workspace = true, features = ["default"] }
+model-checks-common = { workspace = true }

--- a/crates/model-checks/yolo/Cargo.toml
+++ b/crates/model-checks/yolo/Cargo.toml
@@ -15,8 +15,8 @@ metal = ["burn/metal", "burn/autotune", "burn/fusion"]
 [dependencies]
 burn = { workspace = true }
 burn-store = { workspace = true, features = ["std", "burnpack", "pytorch"] }
-model-checks-common = { path = "../common" }
+model-checks-common = { workspace = true }
 
 [build-dependencies]
-burn-onnx = { path = "../../burn-onnx" }
-model-checks-common = { path = "../common" }
+burn-onnx = { workspace = true, features = ["default"] }
+model-checks-common = { workspace = true }

--- a/crates/model-checks/zfnet512/Cargo.toml
+++ b/crates/model-checks/zfnet512/Cargo.toml
@@ -14,8 +14,8 @@ metal = ["burn/metal", "burn/autotune", "burn/fusion"]
 [dependencies]
 burn = { workspace = true }
 burn-store = { workspace = true, features = ["std", "burnpack", "pytorch"] }
-model-checks-common = { path = "../common" }
+model-checks-common = { workspace = true }
 
 [build-dependencies]
-burn-onnx = { path = "../../burn-onnx" }
-model-checks-common = { path = "../common" }
+burn-onnx = { workspace = true, features = ["default"] }
+model-checks-common = { workspace = true }

--- a/crates/onnx-ir/Cargo.toml
+++ b/crates/onnx-ir/Cargo.toml
@@ -20,7 +20,7 @@ default = ["mmap"]
 mmap = ["memmap2"]
 
 [dependencies]
-onnx-ir-derive = { path = "../onnx-ir-derive", version = "=0.21.0-pre.3" }
+onnx-ir-derive = { workspace = true }
 
 burn-tensor = { workspace = true }
 bytemuck = { workspace = true, features = ["extern_crate_alloc"] }

--- a/crates/onnx-official-tests/Cargo.toml
+++ b/crates/onnx-official-tests/Cargo.toml
@@ -15,7 +15,7 @@ test-metal = ["burn/metal"]
 test-candle = ["burn/candle"]
 
 [dependencies]
-onnx-ir = { path = "../onnx-ir" }
+onnx-ir = { workspace = true, features = ["default"] }
 protobuf = { workspace = true }
 serde = { workspace = true, features = ["std"] }
 thiserror = { workspace = true }
@@ -27,8 +27,8 @@ burn-store = { workspace = true, features = ["std", "burnpack"] }
 float-cmp = { workspace = true }
 
 [build-dependencies]
-burn-onnx = { path = "../burn-onnx" }
-onnx-ir = { path = "../onnx-ir" }
+burn-onnx = { workspace = true, features = ["default"] }
+onnx-ir = { workspace = true, features = ["default"] }
 protobuf = { workspace = true }
 serde = { workspace = true, features = ["std", "derive"] }
 toml = { workspace = true }

--- a/crates/onnx-tests/Cargo.toml
+++ b/crates/onnx-tests/Cargo.toml
@@ -21,4 +21,4 @@ insta = { workspace = true }
 half = { workspace = true }
 
 [build-dependencies]
-burn-onnx = { path = "../burn-onnx" }
+burn-onnx = { workspace = true, features = ["default"] }

--- a/examples/image-classification-web/Cargo.toml
+++ b/examples/image-classification-web/Cargo.toml
@@ -34,4 +34,4 @@ web-time = "1.1.0"
 
 [build-dependencies]
 # Used to generate code from ONNX model
-burn-onnx = { path = "../../crates/burn-onnx", default-features = false }
+burn-onnx = { workspace = true }

--- a/examples/onnx-inference/Cargo.toml
+++ b/examples/onnx-inference/Cargo.toml
@@ -15,4 +15,4 @@ burn-store = { workspace = true, features = ["std", "burnpack"] }
 serde = { workspace = true }
 
 [build-dependencies]
-burn-onnx = { path = "../../crates/burn-onnx" }
+burn-onnx = { workspace = true, features = ["default"] }

--- a/examples/raspberry-pi-pico/Cargo.toml
+++ b/examples/raspberry-pi-pico/Cargo.toml
@@ -34,7 +34,7 @@ burn-flex = { workspace = true, features = ["critical-section"] }
 burn-store = { workspace = true, features = ["burnpack"] }
 
 [build-dependencies]
-burn-onnx = { path = "../../crates/burn-onnx" }
+burn-onnx = { workspace = true, features = ["default"] }
 
 [profile.release]
 debug = 2


### PR DESCRIPTION
## Summary

- Add the five internal crates (`burn-import`, `burn-onnx`, `onnx-ir`, `onnx-ir-derive`, `model-checks-common`) to the root `[workspace.dependencies]` table.
- Sweep 35 consumer manifests so each internal dep is now `workspace = true` instead of repeating `path = "..", version = "=0.21.0-pre.3"`.
- Future version bumps touch only the root `Cargo.toml`.

Mirrors tracel-ai/burn#4876.

## Cargo gotcha

Cargo forbids consumers from overriding a workspace dep's `default-features` when inheriting via `workspace = true`. Workspace deps therefore pin `default-features = false`, and consumers that previously had defaults ON now opt back in via `features = ["default"]`. `onnx-ir-derive` has no `default` feature, so nothing is added there.

## Test plan

- [x] `cargo metadata --no-deps` resolves the workspace cleanly
- [x] `cargo check` (default-members) compiles with no errors
- [x] `cargo check -p burn-onnx-model-checks-resnet50` compiles
- [x] `YOLO_MODEL=yolov8n cargo check -p burn-onnx-model-checks-yolo` compiles
- [x] `cargo check -p onnx-inference` compiles