### PR TITLE
Update version to 0.22.0-pre.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -504,9 +504,8 @@ checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "burn"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39474be398d30e08681f1f6a8ff446b1e4f1403b5cf7749649a8871fd5945f3a"
+version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=1997b3295a4cda2bb7366050857f689de7240787#1997b3295a4cda2bb7366050857f689de7240787"
 dependencies = [
  "burn-autodiff",
  "burn-candle",
@@ -530,9 +529,8 @@ dependencies = [
 
 [[package]]
 name = "burn-autodiff"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b93a80e43bfab909399444b29ce3894ff51f7e879720bfc75b6007ae6a01c3d"
+version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=1997b3295a4cda2bb7366050857f689de7240787#1997b3295a4cda2bb7366050857f689de7240787"
 dependencies = [
  "burn-backend",
  "burn-std",
@@ -547,9 +545,8 @@ dependencies = [
 
 [[package]]
 name = "burn-backend"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64491519ac0867f550fa9c726cd443e5db94608c629050986cf2614c8c5ad39f"
+version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=1997b3295a4cda2bb7366050857f689de7240787#1997b3295a4cda2bb7366050857f689de7240787"
 dependencies = [
  "burn-std",
  "bytemuck",
@@ -568,9 +565,8 @@ dependencies = [
 
 [[package]]
 name = "burn-candle"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "917fbbe1238d80ec1483c2c360ed9fa0146fdf57b2e66015c0824ccf5155276c"
+version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=1997b3295a4cda2bb7366050857f689de7240787#1997b3295a4cda2bb7366050857f689de7240787"
 dependencies = [
  "burn-backend",
  "burn-std",
@@ -580,9 +576,8 @@ dependencies = [
 
 [[package]]
 name = "burn-core"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bde1e3b8e7e39b0aa71cd5905207ceea5c3478bec47bdb64acf72dcd0d6f978"
+version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=1997b3295a4cda2bb7366050857f689de7240787#1997b3295a4cda2bb7366050857f689de7240787"
 dependencies = [
  "ahash",
  "bincode",
@@ -611,9 +606,8 @@ dependencies = [
 
 [[package]]
 name = "burn-cpu"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "681478c5438ab6c753a55b85f5b42e5bd4c1f69a8564f2afa2f698ac396ba556"
+version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=1997b3295a4cda2bb7366050857f689de7240787#1997b3295a4cda2bb7366050857f689de7240787"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -623,9 +617,8 @@ dependencies = [
 
 [[package]]
 name = "burn-cubecl"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26efbec96ca3f691593c966fa90f98ef8a72867f62627904920b619ba3a9e6b6"
+version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=1997b3295a4cda2bb7366050857f689de7240787#1997b3295a4cda2bb7366050857f689de7240787"
 dependencies = [
  "burn-backend",
  "burn-cubecl-fusion",
@@ -643,9 +636,8 @@ dependencies = [
 
 [[package]]
 name = "burn-cubecl-fusion"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6993d15b8ed588f55626e835ca768c1c3c7aa7a79d59beff4c987c40fc82d1f4"
+version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=1997b3295a4cda2bb7366050857f689de7240787#1997b3295a4cda2bb7366050857f689de7240787"
 dependencies = [
  "burn-backend",
  "burn-fusion",
@@ -661,9 +653,8 @@ dependencies = [
 
 [[package]]
 name = "burn-cuda"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6c66b49136fc11f59773054358f401fbec7fa0d69615f55ef22c29cf241c9b7"
+version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=1997b3295a4cda2bb7366050857f689de7240787#1997b3295a4cda2bb7366050857f689de7240787"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -673,9 +664,8 @@ dependencies = [
 
 [[package]]
 name = "burn-dataset"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba469fba38357c8bb65458873ddfd82aa97534aec0b3bae93d4c44604fc63839"
+version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=1997b3295a4cda2bb7366050857f689de7240787#1997b3295a4cda2bb7366050857f689de7240787"
 dependencies = [
  "burn-std",
  "csv",
@@ -696,9 +686,8 @@ dependencies = [
 
 [[package]]
 name = "burn-derive"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce7be43cdfc9903c43dbaf3f4821543e0497d79047d8fc9ee9084e448844446"
+version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=1997b3295a4cda2bb7366050857f689de7240787#1997b3295a4cda2bb7366050857f689de7240787"
 dependencies = [
  "derive-new",
  "proc-macro2",
@@ -708,9 +697,8 @@ dependencies = [
 
 [[package]]
 name = "burn-dispatch"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2087b9e12323e0d25cc0ebdccfee40427dfdec4a23fa6d3f49ba2aa1f94ac17"
+version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=1997b3295a4cda2bb7366050857f689de7240787#1997b3295a4cda2bb7366050857f689de7240787"
 dependencies = [
  "burn-autodiff",
  "burn-backend",
@@ -726,9 +714,8 @@ dependencies = [
 
 [[package]]
 name = "burn-flex"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0098bf6555c151517b4c98ca0e8ed1ab6a976e40f5f4e967c117b00eee21e192"
+version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=1997b3295a4cda2bb7366050857f689de7240787#1997b3295a4cda2bb7366050857f689de7240787"
 dependencies = [
  "aligned-vec",
  "burn-backend",
@@ -748,9 +735,8 @@ dependencies = [
 
 [[package]]
 name = "burn-fusion"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95e58fcfd52a60cdf2f7da34fbebf0ed38f960fbd8675d384bacd5795cf2bdf2"
+version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=1997b3295a4cda2bb7366050857f689de7240787#1997b3295a4cda2bb7366050857f689de7240787"
 dependencies = [
  "burn-backend",
  "burn-ir",
@@ -766,16 +752,15 @@ dependencies = [
 
 [[package]]
 name = "burn-import"
-version = "0.21.0"
+version = "0.22.0-pre.1"
 dependencies = [
  "burn-onnx",
 ]
 
 [[package]]
 name = "burn-ir"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a81a55c32f35c2265d9e15ba2e796013d9780d5a49f9e21ea0ac4d29609dbf13"
+version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=1997b3295a4cda2bb7366050857f689de7240787#1997b3295a4cda2bb7366050857f689de7240787"
 dependencies = [
  "burn-backend",
  "hashbrown 0.16.1",
@@ -784,9 +769,8 @@ dependencies = [
 
 [[package]]
 name = "burn-ndarray"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dceb9692e292782bab7ad0259e8e8f5ee80ba2b0329a78f0ba589a26a9633dd6"
+version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=1997b3295a4cda2bb7366050857f689de7240787#1997b3295a4cda2bb7366050857f689de7240787"
 dependencies = [
  "atomic_float",
  "burn-autodiff",
@@ -807,9 +791,8 @@ dependencies = [
 
 [[package]]
 name = "burn-nn"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93e4acd90806fa8663610f1071f3a8992eb98637d2d0816ee3062b334f61af00"
+version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=1997b3295a4cda2bb7366050857f689de7240787#1997b3295a4cda2bb7366050857f689de7240787"
 dependencies = [
  "burn-core",
  "num-traits",
@@ -817,7 +800,7 @@ dependencies = [
 
 [[package]]
 name = "burn-onnx"
-version = "0.21.0"
+version = "0.22.0-pre.1"
 dependencies = [
  "burn",
  "burn-store",
@@ -1110,9 +1093,8 @@ dependencies = [
 
 [[package]]
 name = "burn-optim"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c5ea466ae0b85bf18f7656cdc152050dc8c581057fbbe33bbed267e22600228"
+version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=1997b3295a4cda2bb7366050857f689de7240787#1997b3295a4cda2bb7366050857f689de7240787"
 dependencies = [
  "burn-core",
  "derive-new",
@@ -1124,9 +1106,8 @@ dependencies = [
 
 [[package]]
 name = "burn-rocm"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66af82fdaaf2ad0fa4b0dae90119aa94f333105d76d520e0eb48917717c06fde"
+version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=1997b3295a4cda2bb7366050857f689de7240787#1997b3295a4cda2bb7366050857f689de7240787"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -1136,9 +1117,8 @@ dependencies = [
 
 [[package]]
 name = "burn-router"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7960a5d43918c3158629da2bd7956e38dda16ef54de95cca83b4b7b1477e6185"
+version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=1997b3295a4cda2bb7366050857f689de7240787#1997b3295a4cda2bb7366050857f689de7240787"
 dependencies = [
  "burn-backend",
  "burn-ir",
@@ -1150,9 +1130,8 @@ dependencies = [
 
 [[package]]
 name = "burn-std"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81c7eb60eb2c316854af5b214fd55f59fc7b0e25dfde7db671f09cc49f269048"
+version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=1997b3295a4cda2bb7366050857f689de7240787#1997b3295a4cda2bb7366050857f689de7240787"
 dependencies = [
  "bytemuck",
  "bytes",
@@ -1171,9 +1150,8 @@ dependencies = [
 
 [[package]]
 name = "burn-store"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f64a4fe2a0616d18f07d1d0d19c79e655e70e1828cbcb5e9df7b52211091023"
+version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=1997b3295a4cda2bb7366050857f689de7240787#1997b3295a4cda2bb7366050857f689de7240787"
 dependencies = [
  "burn-core",
  "burn-tensor",
@@ -1193,9 +1171,8 @@ dependencies = [
 
 [[package]]
 name = "burn-tch"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfa36b630bd7a790395b4561f7d0e315c0d5e1c557db7dd4cf1b48d5c0d4aff2"
+version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=1997b3295a4cda2bb7366050857f689de7240787#1997b3295a4cda2bb7366050857f689de7240787"
 dependencies = [
  "burn-backend",
  "cc",
@@ -1207,9 +1184,8 @@ dependencies = [
 
 [[package]]
 name = "burn-tensor"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "223ed3804bb9436e401fc57b87e44c86267070b870813520ed9f706c80c81442"
+version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=1997b3295a4cda2bb7366050857f689de7240787#1997b3295a4cda2bb7366050857f689de7240787"
 dependencies = [
  "burn-backend",
  "burn-std",
@@ -1221,9 +1197,8 @@ dependencies = [
 
 [[package]]
 name = "burn-vision"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b5a3e9096977462cd22bf713087f9777e427f7693508871f86f5b1e8347a70"
+version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=1997b3295a4cda2bb7366050857f689de7240787#1997b3295a4cda2bb7366050857f689de7240787"
 dependencies = [
  "aligned-vec",
  "bon",
@@ -1247,9 +1222,8 @@ dependencies = [
 
 [[package]]
 name = "burn-wgpu"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eb009254af15922cb37814f3b3b61043046193ba2fde97c3879a25fbd51a92e"
+version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=1997b3295a4cda2bb7366050857f689de7240787#1997b3295a4cda2bb7366050857f689de7240787"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -1965,9 +1939,8 @@ dependencies = [
 
 [[package]]
 name = "cubecl"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd203fef6e359472e4cb8f6c0ef3eca062815a1edd560eb6d6c1d5c1397838d9"
+version = "0.11.0-pre.1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=901d37dbd4a916b764360e4fea111b01356f8263#901d37dbd4a916b764360e4fea111b01356f8263"
 dependencies = [
  "cubecl-core",
  "cubecl-cpu",
@@ -1982,9 +1955,8 @@ dependencies = [
 
 [[package]]
 name = "cubecl-common"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc956c2dcc993f16f748d03bfdbd900f75cab4d469f4e5d8924f8ee128e861ad"
+version = "0.11.0-pre.1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=901d37dbd4a916b764360e4fea111b01356f8263#901d37dbd4a916b764360e4fea111b01356f8263"
 dependencies = [
  "backtrace",
  "bytemuck",
@@ -2024,9 +1996,8 @@ dependencies = [
 
 [[package]]
 name = "cubecl-core"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7522e7acf25d7848032c7b5270780f9f2abe84e13c7ed6345aa27ba70c312ca"
+version = "0.11.0-pre.1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=901d37dbd4a916b764360e4fea111b01356f8263#901d37dbd4a916b764360e4fea111b01356f8263"
 dependencies = [
  "bitflags 2.11.1",
  "bytemuck",
@@ -2052,9 +2023,8 @@ dependencies = [
 
 [[package]]
 name = "cubecl-cpp"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "411af04828cbf4583ecd388579fb30cd7a644eec19a334bb8f0d9d08522e1458"
+version = "0.11.0-pre.1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=901d37dbd4a916b764360e4fea111b01356f8263#901d37dbd4a916b764360e4fea111b01356f8263"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -2069,9 +2039,8 @@ dependencies = [
 
 [[package]]
 name = "cubecl-cpu"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f572143f54e42a49ee0635a4ec36005f639e62be029e4f49890c808985981b35"
+version = "0.11.0-pre.1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=901d37dbd4a916b764360e4fea111b01356f8263#901d37dbd4a916b764360e4fea111b01356f8263"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -2091,9 +2060,8 @@ dependencies = [
 
 [[package]]
 name = "cubecl-cuda"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6b0a69ff45688d322ad8e92c8bf645167b9ca490fa8fa087fc6adac8c5e46be"
+version = "0.11.0-pre.1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=901d37dbd4a916b764360e4fea111b01356f8263#901d37dbd4a916b764360e4fea111b01356f8263"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -2110,9 +2078,8 @@ dependencies = [
 
 [[package]]
 name = "cubecl-hip"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c6b510a9348f06ecd56b32cf10eb6241639e927a87f5c09ec61cc7a7610d5a3"
+version = "0.11.0-pre.1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=901d37dbd4a916b764360e4fea111b01356f8263#901d37dbd4a916b764360e4fea111b01356f8263"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -2140,9 +2107,8 @@ dependencies = [
 
 [[package]]
 name = "cubecl-ir"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d28a897a40c8ee6c57a8b8d76d8823ba2e97f4c2b83db9338f17a0752132d486"
+version = "0.11.0-pre.1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=901d37dbd4a916b764360e4fea111b01356f8263#901d37dbd4a916b764360e4fea111b01356f8263"
 dependencies = [
  "cubecl-common",
  "cubecl-macros-internal",
@@ -2162,9 +2128,8 @@ dependencies = [
 
 [[package]]
 name = "cubecl-macros"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77aa6df563e8e6a0926d2e9eeacb968737940a0e1ae9be819f6a65a341006e12"
+version = "0.11.0-pre.1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=901d37dbd4a916b764360e4fea111b01356f8263#901d37dbd4a916b764360e4fea111b01356f8263"
 dependencies = [
  "cubecl-common",
  "darling 0.23.0",
@@ -2179,9 +2144,8 @@ dependencies = [
 
 [[package]]
 name = "cubecl-macros-internal"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a515651a5a91e25d87f71f311f80a088e6cf815798b9922560a97636da6b8740"
+version = "0.11.0-pre.1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=901d37dbd4a916b764360e4fea111b01356f8263#901d37dbd4a916b764360e4fea111b01356f8263"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -2191,9 +2155,8 @@ dependencies = [
 
 [[package]]
 name = "cubecl-opt"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a599c6c3efefdcee8636994c90e58ef696c7efbed2d18b5b5ad8d5f29923abb"
+version = "0.11.0-pre.1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=901d37dbd4a916b764360e4fea111b01356f8263#901d37dbd4a916b764360e4fea111b01356f8263"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -2209,9 +2172,8 @@ dependencies = [
 
 [[package]]
 name = "cubecl-runtime"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b68491bf5b3e997ae36bdc4e63b4ccd6d2f0e86b3b596a5d7a48d2b9e92622a0"
+version = "0.11.0-pre.1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=901d37dbd4a916b764360e4fea111b01356f8263#901d37dbd4a916b764360e4fea111b01356f8263"
 dependencies = [
  "ahash",
  "async-channel",
@@ -2240,9 +2202,8 @@ dependencies = [
 
 [[package]]
 name = "cubecl-std"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b391b584a4897683dd9fc0767f96337ac712b733126ce0f68a9ee8a2df073d2d"
+version = "0.11.0-pre.1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=901d37dbd4a916b764360e4fea111b01356f8263#901d37dbd4a916b764360e4fea111b01356f8263"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -2257,9 +2218,8 @@ dependencies = [
 
 [[package]]
 name = "cubecl-wgpu"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d3663c6e1a86187172b2cee495b6b533e7d91a2cb37e26f421649e315fe4c3a"
+version = "0.11.0-pre.1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=901d37dbd4a916b764360e4fea111b01356f8263#901d37dbd4a916b764360e4fea111b01356f8263"
 dependencies = [
  "async-channel",
  "bytemuck",
@@ -2283,9 +2243,8 @@ dependencies = [
 
 [[package]]
 name = "cubecl-zspace"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04054d95698afab785a4dda9f949e297831dd9e4cc6d036a93e6603f88e88b07"
+version = "0.11.0-pre.1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=901d37dbd4a916b764360e4fea111b01356f8263#901d37dbd4a916b764360e4fea111b01356f8263"
 dependencies = [
  "derive-new",
  "serde",
@@ -2294,14 +2253,14 @@ dependencies = [
 
 [[package]]
 name = "cubek"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba62fb5043d5eb723017415eec57c541f41901beea984500e2e16b57d75fa717"
+version = "0.3.0-pre.1"
+source = "git+https://github.com/tracel-ai/cubek?rev=9372f94bfa8f66c6843bb9c37bd30c6fbcdb45cf#9372f94bfa8f66c6843bb9c37bd30c6fbcdb45cf"
 dependencies = [
  "cubecl",
  "cubek-attention",
  "cubek-convolution",
  "cubek-fft",
+ "cubek-interpolate",
  "cubek-matmul",
  "cubek-quant",
  "cubek-random",
@@ -2311,9 +2270,8 @@ dependencies = [
 
 [[package]]
 name = "cubek-attention"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75ca5c363f05a9297b9d1c0e90959cc5f9fd90bc596e4e537f26f20602ec63a5"
+version = "0.3.0-pre.1"
+source = "git+https://github.com/tracel-ai/cubek?rev=9372f94bfa8f66c6843bb9c37bd30c6fbcdb45cf#9372f94bfa8f66c6843bb9c37bd30c6fbcdb45cf"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2326,9 +2284,8 @@ dependencies = [
 
 [[package]]
 name = "cubek-convolution"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70f2755a8eb9ea5509c17edac78e4a9dc4be89c433d8e2ee709703a93b96f749"
+version = "0.3.0-pre.1"
+source = "git+https://github.com/tracel-ai/cubek?rev=9372f94bfa8f66c6843bb9c37bd30c6fbcdb45cf#9372f94bfa8f66c6843bb9c37bd30c6fbcdb45cf"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2343,18 +2300,26 @@ dependencies = [
 
 [[package]]
 name = "cubek-fft"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dd7c2972363332dc4609067a2ccc21856308d98089e676d3f0c52747ae61a5b"
+version = "0.3.0-pre.1"
+source = "git+https://github.com/tracel-ai/cubek?rev=9372f94bfa8f66c6843bb9c37bd30c6fbcdb45cf#9372f94bfa8f66c6843bb9c37bd30c6fbcdb45cf"
 dependencies = [
  "cubecl",
 ]
 
 [[package]]
+name = "cubek-interpolate"
+version = "0.3.0-pre.1"
+source = "git+https://github.com/tracel-ai/cubek?rev=9372f94bfa8f66c6843bb9c37bd30c6fbcdb45cf#9372f94bfa8f66c6843bb9c37bd30c6fbcdb45cf"
+dependencies = [
+ "cubecl",
+ "cubecl-common",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "cubek-matmul"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a4cea5f0f439907dc953c7638a6204b3f055f1bcbd10db91dfc5faa030ac1c"
+version = "0.3.0-pre.1"
+source = "git+https://github.com/tracel-ai/cubek?rev=9372f94bfa8f66c6843bb9c37bd30c6fbcdb45cf#9372f94bfa8f66c6843bb9c37bd30c6fbcdb45cf"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2366,9 +2331,8 @@ dependencies = [
 
 [[package]]
 name = "cubek-quant"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "802ff1b5f19597a7b7cb308c7c69e9eef28b78d57dab7794c816bb8f7d3d1b85"
+version = "0.3.0-pre.1"
+source = "git+https://github.com/tracel-ai/cubek?rev=9372f94bfa8f66c6843bb9c37bd30c6fbcdb45cf#9372f94bfa8f66c6843bb9c37bd30c6fbcdb45cf"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2378,9 +2342,8 @@ dependencies = [
 
 [[package]]
 name = "cubek-random"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dfecce959bdbeb3b355120e586d1ea9e45a0fc7f2ca354f4260a571952551be"
+version = "0.3.0-pre.1"
+source = "git+https://github.com/tracel-ai/cubek?rev=9372f94bfa8f66c6843bb9c37bd30c6fbcdb45cf#9372f94bfa8f66c6843bb9c37bd30c6fbcdb45cf"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2392,9 +2355,8 @@ dependencies = [
 
 [[package]]
 name = "cubek-reduce"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86758b84452b06e9121f25200da13b4909ecd6235cefb5f33f459bea24dac41a"
+version = "0.3.0-pre.1"
+source = "git+https://github.com/tracel-ai/cubek?rev=9372f94bfa8f66c6843bb9c37bd30c6fbcdb45cf#9372f94bfa8f66c6843bb9c37bd30c6fbcdb45cf"
 dependencies = [
  "cubecl",
  "cubek-std",
@@ -2406,9 +2368,8 @@ dependencies = [
 
 [[package]]
 name = "cubek-std"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a587d0a44b6f14f4c3711ac10717179b48adb59203b2b2bffe334876bf713187"
+version = "0.3.0-pre.1"
+source = "git+https://github.com/tracel-ai/cubek?rev=9372f94bfa8f66c6843bb9c37bd30c6fbcdb45cf#9372f94bfa8f66c6843bb9c37bd30c6fbcdb45cf"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -4244,7 +4205,7 @@ dependencies = [
 
 [[package]]
 name = "image-classification-web"
-version = "0.21.0"
+version = "0.22.0-pre.1"
 dependencies = [
  "burn",
  "burn-onnx",
@@ -4732,9 +4693,9 @@ dependencies = [
 
 [[package]]
 name = "macerator"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da28a09eacf3db6bff7314ed22c3304520fdbc8755630543378c4f92a592b049"
+checksum = "508a2f720538bb7e3ea3cb6d098615b107cb82ae387d77d906276905e9ec894b"
 dependencies = [
  "bytemuck",
  "cfg_aliases",
@@ -5298,7 +5259,7 @@ dependencies = [
 
 [[package]]
 name = "onnx-inference"
-version = "0.21.0"
+version = "0.22.0-pre.1"
 dependencies = [
  "burn",
  "burn-onnx",
@@ -5308,7 +5269,7 @@ dependencies = [
 
 [[package]]
 name = "onnx-ir"
-version = "0.21.0"
+version = "0.22.0-pre.1"
 dependencies = [
  "burn-tensor",
  "bytemuck",
@@ -5330,7 +5291,7 @@ dependencies = [
 
 [[package]]
 name = "onnx-ir-derive"
-version = "0.21.0"
+version = "0.22.0-pre.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5339,7 +5300,7 @@ dependencies = [
 
 [[package]]
 name = "onnx-official-tests"
-version = "0.21.0"
+version = "0.22.0-pre.1"
 dependencies = [
  "burn",
  "burn-onnx",
@@ -5355,7 +5316,7 @@ dependencies = [
 
 [[package]]
 name = "onnx-tests"
-version = "0.21.0"
+version = "0.22.0-pre.1"
 dependencies = [
  "burn",
  "burn-onnx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ exclude = [
 edition = "2024"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
-version = "0.21.0"
+version = "0.22.0-pre.1"
 
 [workspace.lints.clippy]
 
@@ -49,10 +49,10 @@ invalid_html_tags = "deny"
 # (Cargo forbids consumers from overriding default-features when inheriting via
 # `workspace = true`); consumers that previously had defaults ON now opt in via
 # `features = ["default"]`.
-burn-import = { path = "crates/burn-import", version = "0.21.0", default-features = false }
-burn-onnx = { path = "crates/burn-onnx", version = "0.21.0", default-features = false }
-onnx-ir = { path = "crates/onnx-ir", version = "0.21.0", default-features = false }
-onnx-ir-derive = { path = "crates/onnx-ir-derive", version = "0.21.0" }
+burn-import = { path = "crates/burn-import", version = "=0.22.0-pre.1", default-features = false }
+burn-onnx = { path = "crates/burn-onnx", version = "=0.22.0-pre.1", default-features = false }
+onnx-ir = { path = "crates/onnx-ir", version = "=0.22.0-pre.1", default-features = false }
+onnx-ir-derive = { path = "crates/onnx-ir-derive", version = "=0.22.0-pre.1" }
 model-checks-common = { path = "crates/model-checks/common" }
 
 bytemuck = "1.25.0"
@@ -102,10 +102,10 @@ burn-tensor = { git = "https://github.com/tracel-ai/burn", default-features = fa
 # burn-tensor = { path = "../burn/crates/burn-tensor", default-features = false }
 
 ### For the release. ###
-# burn = { version = "0.21.0", default-features = false }
-# burn-flex = { version = "0.21.0", default-features = false }
-# burn-store = { version = "0.21.0", default-features = false }
-# burn-tensor = { version = "0.21.0", default-features = false }
+# burn = { version = "0.22.0-pre.1", default-features = false }
+# burn-flex = { version = "0.22.0-pre.1", default-features = false }
+# burn-store = { version = "0.22.0-pre.1", default-features = false }
+# burn-tensor = { version = "0.22.0-pre.1", default-features = false }
 
 ### For xtask crate ###
 tracel-xtask = "=4.17.2"


### PR DESCRIPTION
## Summary
- Bump workspace and internal crates (`burn-import`, `burn-onnx`, `onnx-ir`, `onnx-ir-derive`) to `0.22.0-pre.1`, restoring the exact-version pin (`=0.22.0-pre.1`) on internal path deps used for pre-release lines.
- Update the commented "For the release" `burn` / `burn-flex` / `burn-store` / `burn-tensor` placeholders to `0.22.0-pre.1` so the next release swap only needs a comment toggle. Active dev deps still point at the burn git rev from #400.

## Test plan
- [x] `cargo check` clean on default-members
- [x] `Cargo.lock` regenerated with all four internal crates at `0.22.0-pre.1`