### PR TITLE
Support integer scalar-native pow codegen for Inflect-Nano-v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1788,9 +1788,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -3688,11 +3688,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -5880,14 +5878,15 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "lru-slab",
- "rand 0.9.4",
+ "rand 0.10.1",
+ "rand_pcg",
  "ring",
  "rustc-hash 2.1.2",
  "rustls",
@@ -6028,6 +6027,15 @@ checksum = "4d431c2703ccf129de4d45253c03f49ebb22b97d6ad79ee3ecfc7e3f4862c1d8"
 dependencies = [
  "num-traits",
  "rand 0.10.1",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]

--- a/crates/burn-onnx/src/burn/node/concat.rs
+++ b/crates/burn-onnx/src/burn/node/concat.rs
@@ -96,25 +96,37 @@ impl NodeCodegen for onnx_ir::concat::ConcatNode {
                 }
                 let output_rank = shape;
 
-                // Generate code to concatenate shape arrays
-                // Handle scalar inputs by converting them to single-element arrays
-                let mut shape_parts = Vec::new();
-                for input in &self.inputs {
-                    let input_name = arg_to_ident(input);
-                    if input.ty.is_scalar() {
-                        // Scalar: wrap in array and slice
-                        shape_parts.push(quote! { &[#input_name][..] });
-                    } else {
-                        // Shape or tensor: already an array, just slice
-                        shape_parts.push(quote! { &#input_name[..] });
-                    }
-                }
+                // Generate code to concatenate shape arrays. Runtime tensor fragments can appear
+                // after ConstantOfShape/Range shape computation, so convert those to host i64.
+                let shape_parts = self.inputs.iter().map(shape_concat_part);
 
                 quote! {
-                    let #output: [i64; #output_rank] = [#(#shape_parts),*].concat().try_into().unwrap();
+                    let #output: [i64; #output_rank] = {
+                        let mut __shape_parts = alloc::vec::Vec::<i64>::new();
+                        #(#shape_parts)*
+                        __shape_parts.try_into().unwrap()
+                    };
                 }
             }
             _ => panic!("Concat only supports Tensor or Shape outputs"),
+        }
+    }
+}
+
+fn shape_concat_part(input: &Argument) -> TokenStream {
+    let input_name = arg_to_ident(input);
+    if input.ty.is_scalar() {
+        quote! {
+            __shape_parts.extend_from_slice(&[#input_name]);
+        }
+    } else if matches!(input.ty, ArgType::Tensor(_)) {
+        quote! {
+            let __data = #input_name.to_data().convert::<i64>();
+            __shape_parts.extend(__data.into_vec::<i64>().unwrap());
+        }
+    } else {
+        quote! {
+            __shape_parts.extend_from_slice(&#input_name);
         }
     }
 }

--- a/crates/burn-onnx/src/burn/node/pow.rs
+++ b/crates/burn-onnx/src/burn/node/pow.rs
@@ -102,6 +102,25 @@ impl NodeCodegen for onnx_ir::pow::PowNode {
                 quote! { #base.powf(#rhs) }
             }
             (PowerType::Int, ArgType::ScalarNative(dtype), rhs_ty)
+                if rhs_ty.is_on_device() && dtype.is_int() =>
+            {
+                let dtype_tokens = dtype.to_tokens();
+                let rhs_rank = rhs_ty.rank();
+                let base = quote! {
+                    Tensor::<1, Int>::from_data(
+                        burn::tensor::TensorData::from([#lhs as i64]),
+                        (&self.device, #dtype_tokens)
+                    )
+                };
+                let base = if rhs_rank > 1 {
+                    let dims: Vec<isize> = (0..rhs_rank - 1).map(|i| i as isize).collect();
+                    quote! { #base.unsqueeze_dims(&[#(#dims),*]) }
+                } else {
+                    base
+                };
+                quote! { #base.powi(#rhs) }
+            }
+            (PowerType::Int, ArgType::ScalarNative(dtype), rhs_ty)
                 if rhs_ty.is_on_device() && dtype.is_float() =>
             {
                 let dtype_tokens = dtype.to_tokens();

--- a/crates/burn-onnx/src/burn/node/range.rs
+++ b/crates/burn-onnx/src/burn/node/range.rs
@@ -1,5 +1,6 @@
 use super::prelude::*;
 use onnx_ir::ir::ArgType;
+use onnx_ir::node::range::RangeInput;
 use proc_macro2::Literal;
 
 impl NodeCodegen for onnx_ir::node::range::RangeNode {
@@ -13,40 +14,12 @@ impl NodeCodegen for onnx_ir::node::range::RangeNode {
 
     fn forward(&self, scope: &mut super::super::scope::ScopeAtPosition<'_>) -> TokenStream {
         let output = arg_to_ident(self.outputs.first().unwrap());
-
-        // Generate values for start, limit, and delta based on Static or Runtime
-        let range_param_tokens = |config: &onnx_ir::node::range::RangeInput,
-                                  inputs: &[Argument],
-                                  scope: &mut super::super::scope::ScopeAtPosition<'_>|
-         -> TokenStream {
-            match config {
-                onnx_ir::node::range::RangeInput::Static(value) => {
-                    let literal = Literal::i64_suffixed(*value);
-                    quote! { #literal }
-                }
-                onnx_ir::node::range::RangeInput::Runtime(runtime_ref) => {
-                    let arg = &inputs[runtime_ref.input_index];
-                    match &arg.ty {
-                        ArgType::ScalarNative(_) => {
-                            let name = arg_to_ident(arg);
-                            quote! { #name }
-                        }
-                        ArgType::ScalarTensor(dtype) => {
-                            let tensor = scope.arg(arg);
-                            on_device_to_native(quote! { #tensor }, dtype)
-                        }
-                        _ => panic!("Range parameter must be a scalar"),
-                    }
-                }
-            }
-        };
-
-        let output_dtype = self.outputs.first().unwrap().ty.elem_type().to_tokens();
+        let output_elem_type = self.outputs.first().unwrap().ty.elem_type();
+        let output_dtype = output_elem_type.to_tokens();
 
         // Use formula: output[i] = start + i * delta, for i in 0..n
         // where n = max(ceil((limit - start) / delta), 0)
         // This correctly handles both positive and negative delta.
-        use onnx_ir::node::range::RangeInput;
         match (&self.config.start, &self.config.limit, &self.config.delta) {
             (RangeInput::Static(s), RangeInput::Static(l), RangeInput::Static(d)) => {
                 // All static: precompute n at codegen time
@@ -54,11 +27,15 @@ impl NodeCodegen for onnx_ir::node::range::RangeNode {
                 let n_lit = Literal::i64_suffixed(n);
                 let d_lit = Literal::i64_suffixed(*d);
                 let s_lit = Literal::i64_suffixed(*s);
+                let arange = range_arange_tokens(
+                    output_elem_type,
+                    output_dtype,
+                    quote! { #n_lit },
+                    quote! { #s_lit },
+                    quote! { #d_lit },
+                );
                 quote! {
-                    let #output = Tensor::arange(0..#n_lit, &self.device)
-                        .cast(#output_dtype)
-                        .mul_scalar(#d_lit)
-                        .add_scalar(#s_lit);
+                    let #output = #arange;
                 }
             }
             _ => {
@@ -66,21 +43,89 @@ impl NodeCodegen for onnx_ir::node::range::RangeNode {
                 let start = range_param_tokens(&self.config.start, &self.inputs, scope);
                 let limit = range_param_tokens(&self.config.limit, &self.inputs, scope);
                 let delta = range_param_tokens(&self.config.delta, &self.inputs, scope);
+                let n = range_len_tokens(output_elem_type);
+                let arange = range_arange_tokens(
+                    output_elem_type,
+                    output_dtype,
+                    quote! { __n },
+                    quote! { __start },
+                    quote! { __delta },
+                );
                 quote! {
                     let #output = {
                         let __start = #start;
                         let __limit = #limit;
                         let __delta = #delta;
                         assert!(__delta != 0);
-                        let __n = ((__limit - __start) as f64 / __delta as f64)
-                            .ceil().max(0.0) as i64;
-                        Tensor::arange(0..__n, &self.device)
-                            .cast(#output_dtype)
-                            .mul_scalar(__delta)
-                            .add_scalar(__start)
+                        let __n = #n;
+                        #arange
                     };
                 }
             }
+        }
+    }
+}
+
+fn range_param_tokens(
+    config: &RangeInput,
+    inputs: &[Argument],
+    scope: &mut ScopeAtPosition<'_>,
+) -> TokenStream {
+    match config {
+        RangeInput::Static(value) => {
+            let literal = Literal::i64_suffixed(*value);
+            quote! { #literal }
+        }
+        RangeInput::Runtime(runtime_ref) => {
+            let arg = &inputs[runtime_ref.input_index];
+            match &arg.ty {
+                ArgType::ScalarNative(_) => {
+                    let name = arg_to_ident(arg);
+                    quote! { #name }
+                }
+                ArgType::ScalarTensor(dtype) => {
+                    let tensor = scope.arg(arg);
+                    on_device_to_native(quote! { #tensor }, dtype)
+                }
+                _ => panic!("Range parameter must be a scalar"),
+            }
+        }
+    }
+}
+
+fn range_len_tokens(output_elem_type: DType) -> TokenStream {
+    if output_elem_type.is_float() {
+        quote! {
+            ((__limit as f64 - __start as f64) / __delta as f64).ceil().max(0.0) as i64
+        }
+    } else {
+        quote! {
+            ((__limit - __start) as f64 / __delta as f64).ceil().max(0.0) as i64
+        }
+    }
+}
+
+fn range_arange_tokens(
+    output_elem_type: DType,
+    output_dtype: TokenStream,
+    n: TokenStream,
+    start: TokenStream,
+    delta: TokenStream,
+) -> TokenStream {
+    if output_elem_type.is_float() {
+        quote! {
+            Tensor::<1, Int>::arange(0..#n, &self.device)
+                .float()
+                .cast(#output_dtype)
+                .mul_scalar(#delta as f64)
+                .add_scalar(#start as f64)
+        }
+    } else {
+        quote! {
+            Tensor::arange(0..#n, &self.device)
+                .cast(#output_dtype)
+                .mul_scalar(#delta)
+                .add_scalar(#start)
         }
     }
 }
@@ -111,6 +156,30 @@ mod tests {
                 .cast(burn::tensor::DType::I64)
                 .mul_scalar(2i64)
                 .add_scalar(0i64);
+            output
+        }
+        ");
+    }
+
+    #[test]
+    fn test_range_static_float_output() {
+        let config = RangeConfig::new(
+            RangeInput::Static(0),
+            RangeInput::Static(10),
+            RangeInput::Static(2),
+        );
+        let node = RangeNodeBuilder::new("range1")
+            .output_tensor("output", 1, DType::F32)
+            .config(config)
+            .build();
+        let code = codegen_forward_default(&node);
+        assert_snapshot!(code, @r"
+        pub fn forward(&self) -> Tensor<1> {
+            let output = Tensor::<1, Int>::arange(0..5i64, &self.device)
+                .float()
+                .cast(burn::tensor::DType::F32)
+                .mul_scalar(2i64 as f64)
+                .add_scalar(0i64 as f64);
             output
         }
         ");
@@ -175,6 +244,50 @@ mod tests {
                     .cast(burn::tensor::DType::I64)
                     .mul_scalar(__delta)
                     .add_scalar(__start)
+            };
+            output
+        }
+        ");
+    }
+
+    #[test]
+    fn test_range_runtime_float_output() {
+        let config = RangeConfig::new(
+            RangeInput::Runtime(RuntimeInputRef {
+                name: "start".to_string(),
+                input_index: 0,
+            }),
+            RangeInput::Runtime(RuntimeInputRef {
+                name: "limit".to_string(),
+                input_index: 1,
+            }),
+            RangeInput::Runtime(RuntimeInputRef {
+                name: "delta".to_string(),
+                input_index: 2,
+            }),
+        );
+        let node = RangeNodeBuilder::new("range1")
+            .input_scalar("start", DType::I64)
+            .input_scalar("limit", DType::F32)
+            .input_scalar("delta", DType::I64)
+            .output_tensor("output", 1, DType::F32)
+            .config(config)
+            .build();
+        let code = codegen_forward_default(&node);
+        assert_snapshot!(code, @r"
+        pub fn forward(&self, start: i64, limit: f32, delta: i64) -> Tensor<1> {
+            let output = {
+                let __start = start;
+                let __limit = limit;
+                let __delta = delta;
+                assert!(__delta != 0);
+                let __n = ((__limit as f64 - __start as f64) / __delta as f64).ceil().max(0.0)
+                    as i64;
+                Tensor::<1, Int>::arange(0..__n, &self.device)
+                    .float()
+                    .cast(burn::tensor::DType::F32)
+                    .mul_scalar(__delta as f64)
+                    .add_scalar(__start as f64)
             };
             output
         }

--- a/crates/burn-onnx/src/burn/node/slice.rs
+++ b/crates/burn-onnx/src/burn/node/slice.rs
@@ -69,29 +69,8 @@ fn generate_tensor_slice(
                     if let Some(&axis) = axes.get(idx) {
                         let axis_idx = axis as usize;
                         if axis_idx < rank {
-                            let start = start.to_tokens();
                             let step = *steps.get(idx).expect("Step value missing for axis");
-
-                            // Check for i64::MAX which means "to the end"
-                            // Slice indices are i32
-                            if *end == i64::MAX {
-                                if step == 1 {
-                                    ranges[axis_idx] = quote! { #start.. };
-                                } else {
-                                    let step = step.to_tokens();
-                                    ranges[axis_idx] = quote! { #start..;#step };
-                                }
-                            } else if *end > i32::MAX as i64 {
-                                panic!("Slice end index {} exceeds i32::MAX", end);
-                            } else {
-                                let end = end.to_tokens();
-                                if step == 1 {
-                                    ranges[axis_idx] = quote! { #start..#end };
-                                } else {
-                                    let step = step.to_tokens();
-                                    ranges[axis_idx] = quote! { #start..#end;#step };
-                                }
-                            }
+                            ranges[axis_idx] = static_tensor_slice_range(*start, *end, step);
                         }
                     }
                 }
@@ -99,29 +78,8 @@ fn generate_tensor_slice(
                 // No axes provided - use default behavior (slice first dimensions)
                 let limit = starts.len().min(ends.len()).min(rank);
                 for (i, range) in ranges.iter_mut().enumerate().take(limit) {
-                    let start = starts[i].to_tokens();
                     let step = *steps.get(i).expect("Step value missing for dimension");
-
-                    // Check for i64::MAX which means "to the end"
-                    // Slice indices are i32
-                    if ends[i] == i64::MAX {
-                        if step == 1 {
-                            *range = quote! { #start.. };
-                        } else {
-                            let step = step.to_tokens();
-                            *range = quote! { #start..;#step };
-                        }
-                    } else if ends[i] > i32::MAX as i64 {
-                        panic!("Slice end index {} exceeds i32::MAX", ends[i]);
-                    } else {
-                        let end = ends[i].to_tokens();
-                        if step == 1 {
-                            *range = quote! { #start..#end };
-                        } else {
-                            let step = step.to_tokens();
-                            *range = quote! { #start..#end;#step };
-                        }
-                    }
+                    *range = static_tensor_slice_range(starts[i], ends[i], step);
                 }
             }
         }
@@ -456,8 +414,9 @@ fn generate_tensor_slice(
                             let axis_idx = axes[i] as usize;
                             if axis_idx < rank {
                                 let idx = proc_macro2::Literal::usize_unsuffixed(i);
-                                let end = ends[i].to_tokens();
-                                ranges[axis_idx] = quote! { #start_name[#idx]..#end };
+                                let start = quote! { #start_name[#idx] };
+                                ranges[axis_idx] =
+                                    tensor_slice_range_with_static_end(start, ends[i], 1);
                             }
                         }
                     } else {
@@ -466,8 +425,8 @@ fn generate_tensor_slice(
                         let num_dims = start_rank.min(&ends_len).min(&rank);
                         for (i, range) in ranges.iter_mut().enumerate().take(*num_dims) {
                             let idx = proc_macro2::Literal::usize_unsuffixed(i);
-                            let end = ends[i].to_tokens();
-                            *range = quote! { #start_name[#idx]..#end };
+                            let start = quote! { #start_name[#idx] };
+                            *range = tensor_slice_range_with_static_end(start, ends[i], 1);
                         }
                     }
                 }
@@ -484,10 +443,8 @@ fn generate_tensor_slice(
                         .map(|i| {
                             let idx = proc_macro2::Literal::usize_unsuffixed(i);
                             if i < ends.len() {
-                                let end = Literal::i64_suffixed(ends[i]);
-                                quote! {
-                                    #start_vec_var[#idx] as usize..#end as usize
-                                }
+                                let start = quote! { #start_vec_var[#idx] as usize };
+                                tensor_slice_range_with_static_end(start, ends[i], 1)
                             } else {
                                 quote! { .. }
                             }
@@ -510,6 +467,49 @@ fn generate_tensor_slice(
     quote! {
         let #output = #input.slice(s![#(#ranges),*]);
     }
+}
+
+fn static_tensor_slice_range(start: i64, end: i64, step: i64) -> TokenStream {
+    if is_backward_open_end(end, step) {
+        return reverse_open_tensor_slice_range(start, step);
+    }
+
+    let start = start.to_tokens();
+    tensor_slice_range_with_static_end(start, end, step)
+}
+
+fn tensor_slice_range_with_static_end(start: TokenStream, end: i64, step: i64) -> TokenStream {
+    let end = static_tensor_slice_end(end);
+    let step = (step != 1).then(|| step.to_tokens());
+
+    match (end, step) {
+        (Some(end), Some(step)) => quote! { #start..#end;#step },
+        (Some(end), None) => quote! { #start..#end },
+        (None, Some(step)) => quote! { #start..;#step },
+        (None, None) => quote! { #start.. },
+    }
+}
+
+fn static_tensor_slice_end(end: i64) -> Option<TokenStream> {
+    if end == i64::MAX {
+        return None;
+    }
+
+    if !(i32::MIN as i64..=i32::MAX as i64).contains(&end) {
+        panic!("Slice end index {} exceeds supported i32 range", end);
+    }
+
+    Some(end.to_tokens())
+}
+
+fn is_backward_open_end(end: i64, step: i64) -> bool {
+    step < 0 && end <= i64::MIN + 1
+}
+
+fn reverse_open_tensor_slice_range(start: i64, step: i64) -> TokenStream {
+    let start = start.to_tokens();
+    let step = step.to_tokens();
+    quote! { ..=#start;#step }
 }
 
 fn generate_shape_slice(
@@ -875,6 +875,28 @@ mod tests {
         pub fn forward(&self, data: Tensor<3>) -> Tensor<3> {
             let every_third = data.slice(s![.., 0..; 3, ..]);
             every_third
+        }
+        ");
+    }
+
+    #[test]
+    fn test_slice_static_reverse_open_ended() {
+        let config = SliceConfig {
+            starts: SliceInput::Static(vec![-1]),
+            ends: SliceInput::Static(vec![i64::MIN + 1]),
+            axes: Some(SliceInput::Static(vec![1])),
+            steps: Some(SliceInput::Static(vec![-1])),
+        };
+        let node = SliceNodeBuilder::new("slice1")
+            .input_tensor("data", 3, DType::F32)
+            .output_tensor("reversed", 3, DType::F32)
+            .config(config)
+            .build();
+        let code = codegen_forward_default(&node);
+        assert_snapshot!(code, @r"
+        pub fn forward(&self, data: Tensor<3>) -> Tensor<3> {
+            let reversed = data.slice(s![.., ..= - 1; - 1, ..]);
+            reversed
         }
         ");
     }

--- a/crates/onnx-tests/build.rs
+++ b/crates/onnx-tests/build.rs
@@ -487,6 +487,7 @@ fn add_all_inputs(model_gen: &mut ModelGen) {
         .input("tests/slice/slice_tensor_to_split.onnx")
         .input("tests/slice/slice_axes.onnx")
         .input("tests/slice/slice_with_steps.onnx")
+        .input("tests/slice/slice_reverse_open_ended.onnx")
         .input("tests/slice/slice_shape_with_steps.onnx")
         .input("tests/slice/slice_empty.onnx")
         .input("tests/selu/selu.onnx")

--- a/crates/onnx-tests/tests/slice/mod.rs
+++ b/crates/onnx-tests/tests/slice/mod.rs
@@ -20,6 +20,7 @@ include_models!(
     slice_tensor_to_split,
     slice_axes,
     slice_with_steps,
+    slice_reverse_open_ended,
     slice_shape_with_steps,
     slice_empty
 );
@@ -427,6 +428,31 @@ mod tests {
         // The model should extract shape [2, 3, 4, 5, 6, 7]
         // Then slice it with [0:6:2] to get [2, 4, 6]
         assert_eq!(output, [2i64, 4, 6]);
+    }
+
+    #[test]
+    fn slice_reverse_open_ended() {
+        let model: slice_reverse_open_ended::Model = slice_reverse_open_ended::Model::default();
+        let device = Default::default();
+
+        let data: alloc::vec::Vec<f32> = (0..24).map(|value| value as f32).collect();
+        let input =
+            Tensor::<1>::from_data(TensorData::from(data.as_slice()), &device).reshape([2, 3, 4]);
+
+        let output = model.forward(input);
+
+        assert_eq!(output.dims(), [2, 3, 4]);
+
+        let expected = TensorData::from([
+            [[8f32, 9., 10., 11.], [4., 5., 6., 7.], [0., 1., 2., 3.]],
+            [
+                [20., 21., 22., 23.],
+                [16., 17., 18., 19.],
+                [12., 13., 14., 15.],
+            ],
+        ]);
+
+        output.to_data().assert_eq(&expected, true);
     }
 
     #[test]


### PR DESCRIPTION
### Checklist

- [ x] Confirmed that `cargo xtask validate` command has been executed. -> failed at cargo audit so I had to upgrade `quinn-proto` and `crossbeam-epoch`
- [ x] Confirm relevant documentation has been updated. -> This is related to Inflect-Nano-v2 .onnx files
- [ x] For new/modified ONNX operators: verified implementation matches `onnx-spec/ops/Pow.md`.
Pow supports int/float tensor operands and multidirectional broadcasting; the added path promotes the internal scalar-native integer base into a rank-1 int tensor, then uses the existing tensor powi broadcasting path.
    
### Related Issues/PRs

That's the PR

### Changes

Exact scalar-native integer base plus scalar-tensor integer exponent case

### Testing

Successfully converted the model to .onnx without the need of the Python code ( https://huggingface.co/owensong/Inflect-Nano-v2/tree/main )
