### PR TITLE
Remove generation of unused constants for Gather (closes #385)

### DIFF
--- a/crates/burn-onnx/src/burn/node/gather.rs
+++ b/crates/burn-onnx/src/burn/node/gather.rs
@@ -24,20 +24,26 @@ impl NodeCodegen for onnx_ir::gather::GatherNode {
     }
 }
 
-/// Convert a scalar index argument to an Ident suitable for use in generated code.
-/// For ScalarTensor, generates a let-binding that converts to native, returning the
-/// conversion code and the ident. For ScalarNative, returns empty code and the arg ident.
-fn scalar_index_to_ident(
+/// Resolves a scalar index argument to a token stream suitable for use in slices.
+/// Tries to inline a constant value first, falls back to runtime variables:
+/// - for ScalarTensor, generates a let-binding that converts to native, returning the
+///   conversion code and the ident code
+/// - for ScalarNative, returns empty code and the arg ident code
+fn resolve_scalar_index_token(
     index_arg: &Argument,
-    scope: &mut super::super::scope::ScopeAtPosition<'_>,
-) -> (proc_macro2::TokenStream, proc_macro2::Ident) {
-    if index_arg.ty.is_scalar_tensor() {
+    scope: &mut ScopeAtPosition<'_>,
+) -> (proc_macro2::TokenStream, proc_macro2::TokenStream) {
+    if let Some(resolved) = index_arg.value().and_then(|v| v.scalar_i64().ok()) {
+        let lit = proc_macro2::Literal::i64_unsuffixed(resolved);
+        (quote! {}, quote! { #lit })
+    } else if index_arg.ty.is_scalar_tensor() {
         let tensor = scope.arg(index_arg);
         let native_expr = on_device_to_native(quote! { #tensor }, &index_arg.ty.elem_type());
         let temp = Ident::new("__scalar_idx", Span::call_site());
-        (quote! { let #temp = #native_expr; }, temp)
+        (quote! { let #temp = #native_expr; }, quote! { #temp })
     } else {
-        (quote! {}, arg_to_ident(index_arg))
+        let index = arg_to_ident(index_arg);
+        (quote! {}, quote! { #index })
     }
 }
 
@@ -53,7 +59,7 @@ fn forward_shape_gather(
     let output = arg_to_ident(output_arg);
 
     // Helper: generate index resolution code for shape gather
-    let gen_index_resolve = |index: &proc_macro2::Ident| {
+    let gen_index_resolve = |index: &proc_macro2::TokenStream| {
         quote! {
             let actual_idx = if #index < 0 {
                 (#input_shape_name.len() as i64 + #index) as usize
@@ -76,8 +82,9 @@ fn forward_shape_gather(
                             );
                         }
                     } else {
-                        let (pre_convert, index_ident) = scalar_index_to_ident(index_arg, scope);
-                        let index_resolve = gen_index_resolve(&index_ident);
+                        let (pre_convert, index_token) =
+                            resolve_scalar_index_token(index_arg, scope);
+                        let index_resolve = gen_index_resolve(&index_token);
                         quote! {
                             #pre_convert
                             #index_resolve
@@ -104,8 +111,9 @@ fn forward_shape_gather(
                             let #output = #input_shape_name[#idx_lit] as #scalar_ty;
                         }
                     } else {
-                        let (pre_convert, index_ident) = scalar_index_to_ident(index_arg, scope);
-                        let index_resolve = gen_index_resolve(&index_ident);
+                        let (pre_convert, index_token) =
+                            resolve_scalar_index_token(index_arg, scope);
+                        let index_resolve = gen_index_resolve(&index_token);
                         quote! {
                             #pre_convert
                             #index_resolve
@@ -230,12 +238,12 @@ fn forward_tensor_gather(
             // Gathering a single element, keep as Tensor<B, 1> on device (no GPU stall)
             match &index_arg.ty {
                 ArgType::ScalarNative(_) | ArgType::ScalarTensor(_) => {
-                    let (pre_convert, index_ident) = scalar_index_to_ident(index_arg, scope);
+                    let (pre_convert, index_token) = resolve_scalar_index_token(index_arg, scope);
                     let axis = node.config.axis;
                     let slice_args = (0..input_rank)
                         .map(|i| {
                             if i == axis {
-                                quote! { #index_ident }
+                                index_token.clone()
                             } else {
                                 quote! { .. }
                             }
@@ -259,12 +267,12 @@ fn forward_tensor_gather(
             let scalar_ty = scalar_type_tokens(dtype);
             match &index_arg.ty {
                 ArgType::ScalarNative(_) | ArgType::ScalarTensor(_) => {
-                    let (pre_convert, index_ident) = scalar_index_to_ident(index_arg, scope);
+                    let (pre_convert, index_token) = resolve_scalar_index_token(index_arg, scope);
                     let axis = node.config.axis;
                     let slice_args = (0..input_rank)
                         .map(|i| {
                             if i == axis {
-                                quote! { #index_ident }
+                                index_token.clone()
                             } else {
                                 quote! { .. }
                             }
@@ -290,25 +298,8 @@ fn forward_tensor_gather(
                     // Use tensor.slice(...) for efficient gather operation
                     let output_rank = input_rank - 1;
                     let axis = node.config.axis;
-
                     // Either a resolved literal or the runtime variable
-                    let index_token = index_arg
-                        .value()
-                        .and_then(|v| v.scalar_i64().ok())
-                        .map(|resolved| {
-                            let lit = proc_macro2::Literal::i64_unsuffixed(resolved);
-                            quote! { #lit }
-                        })
-                        .unwrap_or_else(|| {
-                            if index_arg.ty.is_scalar_tensor() {
-                                let tensor = scope.arg(index_arg);
-                                on_device_to_native(quote! { #tensor }, &index_arg.ty.elem_type())
-                            } else {
-                                let index = arg_to_ident(index_arg);
-                                quote! { #index }
-                            }
-                        });
-
+                    let (pre_convert, index_token) = resolve_scalar_index_token(index_arg, scope);
                     let slice_args = (0..input_rank)
                         .map(|i| {
                             if i == axis {
@@ -318,8 +309,8 @@ fn forward_tensor_gather(
                             }
                         })
                         .collect::<Vec<_>>();
-
                     quote! {
+                        #pre_convert
                         let #output = {
                             let sliced = #input.slice(s![#(#slice_args),*]);
                             sliced.squeeze_dim::<#output_rank>(#dim)
@@ -1104,6 +1095,45 @@ mod tests {
                 let sliced = data.slice(s![- 2, ..]);
                 sliced.squeeze_dim::<1usize>(0)
             };
+            output
+        }
+        ");
+    }
+
+    #[test]
+    fn test_gather_const_index_to_scalar() {
+        let config = GatherConfig { axis: 0 };
+        let node = GatherNodeBuilder::new("get_row")
+            .input_tensor_shape("data", vec![10, 64], DType::F32)
+            .input_const_i64("idx", 2)
+            .output_scalar("output", DType::F32)
+            .config(config)
+            .build();
+        let code = codegen_forward_default(&node);
+        assert_snapshot!(code, @r"
+        pub fn forward(&self, data: Tensor<B, 2>) -> f32 {
+            let output = {
+                let selected = data.slice(s![2, ..]);
+                selected.into_scalar().elem::<f32>()
+            };
+            output
+        }
+        ");
+    }
+
+    #[test]
+    fn test_gather_const_index_to_scalar_tensor() {
+        let config = GatherConfig { axis: 0 };
+        let node = GatherNodeBuilder::new("get_row")
+            .input_tensor_shape("data", vec![10, 64], DType::F32)
+            .input_const_i64("idx", 2)
+            .output_scalar_tensor("output", DType::F32)
+            .config(config)
+            .build();
+        let code = codegen_forward_default(&node);
+        assert_snapshot!(code, @r"
+        pub fn forward(&self, data: Tensor<B, 2>) -> Tensor<B, 1> {
+            let output = { data.slice(s![2, ..]) };
             output
         }
         ");

--- a/crates/burn-onnx/src/burn/node/gather.rs
+++ b/crates/burn-onnx/src/burn/node/gather.rs
@@ -68,15 +68,24 @@ fn forward_shape_gather(
             // Gathering a single element from a shape, keep on device as Tensor<B, 1, Int>
             match &index_arg.ty {
                 ArgType::ScalarNative(_) | ArgType::ScalarTensor(_) => {
-                    let (pre_convert, index_ident) = scalar_index_to_ident(index_arg, scope);
-                    let index_resolve = gen_index_resolve(&index_ident);
-                    quote! {
-                        #pre_convert
-                        #index_resolve
-                        let #output = Tensor::<B, 1, Int>::from_data(
-                            burn::tensor::TensorData::from([#input_shape_name[actual_idx]]),
-                            &self.device,
-                        );
+                    if let Some(idx_lit) = resolve_constant_shape_index(input_arg, index_arg) {
+                        quote! {
+                            let #output = Tensor::<B, 1, Int>::from_data(
+                                burn::tensor::TensorData::from([#input_shape_name[#idx_lit]]),
+                                &self.device,
+                            );
+                        }
+                    } else {
+                        let (pre_convert, index_ident) = scalar_index_to_ident(index_arg, scope);
+                        let index_resolve = gen_index_resolve(&index_ident);
+                        quote! {
+                            #pre_convert
+                            #index_resolve
+                            let #output = Tensor::<B, 1, Int>::from_data(
+                                burn::tensor::TensorData::from([#input_shape_name[actual_idx]]),
+                                &self.device,
+                            );
+                        }
                     }
                 }
                 _ => panic!(
@@ -90,12 +99,18 @@ fn forward_shape_gather(
             let scalar_ty = scalar_type_tokens(dtype);
             match &index_arg.ty {
                 ArgType::ScalarNative(_) | ArgType::ScalarTensor(_) => {
-                    let (pre_convert, index_ident) = scalar_index_to_ident(index_arg, scope);
-                    let index_resolve = gen_index_resolve(&index_ident);
-                    quote! {
-                        #pre_convert
-                        #index_resolve
-                        let #output = #input_shape_name[actual_idx] as #scalar_ty;
+                    if let Some(idx_lit) = resolve_constant_shape_index(input_arg, index_arg) {
+                        quote! {
+                            let #output = #input_shape_name[#idx_lit] as #scalar_ty;
+                        }
+                    } else {
+                        let (pre_convert, index_ident) = scalar_index_to_ident(index_arg, scope);
+                        let index_resolve = gen_index_resolve(&index_ident);
+                        quote! {
+                            #pre_convert
+                            #index_resolve
+                            let #output = #input_shape_name[actual_idx] as #scalar_ty;
+                        }
                     }
                 }
                 _ => panic!(
@@ -351,6 +366,27 @@ fn forward_tensor_gather(
     }
 }
 
+fn resolve_constant_shape_index(
+    input_arg: &Argument,
+    index_arg: &Argument,
+) -> Option<proc_macro2::Literal> {
+    index_arg
+        .value()
+        .and_then(|v| v.scalar_i64().ok())
+        .map(|resolved| {
+            let idx = if resolved < 0 {
+                let shape_rank = match &input_arg.ty {
+                    ArgType::Shape(r) => *r as i64,
+                    _ => unreachable!(),
+                };
+                (shape_rank + resolved) as usize
+            } else {
+                resolved as usize
+            };
+            proc_macro2::Literal::usize_unsuffixed(idx)
+        })
+}
+
 #[cfg(test)]
 mod tests {
     use super::super::test_helpers::*;
@@ -524,6 +560,86 @@ mod tests {
                 .try_into()
                 .unwrap();
             transposed
+        }
+        ");
+    }
+
+    #[test]
+    fn test_gather_shape_const_index_to_scalar() {
+        let config = GatherConfig { axis: 0 };
+        let node = GatherNodeBuilder::new("extract_dim")
+            .input_shape("input_shape", 4)
+            .input_const_i64("dim_idx", 1)
+            .output_scalar("dim_value", DType::I32)
+            .config(config)
+            .build();
+        let code = codegen_forward_default(&node);
+        assert_snapshot!(code, @r"
+        pub fn forward(&self, input_shape: [i64; 4]) -> i32 {
+            let dim_value = input_shape[1] as i32;
+            dim_value
+        }
+        ");
+    }
+
+    #[test]
+    fn test_gather_shape_const_negative_index_to_scalar() {
+        let config = GatherConfig { axis: 0 };
+        let node = GatherNodeBuilder::new("extract_dim")
+            .input_shape("input_shape", 4)
+            .input_const_i64("dim_idx", -1)
+            .output_scalar("dim_value", DType::I32)
+            .config(config)
+            .build();
+        let code = codegen_forward_default(&node);
+        assert_snapshot!(code, @r"
+        pub fn forward(&self, input_shape: [i64; 4]) -> i32 {
+            let dim_value = input_shape[3] as i32;
+            dim_value
+        }
+        ");
+    }
+
+    #[test]
+    fn test_gather_shape_const_index_to_scalar_tensor() {
+        let config = GatherConfig { axis: 0 };
+        let node = GatherNodeBuilder::new("extract_dim")
+            .input_shape("input_shape", 4)
+            .input_const_i64("dim_idx", 1)
+            .output_scalar_tensor("result", DType::F32)
+            .config(config)
+            .build();
+        let code = codegen_forward_default(&node);
+        assert_snapshot!(code, @r"
+        pub fn forward(&self, input_shape: [i64; 4]) -> Tensor<B, 1> {
+            let result = Tensor::<
+                B,
+                1,
+                Int,
+            >::from_data(burn::tensor::TensorData::from([input_shape[1]]), &self.device);
+            result
+        }
+        ");
+    }
+
+    #[test]
+    fn test_gather_shape_const_negative_index_to_scalar_tensor() {
+        let config = GatherConfig { axis: 0 };
+        let node = GatherNodeBuilder::new("extract_dim")
+            .input_shape("input_shape", 4)
+            .input_const_i64("dim_idx", -1)
+            .output_scalar_tensor("result", DType::F32)
+            .config(config)
+            .build();
+        let code = codegen_forward_default(&node);
+        assert_snapshot!(code, @r"
+        pub fn forward(&self, input_shape: [i64; 4]) -> Tensor<B, 1> {
+            let result = Tensor::<
+                B,
+                1,
+                Int,
+            >::from_data(burn::tensor::TensorData::from([input_shape[3]]), &self.device);
+            result
         }
         ");
     }

--- a/crates/onnx-ir/src/node/gather.rs
+++ b/crates/onnx-ir/src/node/gather.rs
@@ -197,6 +197,18 @@ impl NodeProcessor for GatherProcessor {
             }
         }
 
+        // when index is a constant scalar, make it static so that it can be later eliminated
+        // should ideally be in lift_constants but at this point we don't know whether the index
+        // is scalar
+        let is_scalar_index = match &node.inputs[1].ty {
+            ArgType::ScalarTensor(_) | ArgType::ScalarNative(_) => true,
+            ArgType::Tensor(t) => t.rank == 0,
+            _ => false,
+        };
+        if node.inputs.len() > 1 && node.inputs[1].is_constant() && is_scalar_index {
+            node.inputs[1].to_static()?;
+        }
+
         Ok(())
     }
 
@@ -245,6 +257,8 @@ impl NodeProcessor for GatherProcessor {
 
 #[cfg(test)]
 mod tests {
+    use burn_tensor::DType;
+
     use super::*;
     use crate::ir::NodeType;
     use crate::node::test_utils::TestNodeBuilder;
@@ -544,6 +558,100 @@ mod tests {
 
         // Gathering from a tensor is not a no-op
         assert!(!processor.is_noop(&node));
+    }
+
+    #[test]
+    fn test_gather_infer_types_lifts_constant_rank0_tensor_index() {
+        let mut node = TestNodeBuilder::new(NodeType::Gather, "test_gather_rank0_tensor")
+            .attr_int("axis", 0)
+            .input_tensor_f32("data", 3, None)
+            .input_scalar_tensor_i64("indices", Some(2))
+            .output_tensor_f32("output", 2, None)
+            .build_with_graph_data(16);
+
+        node.inputs[1].ty = ArgType::Tensor(TensorType::new(DType::I64, 0, None));
+
+        let processor = GatherProcessor;
+        let prefs = OutputPreferences::new();
+
+        assert!(node.inputs[1].is_constant()); // index is indeed constant
+        processor.infer_types(&mut node, 16, &prefs).unwrap();
+        assert!(node.inputs[1].is_static()); // was converted to static, can be eliminated
+    }
+
+    #[test]
+    fn test_gather_infer_types_lifts_constant_scalar_tensor_index() {
+        let mut node = TestNodeBuilder::new(NodeType::Gather, "test_gather_scalar_tensor")
+            .attr_int("axis", 0)
+            .input_tensor_f32("data", 3, None)
+            .input_scalar_tensor_i64("indices", Some(2))
+            .output_tensor_f32("output", 2, None)
+            .build_with_graph_data(16);
+
+        node.inputs[1].ty = ArgType::ScalarTensor(DType::I64);
+
+        let processor = GatherProcessor;
+        let prefs = OutputPreferences::new();
+
+        assert!(node.inputs[1].is_constant()); // index is indeed constant
+        processor.infer_types(&mut node, 16, &prefs).unwrap();
+        assert!(node.inputs[1].is_static()); // was converted to static, can be eliminated
+    }
+
+    #[test]
+    fn test_gather_infer_types_lifts_constant_scalar_index() {
+        let mut node = TestNodeBuilder::new(NodeType::Gather, "test_gather_scalar")
+            .attr_int("axis", 0)
+            .input_tensor_f32("data", 3, None)
+            .input_scalar_tensor_i64("indices", Some(2))
+            .output_tensor_f32("output", 2, None)
+            .build_with_graph_data(16);
+
+        node.inputs[1].ty = ArgType::ScalarNative(DType::I64);
+
+        let processor = GatherProcessor;
+        let prefs = OutputPreferences::new();
+
+        assert!(node.inputs[1].is_constant()); // index is indeed constant
+        processor.infer_types(&mut node, 16, &prefs).unwrap();
+        assert!(node.inputs[1].is_static()); // was converted to static, can be eliminated
+    }
+
+    #[test]
+    fn test_gather_infer_types_dynamic_index() {
+        let mut node = TestNodeBuilder::new(NodeType::Gather, "test_gather_dynamic")
+            .attr_int("axis", 0)
+            .input_tensor_f32("data", 3, None)
+            .input_scalar_tensor_i64("indices", None)
+            .output_tensor_f32("output", 2, None)
+            .build_with_graph_data(16);
+
+        let processor = GatherProcessor;
+        let prefs = OutputPreferences::new();
+
+        assert!(!node.inputs[1].is_constant()); // index is not constant
+        processor.infer_types(&mut node, 16, &prefs).unwrap();
+        assert!(!node.inputs[1].is_static()); // was not converted to static, can't be eliminated
+    }
+
+    #[test]
+    fn test_gather_infer_types_constant_2d_index() {
+        // 2d indexing is left as is for now
+        let mut node = TestNodeBuilder::new(NodeType::Gather, "test_gather_constant_2d")
+            .attr_int("axis", 0)
+            .input_tensor_f32("data", 3, None)
+            .input_scalar_tensor_i64("indices", Some(2))
+            .output_tensor_f32("output", 2, None)
+            .build_with_graph_data(16);
+
+        node.inputs[1].ty = ArgType::Tensor(TensorType::new(DType::I64, 2, None));
+
+        let processor = GatherProcessor;
+        let prefs = OutputPreferences::new();
+
+        assert!(node.inputs[1].is_constant()); // index is constant
+        processor.infer_types(&mut node, 16, &prefs).unwrap();
+        assert!(!node.inputs[1].is_static()); // was not converted to static, won't be eliminated
     }
 
     // TODO: Add test for out-of-bounds indices - Per spec (opset 11+), out-of-bounds indices should raise error - Missing bounds checking test

--- a/crates/onnx-tests/tests/simplify/mod.rs
+++ b/crates/onnx-tests/tests/simplify/mod.rs
@@ -272,13 +272,7 @@ mod tests {
                     }
                     output
                 };
-                let constant1_out1 = 1i64;
-                let actual_idx = if constant1_out1 < 0 {
-                    (shape1_out1.len() as i64 + constant1_out1) as usize
-                } else {
-                    constant1_out1 as usize
-                };
-                let gather1_out1 = shape1_out1[actual_idx] as i64;
+                let gather1_out1 = shape1_out1[1] as i64;
                 gather1_out1
             }
         }
@@ -336,13 +330,7 @@ mod tests {
                     }
                     output
                 };
-                let constant1_out1 = 1i64;
-                let actual_idx = if constant1_out1 < 0 {
-                    (shape1_out1.len() as i64 + constant1_out1) as usize
-                } else {
-                    constant1_out1 as usize
-                };
-                let gather1_out1 = shape1_out1[actual_idx] as i64;
+                let gather1_out1 = shape1_out1[1] as i64;
                 let shape2_out1: [i64; 3] = {
                     let axes = &y.dims()[0..3];
                     let mut output = [0i64; 3];
@@ -409,34 +397,10 @@ mod tests {
                     }
                     output
                 };
-                let constant1_out1 = 0i64;
-                let constant2_out1 = 1i64;
-                let constant3_out1 = 3i64;
-                let constant4_out1 = 2i64;
-                let actual_idx = if constant1_out1 < 0 {
-                    (shape1_out1.len() as i64 + constant1_out1) as usize
-                } else {
-                    constant1_out1 as usize
-                };
-                let gather1_out1 = shape1_out1[actual_idx] as i64;
-                let actual_idx = if constant2_out1 < 0 {
-                    (shape2_out1.len() as i64 + constant2_out1) as usize
-                } else {
-                    constant2_out1 as usize
-                };
-                let gather2_out1 = shape2_out1[actual_idx] as i64;
-                let actual_idx = if constant3_out1 < 0 {
-                    (shape3_out1.len() as i64 + constant3_out1) as usize
-                } else {
-                    constant3_out1 as usize
-                };
-                let gather3_out1 = shape3_out1[actual_idx] as i64;
-                let actual_idx = if constant4_out1 < 0 {
-                    (shape4_out1.len() as i64 + constant4_out1) as usize
-                } else {
-                    constant4_out1 as usize
-                };
-                let gather4_out1 = shape4_out1[actual_idx] as i64;
+                let gather1_out1 = shape1_out1[0] as i64;
+                let gather2_out1 = shape2_out1[1] as i64;
+                let gather3_out1 = shape3_out1[3] as i64;
+                let gather4_out1 = shape4_out1[2] as i64;
                 let unsqueeze1_out1 = [gather1_out1 as i64];
                 let unsqueeze2_out1 = [gather2_out1 as i64];
                 let unsqueeze3_out1 = [gather3_out1 as i64];
@@ -496,20 +460,8 @@ mod tests {
                     }
                     output
                 };
-                let constant1_out1 = 1i64;
-                let constant2_out1 = 2i64;
-                let actual_idx = if constant1_out1 < 0 {
-                    (shape1_out1.len() as i64 + constant1_out1) as usize
-                } else {
-                    constant1_out1 as usize
-                };
-                let gather1_out1 = shape1_out1[actual_idx] as i64;
-                let actual_idx = if constant2_out1 < 0 {
-                    (shape2_out1.len() as i64 + constant2_out1) as usize
-                } else {
-                    constant2_out1 as usize
-                };
-                let gather2_out1 = shape2_out1[actual_idx] as i64;
+                let gather1_out1 = shape1_out1[1] as i64;
+                let gather2_out1 = shape2_out1[2] as i64;
                 let mul1_out1 = gather1_out1 * gather2_out1;
                 mul1_out1
             }


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `cargo xtask validate` command has been executed. => I only ran cargo test and the beginning of xtask validate because cortex-m doesn't compile on my machine
- [ ] Confirm relevant documentation has been updated.
- [x] For new/modified ONNX operators: verified implementation matches `onnx-spec/ops/<OpName>.md`.

### Related Issues/PRs

issue #385

### Changes

don't generate unused variables

### Testing

through the tests in this pr
