### PR TITLE
Unblock attention _expanded tests (3 codegen fixes + 1 harness fix; 27/27 promoted)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,6 +100,23 @@ Key principles:
 - Python test scripts use `uv` inline script format with `onnx.reference.ReferenceEvaluator` as
   ground truth
 
+### Consuming a generated model
+
+- **Do NOT use `Model::new(&device)`** to run a generated model. `new` calls
+  `Param::uninitialized` for every constant/weight, leaving them zeroed. Graphs whose forward
+  uses `self.<param>.val()` (anything with ONNX Constant/Initializer nodes — including all
+  attention `_expanded` variants and many normal models) then run with all-zero constants and
+  produce wrong output, often as bizarre downstream shape errors (e.g. `repeat([0, 0, 0])`
+  collapsing a tensor to `[0, 0, 0, 0]`)
+- Use `Model::from_file(bpk_path, &device)` instead — it constructs via `new` then runs
+  `load_from(BurnpackStore)`, which is a no-op when there are no `Param` fields, so it is safe
+  for graphs without constants too
+- `Model::default()` works but pins the device to `B::Device::default()` and embeds the absolute
+  bpk path captured at codegen time; prefer the explicit `from_file` form
+- Test harnesses and demo binaries that construct generated models must follow this rule. The
+  symptom of getting it wrong is "compare passes for ops that touch no constants, fails for
+  anything reshape/tile/scatter-shaped"
+
 ## Adding a New Operator
 
 Read `DEVELOPMENT-GUIDE.md` for the full walkthrough with code examples. Checklist:

--- a/crates/burn-onnx/src/burn/node/not.rs
+++ b/crates/burn-onnx/src/burn/node/not.rs
@@ -27,7 +27,13 @@ impl NodeCodegen for onnx_ir::node::not::NotNode {
                     result
                 };
             },
-            _ => quote! {
+            // Native host scalar — emit the Rust `!` operator. `.bool_not()` would
+            // not compile against a `bool` binding.
+            ArgType::ScalarNative(_) => quote! {
+                let #output = !#input;
+            },
+            // On-device tensors (Tensor and ScalarTensor) carry `.bool_not()`.
+            ArgType::Tensor(_) | ArgType::ScalarTensor(_) => quote! {
                 let #output = #input.bool_not();
             },
         }
