### PR TITLE
Expand: reject a rank-0 shape input instead of panicking in codegen

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -5,10 +5,10 @@ Prioritized work queue derived from a measured sweep of the open issues and the
 entry in `crates/onnx-official-tests/expectations.toml` through `onnx2burn`, then compile-checking
 the output against `burn 0.22.0-pre.1` with the `flex` backend.
 
-The `Size` codegen fix and the scoreboard re-triage that produced this baseline landed in #457, and
-the domain-aware unsupported-op error (#433) turned out to be already fixed on `main`. Counts below
-are the current state of `expectations.toml`, including the Upsample promotion (item 1), the
-runtime-`axes` reduce fix (item 2) and the RNN-family runtime weights fix (item 6).
+Three items have shipped since that sweep (#461, #464, #466); "Landed" at the bottom says what each
+one did, and `git log -- TODO.md` has the write-ups they replaced. Findings from those items that
+describe work still open were carried into Tier 2. Counts below are the current state of
+`expectations.toml` and already include all three.
 
 ## Scoreboard baseline
 
@@ -50,182 +50,25 @@ them into the total.
 `test_castlike_*` rows converting to FLOAT8/INT4 variants. Extending the harness to cover them is
 separate work; the honest reading of 932 is "932 compile, 830 match".
 
-Item 2 turned four of those unfalsifiable rows into real tests and immediately found a bug in two
-of them, which is the concrete cost of the category: `test_reduce_log_sum_exp_do_not_keepdims_*`
-were marked `pass` while producing a rank-0 output the harness declines to drive. Correcting the
-inferred rank gave them a driver, and the driver failed.
+#464 turned four of those unfalsifiable rows into real tests and immediately found a bug in two of
+them, which is the concrete cost of the category: `test_reduce_log_sum_exp_do_not_keepdims_*` were
+marked `pass` while producing a rank-0 output the harness declines to drive. Correcting the inferred
+rank gave them a driver, and the driver failed.
 
 ## Tier 1
 
-### 1. Upsample (#415)
-
-A user is blocked importing a public model (`fastdepth_7.onnx`). Upsample is deprecated but common
-in older exports, and is a strict subset of Resize (opset 7: `scales` attribute; opset 9: `scales`
-input; modes nearest/linear).
-
-**Status: done.** ONNX deprecated Upsample *into* Resize: Resize opset 10 is Upsample with the
-coordinate mapping (`asymmetric`) and nearest rounding (`floor`) spelled out as attributes. So
-`node/upsample.rs` extracts Upsample's own attributes across all three shapes it has had -
-`height_scale`/`width_scale` (opset 1), the `scales` float-list attribute (opset 7), the `scales`
-input (opset 9+, static or runtime) - and builds a `ResizeNode` with those two modes pinned. The
-enum entry is `Upsample => resize::ResizeNode` and burn-onnx just lists `Upsample` in its dispatch
-macro, so there is no second copy of the interpolate codegen. Node naming still comes from the
-`RawNode`, so generated code reads `self.upsample1`, not `resize1`.
-
-Beyond what Resize does today, the processor computes the output static shape as
-`floor(dim * scale)` rather than copying the input's, rejects scaling the batch or channel
-dimension instead of silently dropping those scales, and rejects ranks Burn's interpolate cannot
-serve (anything but 3 and 4, or anything but 4 when the scales are a runtime input) rather than
-emitting code that references a field that was never created.
-
-A multi-agent review caught a wrong claim in the first draft of this work, which said nearest mode
-was exact and only linear diverged. Both halves were wrong, and the corrected behavior is the more
-interesting part of the change:
-
-- **`mode="linear"` is refused**, not warned about. Burn's bilinear samples at half-pixel
-  coordinates (ONNX's `half_pixel`); Upsample mandates `asymmetric`. Every interior sample differs
-  at every scale other than 1, so this is "always wrong", not "may differ". A `log::warn!` was also
-  the wrong channel: cargo swallows build-script stdout unless the line is `cargo:warning=`
-  prefixed, so the primary `build.rs` path showed the user nothing at all.
-- **Nearest is refused when a scale does not divide its dimension evenly.** ONNX picks a source
-  element by scale, `floor(o / scale)`; Burn's kernel picks it by output size,
-  `floor(o * in / out)` with `out = floor(in * scale)`. Those agree only when `in * scale` is
-  whole. Verified end to end: `scale=1.75` on width 5 gives Burn `[0,0,1,1,2,3,3,4]` against
-  onnxruntime's `[0,0,1,1,2,2,3,4]`. Where the product is provable the model is rejected with the
-  dimension, the scale and the reason; where it is not (runtime scales, dynamic dims) it warns.
-  Integer scales, which is what fastdepth and most real exports use, are unaffected.
-
-Every test in the first draft used an integer scale, which is exactly the case where the two
-formulas coincide, so the suite could not have caught this. `ReferenceEvaluator` cannot either: its
-Upsample is `np.repeat` and raises on non-integer scales, making onnxruntime the only usable oracle.
-
-Two smaller review fixes: opset 1 spells linear mode `bilinear` (the rename came at opset 7), which
-was being rejected as an unknown mode rather than for the real reason; and spatial scales are now
-checked against the spec's "greater than or equal to 1", since a scale below 1 or a NaN reaches
-`as usize` in generated code and saturates to a zero-size dimension.
-
-Scoreboard: `test_upsample_nearest` moved from `skip-codegen` to `pass`. Opset compliance grew from
-472 to 476 op-version combinations (Upsample at opsets 1, 7, 9, 10).
-
-## Tier 2
-
-### 2. Reduce family comparison failures (99 tests)
-
-**Status: done (#459).** 96 of the 99 rows shared one root cause, and it was the one #459 named. Opset 18
-moved `axes` from an attribute to an input; when that input is a graph input rather than a constant
-its value is unknown at build time, and `ReduceConfig::dims` was a plain `Vec<usize>` that recorded
-that case as an empty vector — the same value ONNX uses for "no axes given, reduce everything".
-Codegen then emitted `.sum()` / `.mean()` with no dimension argument and dropped the axes input on
-the floor. Every one of those models supplies `axes` this way; none of them was a keepdims or
-broadcasting bug. The other 3 are a separate bug, described at the end of this item.
-
-The fix is to make the three meanings of "empty axes" distinguishable, which they are not in a
-`Vec`:
-
-| ONNX                                  | `ReduceConfig::axes`  | Behavior                |
-| ------------------------------------- | --------------------- | ----------------------- |
-| `axes` absent, or an empty list       | `Static(vec![])`      | reduce every axis       |
-| empty list with `noop_with_empty_axes`| `Static(vec![])`      | skip the reduction      |
-| `axes` supplied at run time           | `Runtime(input_ref)`  | reduce what it names    |
-
-`ReduceConfig` now carries `axes: ReduceAxes`, the `Static(..) | Runtime(RuntimeInputRef)` enum that
-22 other node files already use, plus the `noop_with_empty_axes` attribute it was previously
-discarding. "Skip the reduction" is not quite "identity": the spec says other operations still
-happen, so `ReduceSumSquare` still squares and `ReduceL1` still takes an absolute value.
-
-Reducing over axes that are not compile-time constants sounds like it should be impossible against
-Burn's statically-ranked tensors, and it very nearly is — but only the output *rank* has to be
-static, not the axis values. Burn 0.22's `sum_dims`/`mean_dims`/`max_dims`/`min_dims`/`prod_dims`
-and `squeeze_dims::<D2>` all take `&[impl AsIndex]`, a runtime slice, and `AsIndex::try_dim_index`
-wraps negative entries itself, so a runtime axis and a negative axis both come out correct with no
-work in the generated code. The rank comes from two places: with `keepdims=1` it is the input rank,
-and with `keepdims=0` it is `input_rank - len(axes)`, where the *length* is in the axes input's
-static shape even when its values are not. All 99 models declare that length. When they do not
-(a `Range`-computed axes list) and `keepdims` is off, onnx-ir now refuses the model instead of
-guessing.
-
-Generated code for a runtime-axes reduce reads the axes once and hands the slice to Burn:
-
-```rust
-let __axes: alloc::vec::Vec<i64> = axes.into_data().iter::<i64>().collect();
-data.abs().sum_dims(&__axes).squeeze_dims::<2usize>(&__axes)
-```
-
-Two things surfaced while doing it that were not in the original diagnosis:
-
-- **LogSumExp was wrong for `keepdims=0` independently of the axes bug.** It subtracts a running
-  max from the input, so that max has to keep its rank to broadcast back; squeezing it first made
-  `expand(input_shape)` either wrong or a hard `Squeeze` panic. Both intermediate reductions now run
-  with keepdims and the reduced axes are dropped once at the end. This was invisible before because
-  the two affected rows inferred a rank-0 output, which `build.rs` declines to generate a driver for
-  — they were marked `pass` and never ran.
-- **Out-of-range axes were accepted.** `dim as usize` on a negative that did not wrap left a huge
-  index; `extract_config` now returns `ProcessError::InvalidAttribute` naming the axis and the rank.
-
-Scoreboard: 109 rows promoted from `fail-compare` to `pass` — 96 of the 99 reduce rows and all 13
-remaining `rms_normalization_*_expanded` rows, which used `Shape -> Size -> Range` to build their
-axes at run time. Harness tests went from 706 to 819, all green.
-
-A multi-agent review after the fact turned up two more silent-wrong-answer cases in the first
-draft of this work, both now fixed and both worth recording because they are the same shape as the
-bug being fixed:
-
-- **`noop_with_empty_axes` was lowered to a bare identity.** The spec says the reduction is skipped
-  but "other operations will be performed", so `ReduceSumSquare` must still square, `ReduceL1` and
-  `ReduceL2` must still take an absolute value, and `ReduceLogSum` must still take a log. Only the
-  five plain reductions are genuine identities. Modelling this as "reduce over no axes" rather than
-  an early return makes each composite land on the right answer through machinery that already
-  exists - `ReduceL2` becomes `sqrt(square(x))`, `ReduceLogSumExp` becomes `x + log(exp(x - x))`.
-  The reductions that *are* identities now implement `NodeProcessor::is_noop`, so the framework
-  drops those nodes in post-processing instead of codegen emitting a rebinding; the codegen path
-  stays for `simplify(false)`, where only Identity is eliminated.
-- **A runtime axes list that is empty at run time.** Burn's `*_dims` fold over an empty slice is the
-  identity, but ONNX reads empty axes as "every dimension" unless `noop_with_empty_axes` is set.
-  Only reachable when the axes input has no statically known length, which is exactly the case the
-  opset 18 input shape exists for. The generated code now resolves the list where its length is
-  finally known.
-
-Two structural validations were added alongside: an axis count larger than the input rank used to
-underflow `tensor_rank - axis_count` and panic with no node name, and duplicate axes built cleanly
-and then panicked inside Burn's `squeeze_dims`, which deduplicates and so disagreed with the rank
-onnx-ir had declared.
-
-Note for the `build_node` item in Tier 3: Reduce is now the second operator, after Upsample, with
-validation that can first become reachable in `build_node` (an out-of-range axis behind a
-`Constant -> Identity -> Reduce` chain). Its panic at least names the node and formats the error
-with `Display` now, but the underlying hazard is unchanged.
-
-The 3 reduce rows left are `test_reduce_max_empty_set`, `test_reduce_min_empty_set` and
-`test_reduce_log_sum_exp_empty_set`, which are a different bug: reducing over a zero-size dimension,
-where ONNX mandates the identity element (`-inf` for max, `+inf` for min) and Burn's kernels return
-something else. Sum, prod, L1, L2 and LogSum over an empty set all pass, because their identity
-elements are 0 and 1 and Burn agrees. This belongs upstream in burn, not here.
-
-Also fixed in the same pass, since it was blocking clean `retriage` runs: **#460**, non-deterministic
-attribute-validation errors. `Attributes` was a `HashMap`, whose iteration order Rust reseeds per
-process, so a model with two rejected attributes reported whichever one the loop happened to reach
-first. It is now a `BTreeMap`; the type change is one line and the fallout was the 5 construction
-sites the issue predicted plus their test helpers. `test_resize_downsample_sizes_nearest_not_smaller`
-reported `axes` on 8 of 8 runs afterwards, against 1-of-6 before.
-
-### 3. Runtime weight inputs: LayerNorm (#352, 19 tests) + Conv/ConvTranspose (#346, 12 tests)
+### 1. Runtime weight inputs: LayerNorm (#352, 19 tests) + Conv/ConvTranspose (#346, 12 tests)
 
 Both are the same fix: route through the functional API (`burn::tensor::module::conv2d`) instead of
 a baked-in `Param` field. Five ops have now hit this pattern; extract the shared
 `runtime_scalar_to_native(arg, target_dtype, scope)` helper in `argument_helpers.rs` proposed in the
 #314 thread before doing these two.
 
-Unlike the RNN family (item 6), these three do have a functional route: `burn-tensor` exports
+Unlike the RNN family (#466), these three do have a functional route: `burn-tensor` exports
 `conv1d`/`conv2d`/`conv3d`, `conv_transpose*` and `layer_norm` as free functions taking the weights
 as arguments, so no module has to be built per forward call.
 
-### 4. RMSNormalization (19 tests)
-
-Burn has `RmsNorm` natively and ONNX 23 made this a first-class op. High real-world relevance:
-Llama, Qwen and Gemma all use it. The 19 `_expanded` rows this item used to also claim now pass on
-the decomposition alone (item 2); the 19 left are the native op, still `skip-codegen`.
-
-### 5. Remaining compile-error clusters
+### 2. Remaining compile-error clusters (103 rows)
 
 All 103 remaining `skip-compile` rows carry the rustc diagnostic that produced them, so this table
 is a `grep` of `expectations.toml` rather than an estimate. Sorted by blast radius:
@@ -250,124 +93,19 @@ The `half::f16` problem noted during the first sweep is not in this table: gener
 name `half::f16`, but `onnx-official-tests` happens to depend on `half` already. It still bites a
 consuming crate that does not, and is worth fixing independently of these rows.
 
-### 6. GRU/LSTM/RNN discard runtime weights (#458)
+### 3. RMSNormalization (19 tests)
 
-**Status: done.** All three ops accepted models whose `W`/`R` arrive as runtime graph inputs and
-then silently discarded them: each `collect_*_snapshots` returned an empty snapshot list from its
-two `let Some(..) else { return vec![] }` weight guards when the weights were not statically
-available, while `field()` emitted the module regardless. The generated `forward` took the
-weight tensors as parameters and never read them. `Model::from_file` panicked on the missing
-tensors; `Model::new` did not, and ran inference on `GruConfig::init`'s random weights.
+Burn has `RmsNorm` natively and ONNX 23 made this a first-class op. High real-world relevance:
+Llama, Qwen and Gemma all use it. The 19 `_expanded` rows this item used to also claim now pass on
+the decomposition alone (#464); the 19 left are the native op, still `skip-codegen`.
 
-The issue offered two fixes: consume the runtime weights, or reject the model with a clear error.
-The second was the smaller change, but it would have made every RNN test in the upstream suite
-`skip-codegen` - the category that, per "Why skip counts rot" above, nothing ever re-checks. The
-weights are now consumed.
-
-**The functional route this item was expected to share with item 3 does not exist.**
-`burn-tensor/src/tensor/module.rs` exports functional `conv1d`/`conv2d`/`conv3d`,
-`conv_transpose*`, `layer_norm` and `linear`, which is exactly what #346 and #352 need. It exports
-no `gru`, `lstm` or `rnn`. So the earlier guess that doing 6 first would produce the helper 3 needs
-was wrong; these are two different fixes that happen to share a symptom.
-
-What works instead is that Burn's recurrent modules expose their parameters. When the weights are
-runtime, `field()` returns `None` - no struct field, so nothing for the snapshot pipeline to fail to
-fill - and `forward` builds the module locally, then overwrites each gate's `Param` from slices of
-the runtime tensors:
-
-```rust
-let mut gru1 = burn::nn::gru::GruConfig::new(2, 5, false)
-    .with_reset_after(false)
-    .init(&self.device);
-let __w_dir = __w.select_dim::<2>(0, 0);
-gru1.update_gate.input_transform.weight = burn::module::Param::from_tensor(
-    __w_dir.clone().slice_dim(0, 0..5).transpose(),
-);
-```
-
-This is the same slice-and-transpose `collect_*_snapshots` already runs at build time, emitted as
-tokens instead. It is also not a new coupling to Burn's internals: burn-onnx already depended on
-`gru1.update_gate.input_transform.weight`, as a string, in the snapshot paths. Field access trades a
-load-time `Missing tensors` failure for a compile error if Burn ever renames one.
-
-A first draft passed `Initializer::Zeros` here on the theory that the config's Xavier draw was
-wasted work. It is not: `Initializer::init_with` returns `Param::uninitialized`, whose closure runs
-only on the first `val()`, and every parameter is replaced before anything reads one. The config
-allocates no tensor data either way, so the initializer was three lines of emitted code buying
-nothing.
-
-The three ops differ in only three constants, so one table-driven emitter in
-`burn-onnx/src/import/burn/node/rnn_common.rs` covers them. The `GateLayout` const drives each op's
-build-time `collect_*_snapshots` as well, so the gate mapping has one home; its `BiasLayout` drives
-the emitter only, and each collector still hardcodes the matching bias policy by hand:
-
-| Op   | Burn gate order             | ONNX gate index | `B` handling                        |
-| ---- | --------------------------- | --------------- | ----------------------------------- |
-| GRU  | update, reset, new          | `[0, 1, 2]`     | `Wb` and `Rb` on separate `Linear`s |
-| LSTM | input, forget, output, cell | `[0, 2, 1, 3]`  | `Wb + Rb` folded, other zeroed      |
-| RNN  | gate                        | `[0]`           | `Wb + Rb` folded, other zeroed      |
-
-Bidirectional falls out for free: `BiGru`, `BiLstm` and `BiRnn` are `{ forward, reverse }`, which is
-the same `forward.`/`reverse.` prefix pair the snapshot paths already use, so the emitter just
-prefixes the field access.
-
-On the onnx-ir side, `lift_constants` for these three ops is now all-or-nothing across `W`, `R` and
-`B`. Lifting them independently could leave a model where one weight is a lifted `Static` (name
-cleared) and another is a graph input: the runtime path would then have an input it cannot name.
-Refusing to lift any of them when one is dynamic keeps the unlifted constants as named `Constant`
-node outputs, which the runtime path can reference like any other value. The rule is
-`processor::lift_all_or_none(node, indices)`, general rather than RNN-specific, because
-`batch_norm.rs` already open-codes the same reasoning and the next weighted op will want it too.
-
-Two things surfaced that were not in the issue:
-
-- **`layout=1` put the direction axis on the wrong dimension.** ONNX's batch-first layout moves
-  `num_directions` in the *outputs* too: `Y` becomes `[batch, seq, dirs, hidden]` and `Y_h` becomes
-  `[batch, dirs, hidden]`. LSTM and RNN unsqueezed at a fixed dim 1 and 0 regardless of layout, and
-  GRU had `Y` right and `Y_h` wrong. Bidirectional plus `layout=1` needs a `swap_dims(0, 1)` on the
-  final state, which nothing did. This was unreachable before: the only upstream tests with
-  `layout=1` are the three `*_batchwise` rows, and every one of them was already failing for the
-  weights reason. Fixing the weights is what made the shape bug observable - the first pass promoted
-  8 of 11 rows, and the 3 that held out were exactly the batchwise ones.
-- **The snapshot tests were recording the bug.** `Argument::new` defaults to `ValueSource::Dynamic`,
-  so every GRU/LSTM/RNN codegen test built a node whose weights are, semantically, graph inputs. The
-  accepted snapshots showed `pub fn forward(&self, input: Tensor<3>, W: Tensor<3>, R: Tensor<3>, B:
-  Tensor<2>)` with a body that reads `self.gru1` and never touches `W`/`R`/`B` - the defect, frozen
-  as an expectation. The static-path tests now mark their weights as lifted initializers explicitly,
-  and there are new snapshot tests for the runtime path.
-
-Scoreboard: 11 rows promoted from `fail-compare` to `pass` (4 GRU, 3 LSTM, 4 RNN). Harness tests went
-from 819 to 830, all green. Four integration tests were added under `crates/onnx-tests/tests/`: one
-per op going through `from_file`, because the official harness constructs with `Model::new` while
-`#458`'s headline symptom is `from_file` panicking, and those compare against `ReferenceEvaluator`.
-
-The fourth is a bidirectional GRU, which nothing upstream covers and which `ReferenceEvaluator`
-cannot serve either - its GRU raises `NotImplementedError` for `num_directions=2`. It uses the same
-weights as initializers as its own oracle and compares the two models element-wise, which pins the
-one piece of the layout still written twice: flipping GRU's `BiasLayout` to `Merged` fails it, while
-a wrong `GateLayout` does not, because that const drives both paths and moves them together.
-
-Unchanged and still rejected with a clear message: LSTM peephole connections (input `P`) and
-`sequence_lens` on all three.
-
-Two latent bugs were left alone as out of scope, both predating this work and both affecting the
-static path equally:
-
-- `collect_*_snapshots` slices a direction with `.squeeze::<2>()`, which drops *every* size-1
-  dimension, so a GRU with `input_size == 1` or `hidden_size == 1` would squeeze the wrong axis and
-  fail the rank check. The generated runtime path uses `select_dim`/`slice_dim` and is not exposed.
-- Nothing validates a declared `W`/`R` shape against the `hidden_size` and `direction` attributes.
-  An undersized weight panics in Burn's slice check, but an oversized one is silently truncated -
-  a `[2, ...]` W in a `direction="forward"` model quietly uses direction 0 only. This belongs in
-  `infer_types` as a `ProcessError` where the static shape is known.
-
-## Tier 3
+## Tier 2
 
 - **#50 / #51 metal backend.** Dozens of ops fail and YOLO11x diverges by 295 max-abs. Correctness
   on the backend people ship on outweighs op-count wins. Root cause probably belongs upstream in
   burn, but it surfaces here.
-- **Resize shares every gap Upsample just closed (surfaced by the item 1 review).** None of it is
-  new and none of it blocked item 1, but it is all in `crates/burn-onnx/src/import/burn/node/resize.rs`
+- **Resize shares every gap Upsample closed in #461 (surfaced by that review).** None of it is
+  new and none of it blocked #461, but it is all in `crates/burn-onnx/src/import/burn/node/resize.rs`
   and its processor:
   - Accepts `asymmetric` linear and computes half-pixel values (#311 already tracks
     `test_resize_upsample_scales_cubic_asymmetric` as `fail-compare`).
@@ -386,16 +124,17 @@ static path equally:
   after it, so `Constant -> Identity -> Op` reaches `build_node` with a value that was Dynamic
   during `infer_types`. Any validation that first becomes possible there can only panic:
   `NodeProcessor::build_node` returns `Node`, not `Result<Node>`. Every processor in the crate has
-  this shape (`.expect("Config extraction failed")`); Upsample is just the first to have checks
-  that can realistically fire there. Reproduced with a `Constant -> Identity -> Upsample` graph
-  carrying scales of 1.75.
-- **The static-vs-runtime weight decision is stated on both sides of the crate boundary (surfaced by
-  the item 6 review).** `lift_all_or_none`'s liftability test in onnx-ir and `weights_are_runtime` in
-  burn-onnx encode the same invariant with two non-complementary predicates over a four-variant
+  this shape (`.expect("Config extraction failed")`); Upsample and Reduce are the first two with
+  checks that can realistically fire there - an out-of-range axis behind a
+  `Constant -> Identity -> Reduce` chain is the second case. Reproduced with a
+  `Constant -> Identity -> Upsample` graph carrying scales of 1.75.
+- **The static-vs-runtime weight decision is stated on both sides of the crate boundary (surfaced
+  by the #466 review).** `lift_all_or_none`'s liftability test in onnx-ir and `weights_are_runtime`
+  in burn-onnx encode the same invariant with two non-complementary predicates over a four-variant
   `ValueSource`, kept in sync by hand. `BatchNormalizationNode` already shows the deeper answer:
   decide once in `extract_config` and carry it in the IR config (`BatchNormConfig::Static |
   Runtime`), so codegen matches rather than re-derives. Doing the same for GRU/LSTM/RNN churns every
-  positional `Config::new(...)` in their tests, which is why it is not in item 6.
+  positional `Config::new(...)` in their tests, which is why it was left out of #466.
 - **Generated `use` lines are predicted per node.** `BurnImports` emits bare `use` with no
   `#[allow(unused_imports)]`, so LSTM and RNN carry a `needs_module_type` flag purely to avoid
   importing a type the runtime path never names. GRU needs none of it because it uses fully-qualified
@@ -405,6 +144,19 @@ static path equally:
   pre-pass.
 - **#371 Kokoro residual 1.3x.** Established as f32 drift through HiFi-GAN resblocks, not fixable
   here. Close or move to burn.
+- **Empty-set reductions return the wrong identity (3 rows, left over from #464).**
+  `test_reduce_max_empty_set`, `test_reduce_min_empty_set` and `test_reduce_log_sum_exp_empty_set`
+  reduce over a zero-size dimension, where ONNX mandates the identity element (`-inf` for max,
+  `+inf` for min) and Burn's kernels return something else. Sum, prod, L1, L2 and LogSum over an
+  empty set all pass, because their identities are 0 and 1 and Burn agrees. Belongs upstream in burn.
+- **Two latent RNN weight bugs on the static path (out of scope for #466, both predate it).**
+  `collect_*_snapshots` slices a direction with `.squeeze::<2>()`, which drops *every* size-1
+  dimension, so a GRU with `input_size == 1` or `hidden_size == 1` squeezes the wrong axis and fails
+  the rank check; the generated runtime path uses `select_dim`/`slice_dim` and is not exposed. And
+  nothing validates a declared `W`/`R` shape against the `hidden_size` and `direction` attributes:
+  an undersized weight panics in Burn's slice check, an oversized one is silently truncated, so a
+  `[2, ...]` W in a `direction="forward"` model quietly uses direction 0 only. That check belongs in
+  `infer_types` as a `ProcessError` where the static shape is known.
 
 ## Deprioritized
 
@@ -420,14 +172,32 @@ static path equally:
 
 ## Order
 
-Items 1, 2 and 6 are done, and #460 landed alongside item 2. That clears the known
-silent-wrong-answer bugs from the board; what is left is test-count work against an honest baseline.
-
-Item 5's top three rows (34 + 22 + 22 = 78 of the 103 remaining `skip-compile` rows) are probably
-two fixes, which makes that bucket the largest remaining win. Item 3 is the next-largest and the
-better-understood one: Conv/ConvTranspose/LayerNorm all have a functional entry point in
-`burn-tensor` to route through, which is what item 6 turned out not to have. Then 4.
-
-Item 6 did not produce a helper item 3 can reuse — the two share a symptom, not a mechanism — so
-item 3 starts from the `runtime_scalar_to_native` extraction proposed in the #314 thread, not from
+Item 1 first. Conv, ConvTranspose and LayerNorm all have a functional entry point in `burn-tensor`
+to route through, so the mechanism is settled before the work starts, and it is 31 rows across two
+issues. #466 did not produce a helper item 1 can reuse - the two share a symptom, not a mechanism -
+so it starts from the `runtime_scalar_to_native` extraction proposed in the #314 thread, not from
 `node/rnn_common.rs`.
+
+Item 2 is the bigger count (its top three rows are 78 of the 103 remaining `skip-compile` rows, and
+are probably two fixes) but the table there is a set of rustc diagnostics, not a diagnosis. Then 3.
+
+Run `cargo xtask retriage` before trusting any count in this file.
+
+## Landed
+
+Removed from the queue above. `git log -- TODO.md` has the full write-ups.
+
+- **#461 Upsample (#415).** Lowered onto `ResizeNode` with `asymmetric` coordinates and `floor`
+  rounding pinned, so there is no second copy of the interpolate codegen. Refuses linear mode and
+  nearest scales that do not divide their dimension rather than shifting pixels silently. Resize's
+  copy of the same gaps is in Tier 2.
+- **#464 Reduce runtime `axes`, plus #460 non-deterministic attribute errors.** 109 rows promoted
+  from `fail-compare`, harness tests 706 -> 819. `ReduceConfig::axes` is now `Static | Runtime`, so
+  "no axes given", `noop_with_empty_axes` and "axes arrive at run time" stop sharing an empty `Vec`.
+  Only the output rank has to be static: Burn's `*_dims` take a runtime slice. The 3 empty-set rows
+  it could not fix are in Tier 2.
+- **#466 GRU/LSTM/RNN runtime weights (#458).** 11 rows promoted, harness tests 819 -> 830. Burn
+  exports no functional `gru`/`lstm`/`rnn`, so the generated `forward` builds the module and
+  overwrites each gate's `Param` from slices of the runtime tensors, table-driven from one
+  `GateLayout` const per op. Also fixed `layout=1` putting the direction axis on the wrong output
+  dimension. Two latent static-path bugs it left alone are in Tier 2.

--- a/crates/burn-onnx/src/import/burn/node/expand.rs
+++ b/crates/burn-onnx/src/import/burn/node/expand.rs
@@ -34,7 +34,9 @@ impl NodeCodegen for onnx_ir::expand::ExpandNode {
                         let name = arg_to_ident(shape_arg);
                         quote! { #name }
                     }
-                    _ => panic!("Invalid shape source {:?}", shape_arg.ty),
+                    other => {
+                        unreachable!("Expand shape input type validated in onnx-ir, got {other:?}")
+                    }
                 }
             }
         };

--- a/crates/onnx-ir/src/node/expand.rs
+++ b/crates/onnx-ir/src/node/expand.rs
@@ -35,6 +35,11 @@ pub enum ExpandConfig {
     Runtime(RuntimeInputRef),
 }
 
+/// ONNX requires `shape` to be a 1-D tensor. onnx-ir models an ONNX scalar as
+/// `ScalarTensor` / `ScalarNative` rather than a rank-0 `Tensor`, so a rank-0 shape input
+/// never meets the `rank != 1` check and needs rejecting explicitly.
+const SHAPE_NOT_1D: &str = "Expand: shape input must be a 1D tensor, got a rank-0 scalar";
+
 pub(crate) struct ExpandProcessor;
 
 impl NodeProcessor for ExpandProcessor {
@@ -85,7 +90,10 @@ impl NodeProcessor for ExpandProcessor {
                 // Shapes are always 1-D int64 data, so nothing to validate here
             }
             ArgType::ScalarTensor(_) | ArgType::ScalarNative(_) => {
-                // Scalar shape means expanding to rank 0 (scalar output)
+                // A rank-0 shape input is out of spec: `shape` must be 1-D. Expanding to a
+                // rank-0 output is spelled as an empty 1-D shape tensor, which reaches the
+                // `ExpandConfig::Static(vec![])` path instead.
+                return Err(ProcessError::Custom(SHAPE_NOT_1D.to_string()));
             }
         }
 
@@ -121,8 +129,10 @@ impl NodeProcessor for ExpandProcessor {
             ExpandConfig::Runtime(_) => {
                 // When the shape cannot be determined statically, infer the rank from the shape input
                 let output_rank = match &node.inputs[1].ty {
-                    // Scalar shape input means expanding to a scalar (rank 0)
-                    ArgType::ScalarTensor(_) | ArgType::ScalarNative(_) => 0,
+                    // Rejected above; repeated here to keep the match exhaustive.
+                    ArgType::ScalarTensor(_) | ArgType::ScalarNative(_) => {
+                        return Err(ProcessError::Custom(SHAPE_NOT_1D.to_string()));
+                    }
                     ArgType::Shape(rank) => *rank,
                     ArgType::Tensor(tensor) => {
                         if let Some(static_shape) = &tensor.static_shape
@@ -388,16 +398,35 @@ mod tests {
     }
 
     #[test]
-    fn test_expand_scalar_native_shape_outputs_scalar() {
-        // ScalarNative shape input means expanding to rank 0
+    fn test_expand_rejects_scalar_native_shape() {
+        // A rank-0 `shape` input is out of spec; onnxruntime reports
+        // "shape input must be 1D tensor" for the same graph.
         let shape_type = ArgType::ScalarNative(DType::I64);
         let node = create_test_node(2, None, Some(shape_type)).build();
         let mut node = node;
         let processor = ExpandProcessor;
         let prefs = OutputPreferences::new();
-        processor.infer_types(&mut node, 16, &prefs).unwrap();
+        let result = processor.infer_types(&mut node, 16, &prefs);
 
-        assert_eq!(node.outputs[0].ty, ArgType::ScalarTensor(DType::F32));
+        match result {
+            Err(ProcessError::Custom(msg)) => {
+                assert!(msg.contains("1D tensor"), "unexpected message: {msg}");
+            }
+            other => panic!("Expected ProcessError::Custom, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_expand_rejects_scalar_tensor_shape() {
+        // Same rejection when the scalar is still on device rather than lowered to a native.
+        let shape_type = ArgType::ScalarTensor(DType::I64);
+        let node = create_test_node(2, None, Some(shape_type)).build();
+        let mut node = node;
+        let processor = ExpandProcessor;
+        let prefs = OutputPreferences::new();
+        let result = processor.infer_types(&mut node, 16, &prefs);
+
+        assert!(matches!(result, Err(ProcessError::Custom(_))));
     }
 
     #[test]

--- a/crates/onnx-ir/src/node/expand.rs
+++ b/crates/onnx-ir/src/node/expand.rs
@@ -409,9 +409,7 @@ mod tests {
         let result = processor.infer_types(&mut node, 16, &prefs);
 
         match result {
-            Err(ProcessError::Custom(msg)) => {
-                assert!(msg.contains("1D tensor"), "unexpected message: {msg}");
-            }
+            Err(ProcessError::Custom(msg)) => assert_eq!(msg, SHAPE_NOT_1D),
             other => panic!("Expected ProcessError::Custom, got {other:?}"),
         }
     }
@@ -426,7 +424,10 @@ mod tests {
         let prefs = OutputPreferences::new();
         let result = processor.infer_types(&mut node, 16, &prefs);
 
-        assert!(matches!(result, Err(ProcessError::Custom(_))));
+        match result {
+            Err(ProcessError::Custom(msg)) => assert_eq!(msg, SHAPE_NOT_1D),
+            other => panic!("Expected ProcessError::Custom, got {other:?}"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
Fixes #467.

`Expand` accepted a rank-0 `shape` input at type inference and then panicked in codegen:

```
PANIC => panicked at burn/node/expand.rs:37:26: Invalid shape source ScalarNative(I64)
```

Reported against DINOv3 in #18. Now:

```
Type inference failed: Node 'expand1' (Expand): Expand: shape input must be a 1D tensor, got a rank-0 scalar
```

## Why reject rather than lower

The issue originally proposed adding the missing codegen branch. That is the wrong fix: ONNX
requires `shape` to be 1-D, and the panic is only reachable on models onnxruntime also rejects.

| Graph (dynamic batch, nothing constant-folds) | onnxruntime | before | after |
| --- | --- | --- | --- |
| `Shape -> Gather(0) -> Unsqueeze([0]) -> Expand` | runs, out `(3, 3)` | imports | imports |
| `Shape -> Gather(0) -> Expand` | `[ShapeInferenceError] shape input must be 1D tensor` | panics | clear error |

The `Unsqueeze` is what makes the first one legal. `onnx.reference.ReferenceEvaluator` accepts both,
but only because it forwards to `np.broadcast_to`, which ignores the rank of its shape argument, so
it is not a usable oracle here.

## Why the arm existed

`infer_types` already rejects a shape input of rank 2 or more:

```rust
ArgType::Tensor(tensor) => {
    if tensor.rank != 1 {
        return Err(ProcessError::Custom("Expand: shape tensor must be 1D".to_string()));
    }
```

Rank 0 never meets that test, because onnx-ir models an ONNX scalar as `ScalarTensor` /
`ScalarNative` rather than as a rank-0 `Tensor`. It landed in a separate arm that declared it valid.

That arm came in with bb4e13fe, whose commit message describes fixing a different case: *"When the
shape input is an empty vec (scalar expansion), the Expand node was creating Tensor { rank: 0 }"*.
That is `shape = []`, an empty **1-D** tensor, which is valid ONNX and does produce a rank-0 output.
It runs through the `shape.is_empty()` branch on the `ExpandConfig::Static` path, is untouched here,
and `test_expand_static_empty_shape_outputs_scalar` still passes.

## Changes

- `onnx-ir/src/node/expand.rs`: return `ProcessError::Custom` for a rank-0 shape input, matching what
  the rank>=2 case already does. Message shared through one const so the two sites cannot drift.
- `burn-onnx/src/import/burn/node/expand.rs`: `panic!("Invalid shape source ...")` becomes the
  `unreachable!("... validated in onnx-ir")` form already used by `det.rs`, `dft.rs` and `col2im.rs`.

## Tests

`test_expand_scalar_native_shape_outputs_scalar` asserted the out-of-spec output type, so it is
replaced by `test_expand_rejects_scalar_native_shape` and `test_expand_rejects_scalar_tensor_shape`,
one per scalar representation.

No integration test: the fix is a rejection, and a `.onnx` that fails to import would break
`onnx-tests/build.rs`.

| Suite | Result |
| --- | --- |
| `cargo test -p onnx-ir` | 1187 lib + 476 opset compliance, pass |
| `cargo test -p burn-onnx` | 913 pass |
| `cargo test -p onnx-tests` | 601 pass |
| `cargo clippy -p onnx-ir -p burn-onnx --all-targets` | no new warnings (18 pre-existing, unchanged on `main`) |

## Note for the reporter

This makes the failure legible but does not import DINOv3. If that export really does feed a rank-0
value into `Expand`, onnxruntime will not load it either, and the fix belongs on the export side.
Asked on #467 for the result of loading it in `ort` to tell the two cases apart.

---

## Also in this PR: roadmap refresh (`TODO.md`)

Separate commit, no code impact.

Upsample (#461), the reduce runtime-`axes` fix (#464, with #460) and the RNN-family runtime weights
(#466) have all shipped, so their write-ups leave the queue and become one line each under a new
"Landed" section. `git log -- TODO.md` still has the detail.

Findings inside those items that describe work **still open** move to Tier 2 rather than disappearing
with them:

- the 3 empty-set reduce rows (`test_reduce_{max,min}_empty_set`, `test_reduce_log_sum_exp_empty_set`),
  which need the ONNX identity element and belong upstream in burn
- the two latent static-path RNN weight bugs: `collect_*_snapshots` slicing a direction with
  `.squeeze::<2>()`, and nothing validating a declared `W`/`R` shape against `hidden_size`

Remaining items renumber to 1-3 in the order the old "Order" section already argued for, Tier 1
(user-blocking) is empty so the tiers collapse to 1 and 2, and references to the removed items are
rewritten to PR numbers. Counts were re-checked against `expectations.toml` rather than copied
forward: still 932 / 96 / 484 / 103 across 1615 rows.
