### PR TITLE
Wire f16/bf16 through onnx-official-tests harness (closes #393)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -505,8 +505,7 @@ checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 [[package]]
 name = "burn"
 version = "0.21.0-pre.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8935b269ac7c386145087f18ba27b04eff84e00cd310c520d009efe3bb538928"
+source = "git+https://github.com/tracel-ai/burn?rev=7640aa7d0704a6a548587d67e77ef489a9a587b7#7640aa7d0704a6a548587d67e77ef489a9a587b7"
 dependencies = [
  "burn-autodiff",
  "burn-candle",
@@ -531,8 +530,7 @@ dependencies = [
 [[package]]
 name = "burn-autodiff"
 version = "0.21.0-pre.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b85643b1cc9ca6eee60cd121a66eccfdede1d083d2fcb46127751f8c29e91b8"
+source = "git+https://github.com/tracel-ai/burn?rev=7640aa7d0704a6a548587d67e77ef489a9a587b7#7640aa7d0704a6a548587d67e77ef489a9a587b7"
 dependencies = [
  "burn-backend",
  "burn-std",
@@ -548,8 +546,7 @@ dependencies = [
 [[package]]
 name = "burn-backend"
 version = "0.21.0-pre.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f2876adeca552a5679b594421422f1a22cde0bf9cef4a1a23f58920b6588f79"
+source = "git+https://github.com/tracel-ai/burn?rev=7640aa7d0704a6a548587d67e77ef489a9a587b7#7640aa7d0704a6a548587d67e77ef489a9a587b7"
 dependencies = [
  "burn-std",
  "bytemuck",
@@ -569,8 +566,7 @@ dependencies = [
 [[package]]
 name = "burn-candle"
 version = "0.21.0-pre.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167447d2594a7a6983c0af1e0f8ca33fe90744ce79d617fb5f0284b855440b54"
+source = "git+https://github.com/tracel-ai/burn?rev=7640aa7d0704a6a548587d67e77ef489a9a587b7#7640aa7d0704a6a548587d67e77ef489a9a587b7"
 dependencies = [
  "burn-backend",
  "burn-std",
@@ -581,8 +577,7 @@ dependencies = [
 [[package]]
 name = "burn-core"
 version = "0.21.0-pre.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6f0e8b835eb8295fa211aecb07f4a2c235b6fa1ad26e880ed69d8e6fc9f3dd9"
+source = "git+https://github.com/tracel-ai/burn?rev=7640aa7d0704a6a548587d67e77ef489a9a587b7#7640aa7d0704a6a548587d67e77ef489a9a587b7"
 dependencies = [
  "ahash",
  "bincode",
@@ -612,8 +607,7 @@ dependencies = [
 [[package]]
 name = "burn-cpu"
 version = "0.21.0-pre.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "004909f25818d349fd690cb78cdb9bf7c03e83296ceb5854abdadfde50c4060f"
+source = "git+https://github.com/tracel-ai/burn?rev=7640aa7d0704a6a548587d67e77ef489a9a587b7#7640aa7d0704a6a548587d67e77ef489a9a587b7"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -624,8 +618,7 @@ dependencies = [
 [[package]]
 name = "burn-cubecl"
 version = "0.21.0-pre.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d84aba4b59e4d5a1f74004be5251e433e072f61ac11516b4553d4a803ffc073"
+source = "git+https://github.com/tracel-ai/burn?rev=7640aa7d0704a6a548587d67e77ef489a9a587b7#7640aa7d0704a6a548587d67e77ef489a9a587b7"
 dependencies = [
  "burn-backend",
  "burn-cubecl-fusion",
@@ -644,8 +637,7 @@ dependencies = [
 [[package]]
 name = "burn-cubecl-fusion"
 version = "0.21.0-pre.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd9166cc26b2c2b487c3d6ea32e14f1c2c5a0165b8e101b000c79a91795e7909"
+source = "git+https://github.com/tracel-ai/burn?rev=7640aa7d0704a6a548587d67e77ef489a9a587b7#7640aa7d0704a6a548587d67e77ef489a9a587b7"
 dependencies = [
  "burn-backend",
  "burn-fusion",
@@ -662,8 +654,7 @@ dependencies = [
 [[package]]
 name = "burn-cuda"
 version = "0.21.0-pre.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e03ad28b9062b017772e314847e992a50ee622a2b35cacc6802dcbf8dcae49d8"
+source = "git+https://github.com/tracel-ai/burn?rev=7640aa7d0704a6a548587d67e77ef489a9a587b7#7640aa7d0704a6a548587d67e77ef489a9a587b7"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -674,8 +665,7 @@ dependencies = [
 [[package]]
 name = "burn-dataset"
 version = "0.21.0-pre.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1484bd8b1e4d05b74495247f2fbd241fbbebe1ac1519f89479fbd6635e730940"
+source = "git+https://github.com/tracel-ai/burn?rev=7640aa7d0704a6a548587d67e77ef489a9a587b7#7640aa7d0704a6a548587d67e77ef489a9a587b7"
 dependencies = [
  "burn-std",
  "csv",
@@ -697,8 +687,7 @@ dependencies = [
 [[package]]
 name = "burn-derive"
 version = "0.21.0-pre.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743a18cf4711891e4b4afbde51187791a72d73a454accca94b6f8ad7a87c8672"
+source = "git+https://github.com/tracel-ai/burn?rev=7640aa7d0704a6a548587d67e77ef489a9a587b7#7640aa7d0704a6a548587d67e77ef489a9a587b7"
 dependencies = [
  "derive-new",
  "proc-macro2",
@@ -709,8 +698,7 @@ dependencies = [
 [[package]]
 name = "burn-dispatch"
 version = "0.21.0-pre.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567d41ae3d1df7ee3c872aff2833a0a13467f6e493908646c3b07e6b66d4744a"
+source = "git+https://github.com/tracel-ai/burn?rev=7640aa7d0704a6a548587d67e77ef489a9a587b7#7640aa7d0704a6a548587d67e77ef489a9a587b7"
 dependencies = [
  "burn-autodiff",
  "burn-backend",
@@ -727,8 +715,7 @@ dependencies = [
 [[package]]
 name = "burn-flex"
 version = "0.21.0-pre.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6130b3e9c1bcfe8bc029526cd15902d70d3377e8be4e5d42fe7cf2c7d62605fb"
+source = "git+https://github.com/tracel-ai/burn?rev=7640aa7d0704a6a548587d67e77ef489a9a587b7#7640aa7d0704a6a548587d67e77ef489a9a587b7"
 dependencies = [
  "aligned-vec",
  "burn-backend",
@@ -749,8 +736,7 @@ dependencies = [
 [[package]]
 name = "burn-fusion"
 version = "0.21.0-pre.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d069d2b768f44de614f2759bfc5248331ab277ccd56a0e1391439aa0e9a07a39"
+source = "git+https://github.com/tracel-ai/burn?rev=7640aa7d0704a6a548587d67e77ef489a9a587b7#7640aa7d0704a6a548587d67e77ef489a9a587b7"
 dependencies = [
  "burn-backend",
  "burn-ir",
@@ -774,8 +760,7 @@ dependencies = [
 [[package]]
 name = "burn-ir"
 version = "0.21.0-pre.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e7946a4aff6ffe3a823212d7e9b70db063f3f328452836ccff2c0dabca15a76"
+source = "git+https://github.com/tracel-ai/burn?rev=7640aa7d0704a6a548587d67e77ef489a9a587b7#7640aa7d0704a6a548587d67e77ef489a9a587b7"
 dependencies = [
  "burn-backend",
  "hashbrown 0.16.1",
@@ -785,8 +770,7 @@ dependencies = [
 [[package]]
 name = "burn-ndarray"
 version = "0.21.0-pre.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5577c77efb8f32acc614968ec1a1fa19afe62c1a3353d05fb2dbc2a9612c64bb"
+source = "git+https://github.com/tracel-ai/burn?rev=7640aa7d0704a6a548587d67e77ef489a9a587b7#7640aa7d0704a6a548587d67e77ef489a9a587b7"
 dependencies = [
  "atomic_float",
  "burn-autodiff",
@@ -808,8 +792,7 @@ dependencies = [
 [[package]]
 name = "burn-nn"
 version = "0.21.0-pre.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f2ab573599eeb3fa56dae8641f6f5986e8f3d74264d9d44c8f8c1a314a19f81"
+source = "git+https://github.com/tracel-ai/burn?rev=7640aa7d0704a6a548587d67e77ef489a9a587b7#7640aa7d0704a6a548587d67e77ef489a9a587b7"
 dependencies = [
  "burn-core",
  "num-traits",
@@ -1111,8 +1094,7 @@ dependencies = [
 [[package]]
 name = "burn-optim"
 version = "0.21.0-pre.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f0d61ac9c2622e66f7070c83308bd3a90473c2553e51a41be861bf90dfc9638"
+source = "git+https://github.com/tracel-ai/burn?rev=7640aa7d0704a6a548587d67e77ef489a9a587b7#7640aa7d0704a6a548587d67e77ef489a9a587b7"
 dependencies = [
  "burn-core",
  "derive-new",
@@ -1125,8 +1107,7 @@ dependencies = [
 [[package]]
 name = "burn-rocm"
 version = "0.21.0-pre.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b08d4b8b76129d3652e479c39929b725856d8f4ca1083698bf3bb92c5fcc9db3"
+source = "git+https://github.com/tracel-ai/burn?rev=7640aa7d0704a6a548587d67e77ef489a9a587b7#7640aa7d0704a6a548587d67e77ef489a9a587b7"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -1137,8 +1118,7 @@ dependencies = [
 [[package]]
 name = "burn-router"
 version = "0.21.0-pre.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe24ab15494f552366dacb3ccc34bedbb2876629107c5c07a039fdfa32642435"
+source = "git+https://github.com/tracel-ai/burn?rev=7640aa7d0704a6a548587d67e77ef489a9a587b7#7640aa7d0704a6a548587d67e77ef489a9a587b7"
 dependencies = [
  "burn-backend",
  "burn-ir",
@@ -1151,8 +1131,7 @@ dependencies = [
 [[package]]
 name = "burn-std"
 version = "0.21.0-pre.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da8b7817a9d98f3e87de5a86e3658b4e8008b32975057dacc7c395b17d105d0a"
+source = "git+https://github.com/tracel-ai/burn?rev=7640aa7d0704a6a548587d67e77ef489a9a587b7#7640aa7d0704a6a548587d67e77ef489a9a587b7"
 dependencies = [
  "bytemuck",
  "bytes",
@@ -1172,8 +1151,7 @@ dependencies = [
 [[package]]
 name = "burn-store"
 version = "0.21.0-pre.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f174dc8a229fbd7800515bd73e99d42c286f5fe166e79301fed4a57e19fb6ac8"
+source = "git+https://github.com/tracel-ai/burn?rev=7640aa7d0704a6a548587d67e77ef489a9a587b7#7640aa7d0704a6a548587d67e77ef489a9a587b7"
 dependencies = [
  "burn-core",
  "burn-tensor",
@@ -1194,8 +1172,7 @@ dependencies = [
 [[package]]
 name = "burn-tch"
 version = "0.21.0-pre.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d1ae2b1408ab29dce93a0b742a3580d005a3b39e54138c5aafd72a6cafc030"
+source = "git+https://github.com/tracel-ai/burn?rev=7640aa7d0704a6a548587d67e77ef489a9a587b7#7640aa7d0704a6a548587d67e77ef489a9a587b7"
 dependencies = [
  "burn-backend",
  "cc",
@@ -1208,8 +1185,7 @@ dependencies = [
 [[package]]
 name = "burn-tensor"
 version = "0.21.0-pre.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc32102843b0327ac26747a81e63cceabbd61d3f872902d6bc098187a7312544"
+source = "git+https://github.com/tracel-ai/burn?rev=7640aa7d0704a6a548587d67e77ef489a9a587b7#7640aa7d0704a6a548587d67e77ef489a9a587b7"
 dependencies = [
  "burn-backend",
  "burn-std",
@@ -1222,8 +1198,7 @@ dependencies = [
 [[package]]
 name = "burn-vision"
 version = "0.21.0-pre.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c82b6f5d3ef735bfa3cd82c6ec8613dce41450b19eca2a6c08b6279fb62ffad"
+source = "git+https://github.com/tracel-ai/burn?rev=7640aa7d0704a6a548587d67e77ef489a9a587b7#7640aa7d0704a6a548587d67e77ef489a9a587b7"
 dependencies = [
  "aligned-vec",
  "bon",
@@ -1248,8 +1223,7 @@ dependencies = [
 [[package]]
 name = "burn-wgpu"
 version = "0.21.0-pre.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4622cd608b68c79da813c1c11cac077b8774555948772f898e143d0891201d81"
+source = "git+https://github.com/tracel-ai/burn?rev=7640aa7d0704a6a548587d67e77ef489a9a587b7#7640aa7d0704a6a548587d67e77ef489a9a587b7"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -5345,6 +5319,7 @@ dependencies = [
  "burn-onnx",
  "burn-store",
  "float-cmp",
+ "half",
  "onnx-ir",
  "protobuf",
  "serde",

--- a/crates/onnx-official-tests/Cargo.toml
+++ b/crates/onnx-official-tests/Cargo.toml
@@ -15,6 +15,7 @@ test-metal = ["burn/metal"]
 test-candle = ["burn/candle"]
 
 [dependencies]
+half = { workspace = true }
 onnx-ir = { workspace = true, features = ["default"] }
 protobuf = { workspace = true }
 serde = { workspace = true, features = ["std"] }

--- a/crates/onnx-official-tests/build.rs
+++ b/crates/onnx-official-tests/build.rs
@@ -102,6 +102,8 @@ fn load_expectations(path: &Path) -> BTreeMap<String, String> {
 
 #[derive(Clone, Copy, Debug)]
 enum Dtype {
+    F16,
+    BF16,
     F32,
     F64,
     I8,
@@ -117,21 +119,23 @@ enum Dtype {
 
 impl Dtype {
     /// Map an `onnx.TensorProto.DataType` i32 to our narrowed enum.
-    /// Returns `None` for dtypes the harness can't load (FLOAT16,
-    /// BFLOAT16, FLOAT8*, INT4, UINT4, FLOAT4E2M1, STRING, COMPLEX*).
+    /// Returns `None` for dtypes the harness can't load (FLOAT8*,
+    /// INT4, UINT4, FLOAT4E2M1, STRING, COMPLEX*).
     fn from_elem_type(t: i32) -> Option<Self> {
         match t {
-            1 => Some(Self::F32),  // FLOAT
-            2 => Some(Self::U8),   // UINT8
-            3 => Some(Self::I8),   // INT8
-            4 => Some(Self::U16),  // UINT16
-            5 => Some(Self::I16),  // INT16
-            6 => Some(Self::I32),  // INT32
-            7 => Some(Self::I64),  // INT64
-            9 => Some(Self::Bool), // BOOL
-            11 => Some(Self::F64), // DOUBLE
-            12 => Some(Self::U32), // UINT32
-            13 => Some(Self::U64), // UINT64
+            1 => Some(Self::F32),   // FLOAT
+            2 => Some(Self::U8),    // UINT8
+            3 => Some(Self::I8),    // INT8
+            4 => Some(Self::U16),   // UINT16
+            5 => Some(Self::I16),   // INT16
+            6 => Some(Self::I32),   // INT32
+            7 => Some(Self::I64),   // INT64
+            9 => Some(Self::Bool),  // BOOL
+            10 => Some(Self::F16),  // FLOAT16
+            11 => Some(Self::F64),  // DOUBLE
+            12 => Some(Self::U32),  // UINT32
+            13 => Some(Self::U64),  // UINT64
+            16 => Some(Self::BF16), // BFLOAT16
             _ => None,
         }
     }
@@ -140,6 +144,8 @@ impl Dtype {
     /// loaded `ReferenceTensor` in the harness.
     fn values_variant(self) -> &'static str {
         match self {
+            Self::F16 => "F16",
+            Self::BF16 => "BF16",
             Self::F32 => "F32",
             Self::F64 => "F64",
             Self::I8 => "I8",
@@ -157,6 +163,8 @@ impl Dtype {
     /// ONNX dtype display name for diagnostic messages.
     fn onnx_name(self) -> &'static str {
         match self {
+            Self::F16 => "FLOAT16",
+            Self::BF16 => "BFLOAT16",
             Self::F32 => "FLOAT",
             Self::F64 => "DOUBLE",
             Self::I8 => "INT8",
@@ -175,9 +183,11 @@ impl Dtype {
     /// default `Float` kind, explicit for `Int` / `Bool`. Burn groups
     /// every integer dtype under the `Int` tensor kind and uses a
     /// runtime `.cast(DType::…)` to preserve the ONNX bit width.
+    /// f16/bf16 use the default Float kind; the runtime dtype is pinned
+    /// via the `DType::F16`/`DType::BF16` argument to `from_data`.
     fn tensor_kind_suffix(self) -> &'static str {
         match self {
-            Self::F32 | Self::F64 => "",
+            Self::F16 | Self::BF16 | Self::F32 | Self::F64 => "",
             Self::Bool => ", burn::tensor::Bool",
             _ => ", burn::tensor::Int",
         }
@@ -194,6 +204,8 @@ impl Dtype {
     /// the later `assert_eq` against the I64 expected-value TensorData.
     fn burn_dtype_tokens(self) -> &'static str {
         match self {
+            Self::F16 => "burn::tensor::DType::F16",
+            Self::BF16 => "burn::tensor::DType::BF16",
             Self::F32 => "burn::tensor::DType::F32",
             Self::F64 => "burn::tensor::DType::F64",
             Self::I8 => "burn::tensor::DType::I8",
@@ -209,13 +221,18 @@ impl Dtype {
     }
 
     /// The concrete Rust element type to use as the type parameter for
-    /// `TensorData::assert_approx_eq::<T>`. Using `f32` for FLOAT and
-    /// `f64` for DOUBLE avoids two problems: (a) a backend default
-    /// `FloatElem<TestBackend>` that differs from the TensorData dtype
-    /// would cause a type mismatch, and (b) using a narrower type than
-    /// the decoded values would compare at reduced precision.
+    /// `TensorData::assert_approx_eq::<T>`. Matching the source dtype
+    /// avoids two problems: (a) a backend default `FloatElem<TestBackend>`
+    /// that differs from the TensorData dtype would cause a type mismatch,
+    /// and (b) using a narrower type than the decoded values would
+    /// compare at reduced precision.
     fn assert_elem_type(self) -> &'static str {
         match self {
+            // burn-tensor re-exports `half::f16` / `half::bf16` at its
+            // crate root, so the harness can stay self-contained against
+            // its existing `burn` dev-dependency.
+            Self::F16 => "burn::tensor::f16",
+            Self::BF16 => "burn::tensor::bf16",
             Self::F32 => "f32",
             Self::F64 => "f64",
             _ => "f32", // unreachable for non-float; caller guards with is_float()
@@ -225,7 +242,7 @@ impl Dtype {
     /// Whether output comparison should use an approximate float
     /// tolerance (`assert_approx_eq`) or exact equality (`assert_eq`).
     fn is_float(self) -> bool {
-        matches!(self, Self::F32 | Self::F64)
+        matches!(self, Self::F16 | Self::BF16 | Self::F32 | Self::F64)
     }
 }
 

--- a/crates/onnx-official-tests/expectations.toml
+++ b/crates/onnx-official-tests/expectations.toml
@@ -678,7 +678,9 @@ reason = "Unsupported Mod input types: lhs=Shape(1), rhs=Shape(1)"
 tracking = "#314"
 
 [test_attention_4d_gqa_with_past_and_present_fp16]
-status = "pass"
+status = "fail-compare"
+reason = "burn-flex attention_naive panics on GQA: key heads (3) != query heads (9) at burn-flex/src/ops/attention.rs:658. Surfaced after #393 wired f16 comparison through the harness; not a burn-onnx codegen bug."
+tracking = "https://github.com/tracel-ai/burn/issues/4930"
 
 [test_attention_4d_gqa_with_past_and_present_fp16_expanded]
 status = "skip-codegen"

--- a/crates/onnx-official-tests/src/pb_loader.rs
+++ b/crates/onnx-official-tests/src/pb_loader.rs
@@ -8,13 +8,13 @@
 //! The dtype coverage is:
 //!
 //! * Integer: INT8, INT16, INT32, INT64, UINT8, UINT16, UINT32, UINT64
-//! * Float:   FLOAT (f32), DOUBLE (f64)
+//! * Float:   FLOAT (f32), DOUBLE (f64), FLOAT16 (half::f16), BFLOAT16 (half::bf16)
 //! * Other:   BOOL
 //!
-//! Exotic dtypes (FLOAT16, BFLOAT16, FLOAT8*, INT4/UINT4, FLOAT4E2M1,
-//! STRING, COMPLEX*) surface as [`LoadError::UnsupportedDataType`]. Every
-//! upstream node test that uses them is `skip-codegen` or `fail-compare`
-//! in `expectations.toml`, so the harness never tries to load them.
+//! Exotic dtypes (FLOAT8*, INT4/UINT4, FLOAT4E2M1, STRING, COMPLEX*)
+//! surface as [`LoadError::UnsupportedDataType`]. Every upstream node
+//! test that uses them is `skip-codegen` or `fail-compare` in
+//! `expectations.toml`, so the harness never tries to load them.
 //!
 //! ONNX stores values in one of two mutually exclusive places:
 //!
@@ -28,6 +28,7 @@
 //!   lives in `int32_data` as i32 values but must be truncated back to
 //!   i8 on read).
 
+use half::{bf16, f16};
 use onnx_ir::TensorProto;
 use protobuf::Message;
 use std::path::{Path, PathBuf};
@@ -48,9 +49,11 @@ const DATA_TYPE_INT16: i32 = 5;
 const DATA_TYPE_INT32: i32 = 6;
 const DATA_TYPE_INT64: i32 = 7;
 const DATA_TYPE_BOOL: i32 = 9;
+const DATA_TYPE_FLOAT16: i32 = 10;
 const DATA_TYPE_DOUBLE: i32 = 11;
 const DATA_TYPE_UINT32: i32 = 12;
 const DATA_TYPE_UINT64: i32 = 13;
+const DATA_TYPE_BFLOAT16: i32 = 16;
 
 /// A decoded upstream reference tensor. The shape is stored once and
 /// shared across every dtype variant so callers can do shape-only checks
@@ -88,6 +91,8 @@ pub enum TensorValues {
     U32(Vec<u32>),
     U64(Vec<u64>),
     Bool(Vec<bool>),
+    F16(Vec<f16>),
+    BF16(Vec<bf16>),
     F32(Vec<f32>),
     F64(Vec<f64>),
 }
@@ -105,6 +110,8 @@ impl TensorValues {
             Self::U32(_) => "UINT32",
             Self::U64(_) => "UINT64",
             Self::Bool(_) => "BOOL",
+            Self::F16(_) => "FLOAT16",
+            Self::BF16(_) => "BFLOAT16",
             Self::F32(_) => "FLOAT",
             Self::F64(_) => "DOUBLE",
         }
@@ -123,6 +130,8 @@ impl TensorValues {
             Self::U32(v) => v.len(),
             Self::U64(v) => v.len(),
             Self::Bool(v) => v.len(),
+            Self::F16(v) => v.len(),
+            Self::BF16(v) => v.len(),
             Self::F32(v) => v.len(),
             Self::F64(v) => v.len(),
         }
@@ -168,7 +177,7 @@ pub enum LoadError {
     UndefinedDataType { path: PathBuf },
     #[error(
         "{path:?}: unsupported TensorProto data_type {data_type} \
-         (not decoded: FLOAT16, BFLOAT16, FLOAT8*, INT4/UINT4, FLOAT4E2M1, STRING, COMPLEX*)"
+         (not decoded: FLOAT8*, INT4/UINT4, FLOAT4E2M1, STRING, COMPLEX*)"
     )]
     UnsupportedDataType { path: PathBuf, data_type: i32 },
     #[error("{path:?}: loaded dtype {actual} does not match caller's expected dtype {expected}")]
@@ -305,6 +314,8 @@ fn decode_values(
         }),
         DATA_TYPE_FLOAT => decode_f32(path, proto).map(TensorValues::F32),
         DATA_TYPE_DOUBLE => decode_f64(path, proto).map(TensorValues::F64),
+        DATA_TYPE_FLOAT16 => decode_f16(path, proto).map(TensorValues::F16),
+        DATA_TYPE_BFLOAT16 => decode_bf16(path, proto).map(TensorValues::BF16),
         DATA_TYPE_INT8 => decode_i8(path, proto, expected).map(TensorValues::I8),
         DATA_TYPE_INT16 => decode_i16(path, proto, expected).map(TensorValues::I16),
         DATA_TYPE_INT32 => decode_i32(path, proto).map(TensorValues::I32),
@@ -356,6 +367,43 @@ fn decode_f64(path: &Path, proto: &TensorProto) -> Result<Vec<f64>, LoadError> {
             .collect())
     } else {
         Ok(proto.double_data.clone())
+    }
+}
+
+// ONNX stores FLOAT16 / BFLOAT16 either packed in `raw_data` (2 bytes per
+// element, little-endian) or bit-cast into the lower 16 bits of each i32
+// element of `int32_data` (upper 16 bits zero per spec).
+fn decode_f16(path: &Path, proto: &TensorProto) -> Result<Vec<f16>, LoadError> {
+    if !proto.raw_data.is_empty() {
+        check_raw_alignment(path, &proto.raw_data, 2, "FLOAT16")?;
+        Ok(proto
+            .raw_data
+            .chunks_exact(2)
+            .map(|c| f16::from_le_bytes([c[0], c[1]]))
+            .collect())
+    } else {
+        Ok(proto
+            .int32_data
+            .iter()
+            .map(|&v| f16::from_bits((v as u32 & 0xFFFF) as u16))
+            .collect())
+    }
+}
+
+fn decode_bf16(path: &Path, proto: &TensorProto) -> Result<Vec<bf16>, LoadError> {
+    if !proto.raw_data.is_empty() {
+        check_raw_alignment(path, &proto.raw_data, 2, "BFLOAT16")?;
+        Ok(proto
+            .raw_data
+            .chunks_exact(2)
+            .map(|c| bf16::from_le_bytes([c[0], c[1]]))
+            .collect())
+    } else {
+        Ok(proto
+            .int32_data
+            .iter()
+            .map(|&v| bf16::from_bits((v as u32 & 0xFFFF) as u16))
+            .collect())
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes #393.

`crates/onnx-official-tests` skipped the runtime comparison check for any vendor model with f16/bf16 I/O. Codegen + compile still ran, but the test landed in `CODEGEN_ONLY_TESTS` with no `#[test]` body — the `pass` status only confirmed it built.

This wires `FLOAT16` (10) and `BFLOAT16` (16) through both choke points: `pb_loader` decodes them into `TensorValues::F16`/`BF16`, and `build.rs` extends `Dtype` so introspection accepts them and the harness emits `Tensor::from_data(data, (&device, DType::F16))` / `assert_approx_eq::<half::f16>` (via `burn::tensor::{f16,bf16}` re-exports).

12 fp16/bfloat16 tests that previously only verified compilation now actually compare against ORT outputs and pass.

One regression surfaced: `test_attention_4d_gqa_with_past_and_present_fp16` panics in burn-flex's `attention_naive` on Group Query Attention (key heads 3 vs query heads 9). Reclassified to `fail-compare`. Filed upstream as tracel-ai/burn#4930.

## Test plan

- [x] `cargo build -p onnx-official-tests` succeeds; no more `unsupported element dtype 10/16` warnings (only INT4/UINT4 remain, which are out of scope per the issue)
- [x] `cargo test -p onnx-official-tests --test test_mod`: 637 passed / 0 failed (was 637 with the gqa-fp16 test silently elided)
- [x] `verify_expectations_match_tests` and `verify_fail_compare_still_fails` both pass

## Out of scope

Per the issue body, FLOAT8\* / INT4 / UINT4 / FLOAT4E2M1 / STRING / COMPLEX\* are deliberately not addressed here — they need either no `Vec<T>` analogue work or no Burn `DType`, and warrant their own scoped issues.

## Notes

`Cargo.lock` includes a registry → git resync of the `burn-*` entries (workspace already pointed at the git source; the lockfile drifted in #394). Unrelated to f16/bf16 but came along for the ride; reverting it would put the lock back out of sync with the workspace.
