### PR TITLE
Fix output file name mangling

### DIFF
--- a/crates/burn-onnx/src/model_gen.rs
+++ b/crates/burn-onnx/src/model_gen.rs
@@ -354,7 +354,7 @@ impl ModelGen {
         create_dir_all(&out_dir).unwrap();
 
         for input in self.inputs.iter() {
-            let file_name = input.file_stem().unwrap();
+            let file_name = input.file_name().unwrap();
             let out_file: PathBuf = out_dir.join(file_name);
 
             log::info!("Converting {input:?}");


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `cargo xtask validate` command has been executed.
- [ ] Confirm relevant documentation has been updated.
- [ ] For new/modified ONNX operators: verified implementation matches `onnx-spec/ops/<OpName>.md`.

### Changes

With an input file name such as "silero_vad_v6.2_op18_ifless.onnx" the generator produces output files of the shape:
- silero_vad_v6.bpk
- silero_vad_v6.onnx.txt
- silero_vad_v6.rs

This name clearly is not what the user intended. The behavior is rooted in Rust's PathBuf::with_extension() semantics, which identifies ".2_op18_ifless" as the extension (and replaces it) after "silero_vad_v6.2_op18_ifless" was inferred as the file stem.

Fix the problem by using using Path::file_name() instead of Path::file_stem(), as it's also incorrect to call the file stem the input file name (it doesn't even exist):
  > DEBUG burn_onnx::model_gen: Input file name: "silero_vad_v6.2_op18_ifless"

### Testing

Ran the conversion program.