@@ -58,9 +64,6 @@ mod tests {
 
     #[test]
     fn test_not_shape_input() {
-        // Shape arguments encode booleans as 0/1 in an `[i64; N]` array (mirrors
-        // the Equal-on-Shape codegen). Not flips the array element-wise without
-        // calling `.bool_not()` (which is undefined on plain arrays).
         let node = NotNodeBuilder::new("not1")
             .input_shape("flags", 3)
             .output_shape("inverted", 3)

--- a/crates/burn-onnx/src/burn/node/not.rs
+++ b/crates/burn-onnx/src/burn/node/not.rs
@@ -10,11 +10,26 @@ impl NodeCodegen for onnx_ir::node::not::NotNode {
     }
 
     fn forward(&self, scope: &mut ScopeAtPosition<'_>) -> TokenStream {
-        let input = scope.arg(self.inputs.first().unwrap());
+        let input_arg = self.inputs.first().unwrap();
+        let input = scope.arg(input_arg);
         let output = arg_to_ident(self.outputs.first().unwrap());
 
-        quote! {
-            let #output = #input.bool_not();
+        match &input_arg.ty {
+            // Shape arguments are host-side `[i64; N]` arrays whose elements encode
+            // booleans as 0/1 (mirrors the Equal-on-Shape codegen). `.bool_not()`
+            // is not defined on a plain array, so flip in place.
+            ArgType::Shape(_) => quote! {
+                let #output = {
+                    let mut result = #input;
+                    for v in result.iter_mut() {
+                        *v = if *v != 0 { 0i64 } else { 1i64 };
+                    }
+                    result
+                };
+            },
+            _ => quote! {
+                let #output = #input.bool_not();
+            },
         }
     }
 }
@@ -37,6 +52,30 @@ mod tests {
         pub fn forward(&self, input: Tensor<B, 2, Bool>) -> Tensor<B, 2, Bool> {
             let output = input.bool_not();
             output
+        }
+        ");
+    }
+
+    #[test]
+    fn test_not_shape_input() {
+        // Shape arguments encode booleans as 0/1 in an `[i64; N]` array (mirrors
+        // the Equal-on-Shape codegen). Not flips the array element-wise without
+        // calling `.bool_not()` (which is undefined on plain arrays).
+        let node = NotNodeBuilder::new("not1")
+            .input_shape("flags", 3)
+            .output_shape("inverted", 3)
+            .build();
+        let code = codegen_forward_default(&node);
+        assert_snapshot!(code, @r"
+        pub fn forward(&self, flags: [i64; 3]) -> [i64; 3] {
+            let inverted = {
+                let mut result = flags;
+                for v in result.iter_mut() {
+                    *v = if *v != 0 { 0i64 } else { 1i64 };
+                }
+                result
+            };
+            inverted
         }
         ");
     }

--- a/crates/burn-onnx/src/burn/node/trilu.rs
+++ b/crates/burn-onnx/src/burn/node/trilu.rs
@@ -81,8 +81,6 @@ mod tests {
 
     #[test]
     fn test_trilu_bool_input_lower() {
-        // burn-flex's Bool tensor doesn't satisfy the trait bounds for tril,
-        // so codegen routes Bool inputs through Int and casts back.
         let config = TriluConfig::new(false, 0);
         let node = TriluNodeBuilder::new("tril1")
             .input_tensor("mask", 2, DType::Bool(BoolStore::Native))

--- a/crates/burn-onnx/src/burn/node/trilu.rs
+++ b/crates/burn-onnx/src/burn/node/trilu.rs
@@ -11,17 +11,28 @@ impl NodeCodegen for onnx_ir::trilu::TriluNode {
     }
 
     fn forward(&self, scope: &mut ScopeAtPosition<'_>) -> TokenStream {
-        let input = scope.arg(self.inputs.first().unwrap());
+        let input_arg = self.inputs.first().unwrap();
+        let input = scope.arg(input_arg);
         let output = arg_to_ident(self.outputs.first().unwrap());
         let diagonal = self.config.diagonal.to_tokens();
 
-        if self.config.upper {
+        // burn-flex's Bool tensor doesn't satisfy the trait bounds for tril/triu,
+        // so round-trip Bool through Int.
+        let is_bool = matches!(&input_arg.ty, ArgType::Tensor(t) if t.dtype.is_bool());
+
+        let body = if self.config.upper {
+            quote! { triu(#diagonal) }
+        } else {
+            quote! { tril(#diagonal) }
+        };
+
+        if is_bool {
             quote! {
-                let #output = #input.triu(#diagonal);
+                let #output = #input.int().#body.bool();
             }
         } else {
             quote! {
-                let #output = #input.tril(#diagonal);
+                let #output = #input.#body;
             }
         }
     }
@@ -30,7 +41,7 @@ impl NodeCodegen for onnx_ir::trilu::TriluNode {
 #[cfg(test)]
 mod tests {
     use super::super::test_helpers::*;
-    use burn::tensor::DType;
+    use burn::tensor::{BoolStore, DType};
     use insta::assert_snapshot;
     use onnx_ir::trilu::{TriluConfig, TriluNodeBuilder};
 
@@ -64,6 +75,42 @@ mod tests {
         pub fn forward(&self, input: Tensor<B, 2>) -> Tensor<B, 2> {
             let output = input.tril(1);
             output
+        }
+        ");
+    }
+
+    #[test]
+    fn test_trilu_bool_input_lower() {
+        // burn-flex's Bool tensor doesn't satisfy the trait bounds for tril,
+        // so codegen routes Bool inputs through Int and casts back.
+        let config = TriluConfig::new(false, 0);
+        let node = TriluNodeBuilder::new("tril1")
+            .input_tensor("mask", 2, DType::Bool(BoolStore::Native))
+            .output_tensor("masked", 2, DType::Bool(BoolStore::Native))
+            .config(config)
+            .build();
+        let code = codegen_forward_default(&node);
+        assert_snapshot!(code, @r"
+        pub fn forward(&self, mask: Tensor<B, 2, Bool>) -> Tensor<B, 2, Bool> {
+            let masked = mask.int().tril(0).bool();
+            masked
+        }
+        ");
+    }
+
+    #[test]
+    fn test_trilu_bool_input_upper() {
+        let config = TriluConfig::new(true, -1);
+        let node = TriluNodeBuilder::new("triu1")
+            .input_tensor("mask", 3, DType::Bool(BoolStore::Native))
+            .output_tensor("masked", 3, DType::Bool(BoolStore::Native))
+            .config(config)
+            .build();
+        let code = codegen_forward_default(&node);
+        assert_snapshot!(code, @r"
+        pub fn forward(&self, mask: Tensor<B, 3, Bool>) -> Tensor<B, 3, Bool> {
+            let masked = mask.int().triu(-1).bool();
+            masked
         }
         ");
     }

--- a/crates/onnx-ir/src/node/reshape.rs
+++ b/crates/onnx-ir/src/node/reshape.rs
@@ -515,8 +515,15 @@ impl NodeProcessor for ReshapeProcessor {
                 }
             }
             ArgType::Shape(_) => {
-                // Runtime input - store reference instead of cloning the argument
-                ReshapeInput::Runtime(RuntimeInputRef::new(node.inputs[1].name.clone(), 1))
+                // Shape input may carry a static value (e.g. after constant lifting,
+                // which can clear the input name). Prefer the static value when present
+                // so codegen does not need to refer to an empty ident.
+                match node.inputs[1].value() {
+                    Some(tensor_data) => ReshapeInput::Static(tensor_data.to_vec::<i64>().unwrap()),
+                    None => {
+                        ReshapeInput::Runtime(RuntimeInputRef::new(node.inputs[1].name.clone(), 1))
+                    }
+                }
             }
             ArgType::ScalarTensor(_) => {
                 // ScalarTensor is rank 1 with a single element

--- a/crates/onnx-ir/src/node/reshape.rs
+++ b/crates/onnx-ir/src/node/reshape.rs
@@ -666,6 +666,25 @@ mod tests {
     }
 
     #[test]
+    fn test_reshape_config_with_shape_type_static_value() {
+        // Constant lifting can clear an ArgType::Shape input's name while
+        // populating its value, so extract_config must prefer Static when a
+        // value is available rather than emitting a Runtime ref to ""
+        let node = TestNodeBuilder::new(NodeType::Reshape, "test_reshape_shape_static")
+            .input_tensor_f32("data", 4, None)
+            .input_shape_with_data("shape", vec![2, 3, -1])
+            .output_tensor_f32("reshaped", 3, None)
+            .process(ReshapeProcessor, 16);
+
+        let processor = ReshapeProcessor;
+        let config = processor.extract_config(&node, 16).unwrap();
+        match &config.shape {
+            ReshapeInput::Static(shape) => assert_eq!(shape, &vec![2, 3, -1]),
+            other => panic!("Expected static shape, got {:?}", other),
+        }
+    }
+
+    #[test]
     fn test_reshape_dynamic_shape_with_output_rank() {
         // Test dynamic reshape where shape input has no static_shape,
         // but output rank is known from ONNX model metadata.

--- a/crates/onnx-ir/src/node/test_utils.rs
+++ b/crates/onnx-ir/src/node/test_utils.rs
@@ -213,6 +213,24 @@ impl TestNodeBuilder {
         self.add_input(name, ArgType::Shape(rank))
     }
 
+    /// Add a shape input that carries a static value (i64 vector). Mirrors
+    /// `input_tensor_with_data` for the ArgType::Shape case: the argument is
+    /// flagged as a constant and the data is registered in GraphState so
+    /// `arg.value()` resolves once `build_with_graph_data` runs.
+    pub fn input_shape_with_data(mut self, name: &str, data: Vec<i64>) -> Self {
+        let len = data.len();
+        let arg = Argument {
+            name: name.to_string(),
+            ty: ArgType::Shape(len),
+            value_source: crate::ir::ValueSource::Constant,
+            value_store: None,
+        };
+        self.inputs.push(arg);
+        self.constant_data
+            .insert(name.to_string(), TensorData::new(data, vec![len]));
+        self
+    }
+
     /// Add a tensor input with data value
     ///
     /// Note: In the new design, constant values are stored in GraphState, not in Arguments.

--- a/crates/onnx-official-tests/build.rs
+++ b/crates/onnx-official-tests/build.rs
@@ -782,9 +782,21 @@ fn emit_single_test(buf: &mut String, name: &str, meta: &TestMeta, mode: TestMod
         }
     }
     writeln!(buf, "    let device = Default::default();").unwrap();
+    // Load weights/constants from bpk on the test's chosen device. `Model::new`
+    // leaves `Param::uninitialized` fields zeroed; that's fine for graphs whose
+    // forward uses no `self.<param>.val()` calls but breaks for graphs with
+    // baked-in Constant nodes (e.g. attention's _expanded variants emit
+    // `Param<Tensor<...>>` for shape-constant tensors). `from_file` handles
+    // both: it constructs via `new` then runs `load_from`, which is a no-op
+    // when there are no module fields to populate.
     writeln!(
         buf,
-        "    let model = generated::{name}::Model::<TestBackend>::new(&device);"
+        "    let bpk_path = concat!(env!(\"OUT_DIR\"), \"/model/{name}.bpk\");"
+    )
+    .unwrap();
+    writeln!(
+        buf,
+        "    let model = generated::{name}::Model::<TestBackend>::from_file(bpk_path, &device);"
     )
     .unwrap();
 

--- a/crates/onnx-official-tests/expectations.toml
+++ b/crates/onnx-official-tests/expectations.toml
@@ -320,9 +320,9 @@ reason = "attention op family comparison failure"
 tracking = "#311"
 
 [test_attention_3d_causal_expanded]
-status = "skip-codegen"
-reason = "Unsupported Mod input types: lhs=Shape(1), rhs=Shape(1)"
-tracking = "#314"
+status = "fail-compare"
+reason = "attention op family comparison failure"
+tracking = "#311"
 
 [test_attention_3d_diff_heads_sizes]
 status = "pass"
@@ -341,30 +341,30 @@ reason = "attention op family comparison failure"
 tracking = "#311"
 
 [test_attention_3d_diff_heads_sizes_causal_expanded]
-status = "skip-codegen"
-reason = "Unsupported Mod input types: lhs=Shape(1), rhs=Shape(1)"
-tracking = "#314"
+status = "fail-compare"
+reason = "attention op family comparison failure"
+tracking = "#311"
 
 [test_attention_3d_diff_heads_sizes_expanded]
-status = "skip-codegen"
-reason = "Unsupported Mod input types: lhs=Shape(1), rhs=Shape(1)"
-tracking = "#314"
+status = "fail-compare"
+reason = "attention op family comparison failure"
+tracking = "#311"
 
 [test_attention_3d_diff_heads_sizes_scaled]
 status = "pass"
 
 [test_attention_3d_diff_heads_sizes_scaled_expanded]
-status = "skip-codegen"
-reason = "Unsupported Mod input types: lhs=Shape(1), rhs=Shape(1)"
-tracking = "#314"
+status = "fail-compare"
+reason = "attention op family comparison failure"
+tracking = "#311"
 
 [test_attention_3d_diff_heads_sizes_softcap]
 status = "pass"
 
 [test_attention_3d_diff_heads_sizes_softcap_expanded]
-status = "skip-codegen"
-reason = "Unsupported Mod input types: lhs=Shape(1), rhs=Shape(1)"
-tracking = "#314"
+status = "fail-compare"
+reason = "attention op family comparison failure"
+tracking = "#311"
 
 [test_attention_3d_diff_heads_with_past_and_present]
 status = "pass"
@@ -375,9 +375,9 @@ reason = "Unsupported Mod input types: lhs=Shape(1), rhs=Shape(1)"
 tracking = "#314"
 
 [test_attention_3d_expanded]
-status = "skip-codegen"
-reason = "Unsupported Mod input types: lhs=Shape(1), rhs=Shape(1)"
-tracking = "#314"
+status = "fail-compare"
+reason = "attention op family comparison failure"
+tracking = "#311"
 
 [test_attention_3d_gqa]
 status = "fail-compare"
@@ -400,14 +400,14 @@ reason = "comparison against reference tensor fails (classified by M2 first-run 
 tracking = "#311"
 
 [test_attention_3d_gqa_causal_expanded]
-status = "skip-codegen"
-reason = "Unsupported Mod input types: lhs=Shape(1), rhs=Shape(1)"
-tracking = "#314"
+status = "fail-compare"
+reason = "attention op family comparison failure"
+tracking = "#311"
 
 [test_attention_3d_gqa_expanded]
-status = "skip-codegen"
-reason = "Unsupported Mod input types: lhs=Shape(1), rhs=Shape(1)"
-tracking = "#314"
+status = "fail-compare"
+reason = "attention op family comparison failure"
+tracking = "#311"
 
 [test_attention_3d_gqa_scaled]
 status = "fail-compare"
@@ -415,9 +415,9 @@ reason = "comparison against reference tensor fails (classified by M2 first-run 
 tracking = "#311"
 
 [test_attention_3d_gqa_scaled_expanded]
-status = "skip-codegen"
-reason = "Unsupported Mod input types: lhs=Shape(1), rhs=Shape(1)"
-tracking = "#314"
+status = "fail-compare"
+reason = "attention op family comparison failure"
+tracking = "#311"
 
 [test_attention_3d_gqa_softcap]
 status = "fail-compare"
@@ -425,9 +425,9 @@ reason = "comparison against reference tensor fails (classified by M2 first-run 
 tracking = "#311"
 
 [test_attention_3d_gqa_softcap_expanded]
-status = "skip-codegen"
-reason = "Unsupported Mod input types: lhs=Shape(1), rhs=Shape(1)"
-tracking = "#314"
+status = "fail-compare"
+reason = "attention op family comparison failure"
+tracking = "#311"
 
 [test_attention_3d_gqa_with_past_and_present]
 status = "fail-compare"
@@ -443,25 +443,25 @@ tracking = "#314"
 status = "pass"
 
 [test_attention_3d_scaled_expanded]
-status = "skip-codegen"
-reason = "Unsupported Mod input types: lhs=Shape(1), rhs=Shape(1)"
-tracking = "#314"
+status = "fail-compare"
+reason = "attention op family comparison failure"
+tracking = "#311"
 
 [test_attention_3d_softcap]
 status = "pass"
 
 [test_attention_3d_softcap_expanded]
-status = "skip-codegen"
-reason = "Unsupported Mod input types: lhs=Shape(1), rhs=Shape(1)"
-tracking = "#314"
+status = "fail-compare"
+reason = "attention op family comparison failure"
+tracking = "#311"
 
 [test_attention_3d_transpose_verification]
 status = "pass"
 
 [test_attention_3d_transpose_verification_expanded]
-status = "skip-codegen"
-reason = "Unsupported Mod input types: lhs=Shape(1), rhs=Shape(1)"
-tracking = "#314"
+status = "fail-compare"
+reason = "attention op family comparison failure"
+tracking = "#311"
 
 [test_attention_3d_with_past_and_present]
 status = "pass"
@@ -572,9 +572,9 @@ reason = "attention op family comparison failure"
 tracking = "#311"
 
 [test_attention_4d_causal_expanded]
-status = "skip-compile"
-reason = "burn-onnx attention codegen emits bool_not on Shape array and tril on Bool tensor; pre-existing bug"
-tracking = "#314"
+status = "fail-compare"
+reason = "attention op family comparison failure"
+tracking = "#311"
 
 [test_attention_4d_diff_heads_mask4d_padded_kv]
 status = "skip-codegen"
@@ -603,30 +603,30 @@ reason = "attention op family comparison failure"
 tracking = "#311"
 
 [test_attention_4d_diff_heads_sizes_causal_expanded]
-status = "skip-compile"
-reason = "burn-onnx attention codegen emits bool_not on Shape array and tril on Bool tensor; pre-existing bug"
-tracking = "#314"
+status = "fail-compare"
+reason = "attention op family comparison failure"
+tracking = "#311"
 
 [test_attention_4d_diff_heads_sizes_expanded]
-status = "skip-compile"
-reason = "burn-onnx attention codegen emits bool_not on Shape array and tril on Bool tensor; pre-existing bug"
-tracking = "#314"
+status = "fail-compare"
+reason = "attention op family comparison failure"
+tracking = "#311"
 
 [test_attention_4d_diff_heads_sizes_scaled]
 status = "pass"
 
 [test_attention_4d_diff_heads_sizes_scaled_expanded]
-status = "skip-compile"
-reason = "burn-onnx attention codegen emits bool_not on Shape array and tril on Bool tensor; pre-existing bug"
-tracking = "#314"
+status = "fail-compare"
+reason = "attention op family comparison failure"
+tracking = "#311"
 
 [test_attention_4d_diff_heads_sizes_softcap]
 status = "pass"
 
 [test_attention_4d_diff_heads_sizes_softcap_expanded]
-status = "skip-compile"
-reason = "burn-onnx attention codegen emits bool_not on Shape array and tril on Bool tensor; pre-existing bug"
-tracking = "#314"
+status = "fail-compare"
+reason = "attention op family comparison failure"
+tracking = "#311"
 
 [test_attention_4d_diff_heads_with_past_and_present]
 status = "pass"
@@ -653,17 +653,17 @@ reason = "Unsupported Mod input types: lhs=Shape(1), rhs=Shape(1)"
 tracking = "#314"
 
 [test_attention_4d_expanded]
-status = "skip-compile"
-reason = "burn-onnx attention codegen emits bool_not on Shape array and tril on Bool tensor; pre-existing bug"
-tracking = "#314"
+status = "fail-compare"
+reason = "attention op family comparison failure"
+tracking = "#311"
 
 [test_attention_4d_fp16]
 status = "pass"
 
 [test_attention_4d_fp16_expanded]
-status = "skip-compile"
-reason = "burn-onnx attention codegen emits bool_not on Shape array and tril on Bool tensor; pre-existing bug"
-tracking = "#314"
+status = "fail-compare"
+reason = "attention op family comparison failure"
+tracking = "#311"
 
 [test_attention_4d_gqa]
 status = "fail-compare"
@@ -686,14 +686,14 @@ reason = "comparison against reference tensor fails (classified by M2 first-run 
 tracking = "#311"
 
 [test_attention_4d_gqa_causal_expanded]
-status = "skip-compile"
-reason = "burn-onnx attention codegen emits bool_not on Shape array and tril on Bool tensor; pre-existing bug"
-tracking = "#314"
+status = "fail-compare"
+reason = "attention op family comparison failure"
+tracking = "#311"
 
 [test_attention_4d_gqa_expanded]
-status = "skip-compile"
-reason = "burn-onnx attention codegen emits bool_not on Shape array and tril on Bool tensor; pre-existing bug"
-tracking = "#314"
+status = "fail-compare"
+reason = "attention op family comparison failure"
+tracking = "#311"
 
 [test_attention_4d_gqa_scaled]
 status = "fail-compare"
@@ -701,9 +701,9 @@ reason = "comparison against reference tensor fails (classified by M2 first-run 
 tracking = "#311"
 
 [test_attention_4d_gqa_scaled_expanded]
-status = "skip-compile"
-reason = "burn-onnx attention codegen emits bool_not on Shape array and tril on Bool tensor; pre-existing bug"
-tracking = "#314"
+status = "fail-compare"
+reason = "attention op family comparison failure"
+tracking = "#311"
 
 [test_attention_4d_gqa_softcap]
 status = "fail-compare"
@@ -711,9 +711,9 @@ reason = "comparison against reference tensor fails (classified by M2 first-run 
 tracking = "#311"
 
 [test_attention_4d_gqa_softcap_expanded]
-status = "skip-compile"
-reason = "burn-onnx attention codegen emits bool_not on Shape array and tril on Bool tensor; pre-existing bug"
-tracking = "#314"
+status = "fail-compare"
+reason = "attention op family comparison failure"
+tracking = "#311"
 
 [test_attention_4d_gqa_with_past_and_present]
 status = "fail-compare"
@@ -737,17 +737,17 @@ tracking = "#314"
 status = "pass"
 
 [test_attention_4d_scaled_expanded]
-status = "skip-compile"
-reason = "burn-onnx attention codegen emits bool_not on Shape array and tril on Bool tensor; pre-existing bug"
-tracking = "#314"
+status = "fail-compare"
+reason = "attention op family comparison failure"
+tracking = "#311"
 
 [test_attention_4d_softcap]
 status = "pass"
 
 [test_attention_4d_softcap_expanded]
-status = "skip-compile"
-reason = "burn-onnx attention codegen emits bool_not on Shape array and tril on Bool tensor; pre-existing bug"
-tracking = "#314"
+status = "fail-compare"
+reason = "attention op family comparison failure"
+tracking = "#311"
 
 [test_attention_4d_with_past_and_present]
 status = "pass"
@@ -825,9 +825,9 @@ reason = "Unsupported Mod input types: lhs=Shape(1), rhs=Shape(1)"
 tracking = "#314"
 
 [test_attention_4d_with_qk_matmul_expanded]
-status = "skip-compile"
-reason = "burn-onnx attention codegen emits bool_not on Shape array and tril on Bool tensor; pre-existing bug"
-tracking = "#314"
+status = "fail-compare"
+reason = "attention op family comparison failure"
+tracking = "#311"
 
 [test_attention_4d_with_qk_matmul_softcap]
 status = "skip-codegen"

--- a/crates/onnx-official-tests/expectations.toml
+++ b/crates/onnx-official-tests/expectations.toml
@@ -320,9 +320,7 @@ reason = "attention op family comparison failure"
 tracking = "#311"
 
 [test_attention_3d_causal_expanded]
-status = "fail-compare"
-reason = "attention op family comparison failure"
-tracking = "#311"
+status = "pass"
 
 [test_attention_3d_diff_heads_sizes]
 status = "pass"
@@ -341,30 +339,22 @@ reason = "attention op family comparison failure"
 tracking = "#311"
 
 [test_attention_3d_diff_heads_sizes_causal_expanded]
-status = "fail-compare"
-reason = "attention op family comparison failure"
-tracking = "#311"
+status = "pass"
 
 [test_attention_3d_diff_heads_sizes_expanded]
-status = "fail-compare"
-reason = "attention op family comparison failure"
-tracking = "#311"
+status = "pass"
 
 [test_attention_3d_diff_heads_sizes_scaled]
 status = "pass"
 
 [test_attention_3d_diff_heads_sizes_scaled_expanded]
-status = "fail-compare"
-reason = "attention op family comparison failure"
-tracking = "#311"
+status = "pass"
 
 [test_attention_3d_diff_heads_sizes_softcap]
 status = "pass"
 
 [test_attention_3d_diff_heads_sizes_softcap_expanded]
-status = "fail-compare"
-reason = "attention op family comparison failure"
-tracking = "#311"
+status = "pass"
 
 [test_attention_3d_diff_heads_with_past_and_present]
 status = "pass"
@@ -375,9 +365,7 @@ reason = "Unsupported Mod input types: lhs=Shape(1), rhs=Shape(1)"
 tracking = "#314"
 
 [test_attention_3d_expanded]
-status = "fail-compare"
-reason = "attention op family comparison failure"
-tracking = "#311"
+status = "pass"
 
 [test_attention_3d_gqa]
 status = "fail-compare"
@@ -400,14 +388,10 @@ reason = "comparison against reference tensor fails (classified by M2 first-run 
 tracking = "#311"
 
 [test_attention_3d_gqa_causal_expanded]
-status = "fail-compare"
-reason = "attention op family comparison failure"
-tracking = "#311"
+status = "pass"
 
 [test_attention_3d_gqa_expanded]
-status = "fail-compare"
-reason = "attention op family comparison failure"
-tracking = "#311"
+status = "pass"
 
 [test_attention_3d_gqa_scaled]
 status = "fail-compare"
@@ -415,9 +399,7 @@ reason = "comparison against reference tensor fails (classified by M2 first-run 
 tracking = "#311"
 
 [test_attention_3d_gqa_scaled_expanded]
-status = "fail-compare"
-reason = "attention op family comparison failure"
-tracking = "#311"
+status = "pass"
 
 [test_attention_3d_gqa_softcap]
 status = "fail-compare"
@@ -425,9 +407,7 @@ reason = "comparison against reference tensor fails (classified by M2 first-run 
 tracking = "#311"
 
 [test_attention_3d_gqa_softcap_expanded]
-status = "fail-compare"
-reason = "attention op family comparison failure"
-tracking = "#311"
+status = "pass"
 
 [test_attention_3d_gqa_with_past_and_present]
 status = "fail-compare"
@@ -443,25 +423,19 @@ tracking = "#314"
 status = "pass"
 
 [test_attention_3d_scaled_expanded]
-status = "fail-compare"
-reason = "attention op family comparison failure"
-tracking = "#311"
+status = "pass"
 
 [test_attention_3d_softcap]
 status = "pass"
 
 [test_attention_3d_softcap_expanded]
-status = "fail-compare"
-reason = "attention op family comparison failure"
-tracking = "#311"
+status = "pass"
 
 [test_attention_3d_transpose_verification]
 status = "pass"
 
 [test_attention_3d_transpose_verification_expanded]
-status = "fail-compare"
-reason = "attention op family comparison failure"
-tracking = "#311"
+status = "pass"
 
 [test_attention_3d_with_past_and_present]
 status = "pass"
@@ -572,9 +546,7 @@ reason = "attention op family comparison failure"
 tracking = "#311"
 
 [test_attention_4d_causal_expanded]
-status = "fail-compare"
-reason = "attention op family comparison failure"
-tracking = "#311"
+status = "pass"
 
 [test_attention_4d_diff_heads_mask4d_padded_kv]
 status = "skip-codegen"
@@ -603,30 +575,22 @@ reason = "attention op family comparison failure"
 tracking = "#311"
 
 [test_attention_4d_diff_heads_sizes_causal_expanded]
-status = "fail-compare"
-reason = "attention op family comparison failure"
-tracking = "#311"
+status = "pass"
 
 [test_attention_4d_diff_heads_sizes_expanded]
-status = "fail-compare"
-reason = "attention op family comparison failure"
-tracking = "#311"
+status = "pass"
 
 [test_attention_4d_diff_heads_sizes_scaled]
 status = "pass"
 
 [test_attention_4d_diff_heads_sizes_scaled_expanded]
-status = "fail-compare"
-reason = "attention op family comparison failure"
-tracking = "#311"
+status = "pass"
 
 [test_attention_4d_diff_heads_sizes_softcap]
 status = "pass"
 
 [test_attention_4d_diff_heads_sizes_softcap_expanded]
-status = "fail-compare"
-reason = "attention op family comparison failure"
-tracking = "#311"
+status = "pass"
 
 [test_attention_4d_diff_heads_with_past_and_present]
 status = "pass"
@@ -653,9 +617,7 @@ reason = "Unsupported Mod input types: lhs=Shape(1), rhs=Shape(1)"
 tracking = "#314"
 
 [test_attention_4d_expanded]
-status = "fail-compare"
-reason = "attention op family comparison failure"
-tracking = "#311"
+status = "pass"
 
 [test_attention_4d_fp16]
 status = "pass"
@@ -686,14 +648,10 @@ reason = "comparison against reference tensor fails (classified by M2 first-run 
 tracking = "#311"
 
 [test_attention_4d_gqa_causal_expanded]
-status = "fail-compare"
-reason = "attention op family comparison failure"
-tracking = "#311"
+status = "pass"
 
 [test_attention_4d_gqa_expanded]
-status = "fail-compare"
-reason = "attention op family comparison failure"
-tracking = "#311"
+status = "pass"
 
 [test_attention_4d_gqa_scaled]
 status = "fail-compare"
@@ -701,9 +659,7 @@ reason = "comparison against reference tensor fails (classified by M2 first-run 
 tracking = "#311"
 
 [test_attention_4d_gqa_scaled_expanded]
-status = "fail-compare"
-reason = "attention op family comparison failure"
-tracking = "#311"
+status = "pass"
 
 [test_attention_4d_gqa_softcap]
 status = "fail-compare"
@@ -711,9 +667,7 @@ reason = "comparison against reference tensor fails (classified by M2 first-run 
 tracking = "#311"
 
 [test_attention_4d_gqa_softcap_expanded]
-status = "fail-compare"
-reason = "attention op family comparison failure"
-tracking = "#311"
+status = "pass"
 
 [test_attention_4d_gqa_with_past_and_present]
 status = "fail-compare"
@@ -737,17 +691,13 @@ tracking = "#314"
 status = "pass"
 
 [test_attention_4d_scaled_expanded]
-status = "fail-compare"
-reason = "attention op family comparison failure"
-tracking = "#311"
+status = "pass"
 
 [test_attention_4d_softcap]
 status = "pass"
 
 [test_attention_4d_softcap_expanded]
-status = "fail-compare"
-reason = "attention op family comparison failure"
-tracking = "#311"
+status = "pass"
 
 [test_attention_4d_with_past_and_present]
 status = "pass"
@@ -825,9 +775,7 @@ reason = "Unsupported Mod input types: lhs=Shape(1), rhs=Shape(1)"
 tracking = "#314"
 
 [test_attention_4d_with_qk_matmul_expanded]
-status = "fail-compare"
-reason = "attention op family comparison failure"
-tracking = "#311"
+status = "pass"
 
 [test_attention_4d_with_qk_matmul_softcap]
 status = "skip-codegen"
@@ -1780,9 +1728,7 @@ status = "pass"
 status = "pass"
 
 [test_celu_expanded]
-status = "fail-compare"
-reason = "comparison against reference tensor fails (classified by M2 first-run sweep; root cause not yet triaged)"
-tracking = "#311"
+status = "pass"
 
 [test_center_crop_pad_crop]
 status = "skip-codegen"
@@ -2762,9 +2708,7 @@ reason = "Failed to write burnpack file: IoError(\"Failed to get tensor data: Da
 tracking = "#314"
 
 [test_group_normalization_epsilon_expanded]
-status = "fail-compare"
-reason = "comparison against reference tensor fails (classified by M2 first-run sweep; root cause not yet triaged)"
-tracking = "#311"
+status = "pass"
 
 [test_group_normalization_example]
 status = "skip-codegen"
@@ -3944,9 +3888,7 @@ reason = "Unsupported ONNX operation(s): NegativeLogLikelihoodLoss (node 'negati
 tracking = "#314"
 
 [test_nllloss_NCd1d2d3_none_no_weight_negative_ii_expanded]
-status = "fail-compare"
-reason = "comparison against reference tensor fails (classified by M2 first-run sweep; root cause not yet triaged)"
-tracking = "#311"
+status = "pass"
 
 [test_nllloss_NCd1d2d3_sum_weight_high_ii]
 status = "skip-codegen"

--- a/crates/onnx-official-tests/expectations.toml
+++ b/crates/onnx-official-tests/expectations.toml
@@ -623,9 +623,7 @@ status = "pass"
 status = "pass"
 
 [test_attention_4d_fp16_expanded]
-status = "fail-compare"
-reason = "attention op family comparison failure"
-tracking = "#311"
+status = "pass"
 
 [test_attention_4d_gqa]
 status = "fail-compare"


### PR DESCRIPTION
## Summary

Fixes #342. All 27 of the attention `_expanded` tests called out in the issue now compile and run. Of those, 26 also pass numerical comparison; the 27th (`test_attention_4d_fp16_expanded`) is codegen-only because the test harness has no f16 input path — see followup #393.

Three independent codegen bugs were blocking the cluster:

1. **Reshape empty-ident panic** (the 14 × 3D `_expanded` symptoms). `extract_config` always built a `Runtime` shape ref for `ArgType::Shape` inputs, even when the input had a static value. After constant lifting cleared the input name, codegen tried `arg_to_ident("")` and panicked. Fixed in `crates/onnx-ir/src/node/reshape.rs:517` by mirroring the `ScalarTensor` branch — return `Static(values)` when `value()` is present, `Runtime` only when it isn't.

2. **`bool_not` on `[i64; N]`** (Shape-typed Not). Shape arguments encode booleans as 0/1 in a host-side `i64` array (mirroring Equal-on-Shape). The Not codegen unconditionally emitted `.bool_not()`, which doesn't exist on a plain array. Fixed in `crates/burn-onnx/src/burn/node/not.rs` with a `Shape` branch that flips the array element-wise.

3. **`tril`/`triu` on `Tensor<B, 2, Bool>`** (the 14 × 4D `_expanded` symptoms). `burn-flex`'s Bool tensor doesn't satisfy the trait bounds for `tril`/`triu`. Fixed in `crates/burn-onnx/src/burn/node/trilu.rs` by routing Bool inputs through `.int().tril/triu(d).bool()`. The Float/Int paths are unchanged. Mirrors the `attention.rs:356` idiom.

A separate, harder-to-spot bug in the test harness was also masking the actual numerics:

4. **Test harness used `Model::new(&device)` instead of `Model::from_file(bpk, &device)`**. `new` calls `Param::uninitialized` for every field; the closure returns zeros. Models that materialize ONNX `Constant`/`Initializer` nodes as `Param<Tensor<…>>` (every attention `_expanded` variant, plus several other `_expanded` tests) then ran with all-zero constants and produced wrong output, often manifesting as bizarre downstream shape errors (`repeat([0, 0, 0])` collapsing a tensor to `[0, 0, 0, 0]`). Fixed in `crates/onnx-official-tests/build.rs` by emitting `Model::from_file(concat!(env!("OUT_DIR"), "/model/<name>.bpk"), &device)` in the harness. `from_file` is `new` + `load_from`; `load_from` is a no-op when there are no `Param` fields, so this is safe for graphs without constants too.

5. **AGENTS.md guidance**. Added a "Consuming a generated model" subsection under Testing so future contributors don't fall into (4) again. Documents the `Model::from_file` rule, the failure mode, and why the symptom looks downstream ("compare passes for ops that touch no constants, fails for anything reshape/tile/scatter-shaped").

## Net test impact

- `onnx-official-tests`: **595 → 624 runtime tests passing** (+29). 26 attention `_expanded` + 3 unrelated `_expanded` tests (`celu`, `group_normalization_epsilon`, `nllloss_NCd1d2d3_none_no_weight_negative_ii`) that were hitting the same zeroed-`Param` failure mode are now `pass`.
- `test_attention_4d_fp16_expanded` is `pass` but never runs comparison: it lands in `CODEGEN_ONLY_TESTS` because the harness has no f16 path (`pb_loader::TensorValues` lacks an `F16` variant). Its sibling `test_attention_4d_fp16` has the same shape and was already classified `pass` for the same reason. Tracking proper f16 harness support in #393.
- Drift gate (`verify_fail_compare_still_fails`) green.
- All unit tests across `onnx-ir`, `burn-onnx`, `onnx-tests` still pass.

## Test plan
- [x] `cargo test -p onnx-ir` — 472 + 9 pass
- [x] `cargo test -p burn-onnx` — 826 pass (3 new snapshot tests for the Not/Trilu changes)
- [x] `cargo test -p onnx-tests` — 567 pass
- [x] `cargo test -p onnx-official-tests` — 624 pass, drift gate clean
- [x] `cargo fmt --check` clean
- [x] `cargo clippy` introduces no new warnings (28 pre-existing on baseline, 28 on this branch)

## Followups
- #393 — harness can't construct f16/bf16 tensors, so 88+ vendor tests are codegen-only