### PR TITLE
Migrate to burn_pack::Tensor and bump burn rev

### DIFF
--- a/.github/workflows/bump-burn.yml
+++ b/.github/workflows/bump-burn.yml
@@ -48,6 +48,10 @@ jobs:
           OLD="${{ steps.current.outputs.sha }}"
           NEW="${{ steps.latest.outputs.sha }}"
           sed -i "s/$OLD/$NEW/g" Cargo.toml
+          # scoreboard/runner is a separate workspace carrying its own pin, so it
+          # never matches the root rev. Rewrite whatever sha it currently holds,
+          # otherwise it silently drifts away from the workspace.
+          sed -i -E "s/rev = \"[0-9a-f]{40}\"/rev = \"$NEW\"/g" scoreboard/runner/Cargo.toml
 
       - name: Install Rust
         if: steps.check.outputs.skip == 'false'
@@ -58,7 +62,9 @@ jobs:
 
       - name: Update lockfile
         if: steps.check.outputs.skip == 'false'
-        run: cargo update -p burn -p burn-flex -p burn-store -p burn-tensor
+        run: |
+          cargo update -p burn -p burn-flex -p burn-store -p burn-tensor
+          cargo update --manifest-path scoreboard/runner/Cargo.toml -p burn -p burn-store
 
       - name: Create pull request
         if: steps.check.outputs.skip == 'false'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -559,7 +559,7 @@ checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 [[package]]
 name = "burn"
 version = "0.22.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=9cdb20df7ab3ff5572518cb0dae370a3cf85ed02#9cdb20df7ab3ff5572518cb0dae370a3cf85ed02"
+source = "git+https://github.com/tracel-ai/burn?rev=a467575b5642fb135384d928ae9c0c7f1e0765be#a467575b5642fb135384d928ae9c0c7f1e0765be"
 dependencies = [
  "burn-core",
  "burn-nn",
@@ -572,7 +572,7 @@ dependencies = [
 [[package]]
 name = "burn-autodiff"
 version = "0.22.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=9cdb20df7ab3ff5572518cb0dae370a3cf85ed02#9cdb20df7ab3ff5572518cb0dae370a3cf85ed02"
+source = "git+https://github.com/tracel-ai/burn?rev=a467575b5642fb135384d928ae9c0c7f1e0765be#a467575b5642fb135384d928ae9c0c7f1e0765be"
 dependencies = [
  "burn-backend",
  "burn-std",
@@ -589,7 +589,7 @@ dependencies = [
 [[package]]
 name = "burn-backend"
 version = "0.22.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=9cdb20df7ab3ff5572518cb0dae370a3cf85ed02#9cdb20df7ab3ff5572518cb0dae370a3cf85ed02"
+source = "git+https://github.com/tracel-ai/burn?rev=a467575b5642fb135384d928ae9c0c7f1e0765be#a467575b5642fb135384d928ae9c0c7f1e0765be"
 dependencies = [
  "burn-std",
  "bytemuck",
@@ -609,7 +609,7 @@ dependencies = [
 [[package]]
 name = "burn-backend-extension"
 version = "0.22.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=9cdb20df7ab3ff5572518cb0dae370a3cf85ed02#9cdb20df7ab3ff5572518cb0dae370a3cf85ed02"
+source = "git+https://github.com/tracel-ai/burn?rev=a467575b5642fb135384d928ae9c0c7f1e0765be#a467575b5642fb135384d928ae9c0c7f1e0765be"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -619,7 +619,7 @@ dependencies = [
 [[package]]
 name = "burn-capture"
 version = "0.22.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=9cdb20df7ab3ff5572518cb0dae370a3cf85ed02#9cdb20df7ab3ff5572518cb0dae370a3cf85ed02"
+source = "git+https://github.com/tracel-ai/burn?rev=a467575b5642fb135384d928ae9c0c7f1e0765be#a467575b5642fb135384d928ae9c0c7f1e0765be"
 dependencies = [
  "burn-backend",
  "burn-ir",
@@ -633,7 +633,7 @@ dependencies = [
 [[package]]
 name = "burn-core"
 version = "0.22.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=9cdb20df7ab3ff5572518cb0dae370a3cf85ed02#9cdb20df7ab3ff5572518cb0dae370a3cf85ed02"
+source = "git+https://github.com/tracel-ai/burn?rev=a467575b5642fb135384d928ae9c0c7f1e0765be#a467575b5642fb135384d928ae9c0c7f1e0765be"
 dependencies = [
  "ahash",
  "burn-backend",
@@ -662,7 +662,7 @@ dependencies = [
 [[package]]
 name = "burn-cpu"
 version = "0.22.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=9cdb20df7ab3ff5572518cb0dae370a3cf85ed02#9cdb20df7ab3ff5572518cb0dae370a3cf85ed02"
+source = "git+https://github.com/tracel-ai/burn?rev=a467575b5642fb135384d928ae9c0c7f1e0765be#a467575b5642fb135384d928ae9c0c7f1e0765be"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -673,7 +673,7 @@ dependencies = [
 [[package]]
 name = "burn-cubecl"
 version = "0.22.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=9cdb20df7ab3ff5572518cb0dae370a3cf85ed02#9cdb20df7ab3ff5572518cb0dae370a3cf85ed02"
+source = "git+https://github.com/tracel-ai/burn?rev=a467575b5642fb135384d928ae9c0c7f1e0765be#a467575b5642fb135384d928ae9c0c7f1e0765be"
 dependencies = [
  "burn-backend",
  "burn-cubecl-fusion",
@@ -692,7 +692,7 @@ dependencies = [
 [[package]]
 name = "burn-cubecl-fusion"
 version = "0.22.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=9cdb20df7ab3ff5572518cb0dae370a3cf85ed02#9cdb20df7ab3ff5572518cb0dae370a3cf85ed02"
+source = "git+https://github.com/tracel-ai/burn?rev=a467575b5642fb135384d928ae9c0c7f1e0765be#a467575b5642fb135384d928ae9c0c7f1e0765be"
 dependencies = [
  "burn-backend",
  "burn-fusion",
@@ -710,7 +710,7 @@ dependencies = [
 [[package]]
 name = "burn-cuda"
 version = "0.22.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=9cdb20df7ab3ff5572518cb0dae370a3cf85ed02#9cdb20df7ab3ff5572518cb0dae370a3cf85ed02"
+source = "git+https://github.com/tracel-ai/burn?rev=a467575b5642fb135384d928ae9c0c7f1e0765be#a467575b5642fb135384d928ae9c0c7f1e0765be"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -721,7 +721,7 @@ dependencies = [
 [[package]]
 name = "burn-dataset"
 version = "0.22.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=9cdb20df7ab3ff5572518cb0dae370a3cf85ed02#9cdb20df7ab3ff5572518cb0dae370a3cf85ed02"
+source = "git+https://github.com/tracel-ai/burn?rev=a467575b5642fb135384d928ae9c0c7f1e0765be#a467575b5642fb135384d928ae9c0c7f1e0765be"
 dependencies = [
  "burn-std",
  "csv",
@@ -743,7 +743,7 @@ dependencies = [
 [[package]]
 name = "burn-derive"
 version = "0.22.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=9cdb20df7ab3ff5572518cb0dae370a3cf85ed02#9cdb20df7ab3ff5572518cb0dae370a3cf85ed02"
+source = "git+https://github.com/tracel-ai/burn?rev=a467575b5642fb135384d928ae9c0c7f1e0765be#a467575b5642fb135384d928ae9c0c7f1e0765be"
 dependencies = [
  "derive-new",
  "proc-macro2",
@@ -754,7 +754,7 @@ dependencies = [
 [[package]]
 name = "burn-dispatch"
 version = "0.22.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=9cdb20df7ab3ff5572518cb0dae370a3cf85ed02#9cdb20df7ab3ff5572518cb0dae370a3cf85ed02"
+source = "git+https://github.com/tracel-ai/burn?rev=a467575b5642fb135384d928ae9c0c7f1e0765be#a467575b5642fb135384d928ae9c0c7f1e0765be"
 dependencies = [
  "burn-autodiff",
  "burn-backend",
@@ -773,7 +773,7 @@ dependencies = [
 [[package]]
 name = "burn-flex"
 version = "0.22.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=9cdb20df7ab3ff5572518cb0dae370a3cf85ed02#9cdb20df7ab3ff5572518cb0dae370a3cf85ed02"
+source = "git+https://github.com/tracel-ai/burn?rev=a467575b5642fb135384d928ae9c0c7f1e0765be#a467575b5642fb135384d928ae9c0c7f1e0765be"
 dependencies = [
  "burn-backend",
  "burn-ir",
@@ -791,7 +791,7 @@ dependencies = [
 [[package]]
 name = "burn-fusion"
 version = "0.22.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=9cdb20df7ab3ff5572518cb0dae370a3cf85ed02#9cdb20df7ab3ff5572518cb0dae370a3cf85ed02"
+source = "git+https://github.com/tracel-ai/burn?rev=a467575b5642fb135384d928ae9c0c7f1e0765be#a467575b5642fb135384d928ae9c0c7f1e0765be"
 dependencies = [
  "burn-backend",
  "burn-ir",
@@ -815,7 +815,7 @@ dependencies = [
 [[package]]
 name = "burn-ir"
 version = "0.22.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=9cdb20df7ab3ff5572518cb0dae370a3cf85ed02#9cdb20df7ab3ff5572518cb0dae370a3cf85ed02"
+source = "git+https://github.com/tracel-ai/burn?rev=a467575b5642fb135384d928ae9c0c7f1e0765be#a467575b5642fb135384d928ae9c0c7f1e0765be"
 dependencies = [
  "burn-backend",
  "hashbrown 0.16.1",
@@ -825,7 +825,7 @@ dependencies = [
 [[package]]
 name = "burn-ndarray"
 version = "0.22.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=9cdb20df7ab3ff5572518cb0dae370a3cf85ed02#9cdb20df7ab3ff5572518cb0dae370a3cf85ed02"
+source = "git+https://github.com/tracel-ai/burn?rev=a467575b5642fb135384d928ae9c0c7f1e0765be#a467575b5642fb135384d928ae9c0c7f1e0765be"
 dependencies = [
  "atomic_float",
  "burn-backend",
@@ -846,7 +846,7 @@ dependencies = [
 [[package]]
 name = "burn-nn"
 version = "0.22.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=9cdb20df7ab3ff5572518cb0dae370a3cf85ed02#9cdb20df7ab3ff5572518cb0dae370a3cf85ed02"
+source = "git+https://github.com/tracel-ai/burn?rev=a467575b5642fb135384d928ae9c0c7f1e0765be#a467575b5642fb135384d928ae9c0c7f1e0765be"
 dependencies = [
  "burn-core",
  "num-traits",
@@ -1155,7 +1155,7 @@ dependencies = [
 [[package]]
 name = "burn-optim"
 version = "0.22.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=9cdb20df7ab3ff5572518cb0dae370a3cf85ed02#9cdb20df7ab3ff5572518cb0dae370a3cf85ed02"
+source = "git+https://github.com/tracel-ai/burn?rev=a467575b5642fb135384d928ae9c0c7f1e0765be#a467575b5642fb135384d928ae9c0c7f1e0765be"
 dependencies = [
  "burn-core",
  "burn-derive",
@@ -1170,7 +1170,7 @@ dependencies = [
 [[package]]
 name = "burn-pack"
 version = "0.22.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=9cdb20df7ab3ff5572518cb0dae370a3cf85ed02#9cdb20df7ab3ff5572518cb0dae370a3cf85ed02"
+source = "git+https://github.com/tracel-ai/burn?rev=a467575b5642fb135384d928ae9c0c7f1e0765be#a467575b5642fb135384d928ae9c0c7f1e0765be"
 dependencies = [
  "burn-std",
  "byteorder",
@@ -1181,7 +1181,7 @@ dependencies = [
 [[package]]
 name = "burn-remote"
 version = "0.22.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=9cdb20df7ab3ff5572518cb0dae370a3cf85ed02#9cdb20df7ab3ff5572518cb0dae370a3cf85ed02"
+source = "git+https://github.com/tracel-ai/burn?rev=a467575b5642fb135384d928ae9c0c7f1e0765be#a467575b5642fb135384d928ae9c0c7f1e0765be"
 dependencies = [
  "burn-backend",
  "burn-fusion",
@@ -1203,7 +1203,7 @@ dependencies = [
 [[package]]
 name = "burn-rocm"
 version = "0.22.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=9cdb20df7ab3ff5572518cb0dae370a3cf85ed02#9cdb20df7ab3ff5572518cb0dae370a3cf85ed02"
+source = "git+https://github.com/tracel-ai/burn?rev=a467575b5642fb135384d928ae9c0c7f1e0765be#a467575b5642fb135384d928ae9c0c7f1e0765be"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -1214,7 +1214,7 @@ dependencies = [
 [[package]]
 name = "burn-router"
 version = "0.22.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=9cdb20df7ab3ff5572518cb0dae370a3cf85ed02#9cdb20df7ab3ff5572518cb0dae370a3cf85ed02"
+source = "git+https://github.com/tracel-ai/burn?rev=a467575b5642fb135384d928ae9c0c7f1e0765be#a467575b5642fb135384d928ae9c0c7f1e0765be"
 dependencies = [
  "burn-backend",
  "burn-fusion",
@@ -1230,7 +1230,7 @@ dependencies = [
 [[package]]
 name = "burn-std"
 version = "0.22.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=9cdb20df7ab3ff5572518cb0dae370a3cf85ed02#9cdb20df7ab3ff5572518cb0dae370a3cf85ed02"
+source = "git+https://github.com/tracel-ai/burn?rev=a467575b5642fb135384d928ae9c0c7f1e0765be#a467575b5642fb135384d928ae9c0c7f1e0765be"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1260,7 +1260,7 @@ dependencies = [
 [[package]]
 name = "burn-store"
 version = "0.22.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=9cdb20df7ab3ff5572518cb0dae370a3cf85ed02#9cdb20df7ab3ff5572518cb0dae370a3cf85ed02"
+source = "git+https://github.com/tracel-ai/burn?rev=a467575b5642fb135384d928ae9c0c7f1e0765be#a467575b5642fb135384d928ae9c0c7f1e0765be"
 dependencies = [
  "burn-core",
  "burn-pack",
@@ -1283,7 +1283,7 @@ dependencies = [
 [[package]]
 name = "burn-tch"
 version = "0.22.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=9cdb20df7ab3ff5572518cb0dae370a3cf85ed02#9cdb20df7ab3ff5572518cb0dae370a3cf85ed02"
+source = "git+https://github.com/tracel-ai/burn?rev=a467575b5642fb135384d928ae9c0c7f1e0765be#a467575b5642fb135384d928ae9c0c7f1e0765be"
 dependencies = [
  "burn-backend",
  "cc",
@@ -1296,7 +1296,7 @@ dependencies = [
 [[package]]
 name = "burn-tensor"
 version = "0.22.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=9cdb20df7ab3ff5572518cb0dae370a3cf85ed02#9cdb20df7ab3ff5572518cb0dae370a3cf85ed02"
+source = "git+https://github.com/tracel-ai/burn?rev=a467575b5642fb135384d928ae9c0c7f1e0765be#a467575b5642fb135384d928ae9c0c7f1e0765be"
 dependencies = [
  "burn-backend",
  "burn-dispatch",
@@ -1310,7 +1310,7 @@ dependencies = [
 [[package]]
 name = "burn-vision"
 version = "0.22.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=9cdb20df7ab3ff5572518cb0dae370a3cf85ed02#9cdb20df7ab3ff5572518cb0dae370a3cf85ed02"
+source = "git+https://github.com/tracel-ai/burn?rev=a467575b5642fb135384d928ae9c0c7f1e0765be#a467575b5642fb135384d928ae9c0c7f1e0765be"
 dependencies = [
  "aligned-vec",
  "bon",
@@ -1334,7 +1334,7 @@ dependencies = [
 [[package]]
 name = "burn-wgpu"
 version = "0.22.0-pre.2"
-source = "git+https://github.com/tracel-ai/burn?rev=9cdb20df7ab3ff5572518cb0dae370a3cf85ed02#9cdb20df7ab3ff5572518cb0dae370a3cf85ed02"
+source = "git+https://github.com/tracel-ai/burn?rev=a467575b5642fb135384d928ae9c0c7f1e0765be#a467575b5642fb135384d928ae9c0c7f1e0765be"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -1570,7 +1570,7 @@ checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
 dependencies = [
  "serde",
  "termcolor",
- "unicode-width 0.2.2",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -1948,7 +1948,7 @@ dependencies = [
 [[package]]
 name = "cubecl"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=48348968468e433235be3db6e7c344c34bc446c0#48348968468e433235be3db6e7c344c34bc446c0"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4057f39e7fe025323e032bab8fc7600d16414f5e#4057f39e7fe025323e032bab8fc7600d16414f5e"
 dependencies = [
  "cubecl-core",
  "cubecl-cpu",
@@ -1965,7 +1965,7 @@ dependencies = [
 [[package]]
 name = "cubecl-common"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=48348968468e433235be3db6e7c344c34bc446c0#48348968468e433235be3db6e7c344c34bc446c0"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4057f39e7fe025323e032bab8fc7600d16414f5e#4057f39e7fe025323e032bab8fc7600d16414f5e"
 dependencies = [
  "bytemuck",
  "cfg_aliases",
@@ -1989,7 +1989,7 @@ dependencies = [
 [[package]]
 name = "cubecl-core"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=48348968468e433235be3db6e7c344c34bc446c0#48348968468e433235be3db6e7c344c34bc446c0"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4057f39e7fe025323e032bab8fc7600d16414f5e#4057f39e7fe025323e032bab8fc7600d16414f5e"
 dependencies = [
  "bitflags 2.13.1",
  "bytemuck",
@@ -2020,7 +2020,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpp"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=48348968468e433235be3db6e7c344c34bc446c0#48348968468e433235be3db6e7c344c34bc446c0"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4057f39e7fe025323e032bab8fc7600d16414f5e#4057f39e7fe025323e032bab8fc7600d16414f5e"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -2043,7 +2043,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpu"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=48348968468e433235be3db6e7c344c34bc446c0#48348968468e433235be3db6e7c344c34bc446c0"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4057f39e7fe025323e032bab8fc7600d16414f5e#4057f39e7fe025323e032bab8fc7600d16414f5e"
 dependencies = [
  "crossbeam-utils",
  "cubecl-common",
@@ -2064,7 +2064,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cuda"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=48348968468e433235be3db6e7c344c34bc446c0#48348968468e433235be3db6e7c344c34bc446c0"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4057f39e7fe025323e032bab8fc7600d16414f5e#4057f39e7fe025323e032bab8fc7600d16414f5e"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -2083,7 +2083,7 @@ dependencies = [
 [[package]]
 name = "cubecl-environment"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=48348968468e433235be3db6e7c344c34bc446c0#48348968468e433235be3db6e7c344c34bc446c0"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4057f39e7fe025323e032bab8fc7600d16414f5e#4057f39e7fe025323e032bab8fc7600d16414f5e"
 dependencies = [
  "async-channel",
  "backtrace",
@@ -2118,7 +2118,7 @@ dependencies = [
 [[package]]
 name = "cubecl-hip"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=48348968468e433235be3db6e7c344c34bc446c0#48348968468e433235be3db6e7c344c34bc446c0"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4057f39e7fe025323e032bab8fc7600d16414f5e#4057f39e7fe025323e032bab8fc7600d16414f5e"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -2148,7 +2148,7 @@ dependencies = [
 [[package]]
 name = "cubecl-ir"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=48348968468e433235be3db6e7c344c34bc446c0#48348968468e433235be3db6e7c344c34bc446c0"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4057f39e7fe025323e032bab8fc7600d16414f5e#4057f39e7fe025323e032bab8fc7600d16414f5e"
 dependencies = [
  "bumpalo",
  "cubecl-common",
@@ -2178,7 +2178,7 @@ dependencies = [
 [[package]]
 name = "cubecl-llvm"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=48348968468e433235be3db6e7c344c34bc446c0#48348968468e433235be3db6e7c344c34bc446c0"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4057f39e7fe025323e032bab8fc7600d16414f5e#4057f39e7fe025323e032bab8fc7600d16414f5e"
 dependencies = [
  "cubecl-core",
  "cubecl-environment",
@@ -2195,7 +2195,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=48348968468e433235be3db6e7c344c34bc446c0#48348968468e433235be3db6e7c344c34bc446c0"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4057f39e7fe025323e032bab8fc7600d16414f5e#4057f39e7fe025323e032bab8fc7600d16414f5e"
 dependencies = [
  "cubecl-common",
  "darling 0.24.0",
@@ -2213,7 +2213,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros-internal"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=48348968468e433235be3db6e7c344c34bc446c0#48348968468e433235be3db6e7c344c34bc446c0"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4057f39e7fe025323e032bab8fc7600d16414f5e#4057f39e7fe025323e032bab8fc7600d16414f5e"
 dependencies = [
  "darling 0.24.0",
  "inflections",
@@ -2225,7 +2225,7 @@ dependencies = [
 [[package]]
 name = "cubecl-opt"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=48348968468e433235be3db6e7c344c34bc446c0#48348968468e433235be3db6e7c344c34bc446c0"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4057f39e7fe025323e032bab8fc7600d16414f5e#4057f39e7fe025323e032bab8fc7600d16414f5e"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -2247,7 +2247,7 @@ dependencies = [
 [[package]]
 name = "cubecl-runtime"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=48348968468e433235be3db6e7c344c34bc446c0#48348968468e433235be3db6e7c344c34bc446c0"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4057f39e7fe025323e032bab8fc7600d16414f5e#4057f39e7fe025323e032bab8fc7600d16414f5e"
 dependencies = [
  "ahash",
  "buildid",
@@ -2278,7 +2278,7 @@ dependencies = [
 [[package]]
 name = "cubecl-std"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=48348968468e433235be3db6e7c344c34bc446c0#48348968468e433235be3db6e7c344c34bc446c0"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4057f39e7fe025323e032bab8fc7600d16414f5e#4057f39e7fe025323e032bab8fc7600d16414f5e"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -2295,7 +2295,7 @@ dependencies = [
 [[package]]
 name = "cubecl-wgpu"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=48348968468e433235be3db6e7c344c34bc446c0#48348968468e433235be3db6e7c344c34bc446c0"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4057f39e7fe025323e032bab8fc7600d16414f5e#4057f39e7fe025323e032bab8fc7600d16414f5e"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -2327,7 +2327,7 @@ dependencies = [
 [[package]]
 name = "cubecl-zspace"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=48348968468e433235be3db6e7c344c34bc446c0#48348968468e433235be3db6e7c344c34bc446c0"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4057f39e7fe025323e032bab8fc7600d16414f5e#4057f39e7fe025323e032bab8fc7600d16414f5e"
 dependencies = [
  "derive-new",
  "serde",
@@ -2337,7 +2337,7 @@ dependencies = [
 [[package]]
 name = "cubek"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=939e449c278671b4cc4315ee83f891bfe36dc27f#939e449c278671b4cc4315ee83f891bfe36dc27f"
+source = "git+https://github.com/tracel-ai/cubek?rev=622d6714f12104f21314f7173bf841f697caf5ca#622d6714f12104f21314f7173bf841f697caf5ca"
 dependencies = [
  "cubecl",
  "cubek-attention",
@@ -2355,7 +2355,7 @@ dependencies = [
 [[package]]
 name = "cubek-attention"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=939e449c278671b4cc4315ee83f891bfe36dc27f#939e449c278671b4cc4315ee83f891bfe36dc27f"
+source = "git+https://github.com/tracel-ai/cubek?rev=622d6714f12104f21314f7173bf841f697caf5ca#622d6714f12104f21314f7173bf841f697caf5ca"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2369,7 +2369,7 @@ dependencies = [
 [[package]]
 name = "cubek-convolution"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=939e449c278671b4cc4315ee83f891bfe36dc27f#939e449c278671b4cc4315ee83f891bfe36dc27f"
+source = "git+https://github.com/tracel-ai/cubek?rev=622d6714f12104f21314f7173bf841f697caf5ca#622d6714f12104f21314f7173bf841f697caf5ca"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2385,7 +2385,7 @@ dependencies = [
 [[package]]
 name = "cubek-fft"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=939e449c278671b4cc4315ee83f891bfe36dc27f#939e449c278671b4cc4315ee83f891bfe36dc27f"
+source = "git+https://github.com/tracel-ai/cubek?rev=622d6714f12104f21314f7173bf841f697caf5ca#622d6714f12104f21314f7173bf841f697caf5ca"
 dependencies = [
  "cubecl",
 ]
@@ -2393,7 +2393,7 @@ dependencies = [
 [[package]]
 name = "cubek-interpolate"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=939e449c278671b4cc4315ee83f891bfe36dc27f#939e449c278671b4cc4315ee83f891bfe36dc27f"
+source = "git+https://github.com/tracel-ai/cubek?rev=622d6714f12104f21314f7173bf841f697caf5ca#622d6714f12104f21314f7173bf841f697caf5ca"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2405,7 +2405,7 @@ dependencies = [
 [[package]]
 name = "cubek-matmul"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=939e449c278671b4cc4315ee83f891bfe36dc27f#939e449c278671b4cc4315ee83f891bfe36dc27f"
+source = "git+https://github.com/tracel-ai/cubek?rev=622d6714f12104f21314f7173bf841f697caf5ca#622d6714f12104f21314f7173bf841f697caf5ca"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2419,7 +2419,7 @@ dependencies = [
 [[package]]
 name = "cubek-pool"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=939e449c278671b4cc4315ee83f891bfe36dc27f#939e449c278671b4cc4315ee83f891bfe36dc27f"
+source = "git+https://github.com/tracel-ai/cubek?rev=622d6714f12104f21314f7173bf841f697caf5ca#622d6714f12104f21314f7173bf841f697caf5ca"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2429,7 +2429,7 @@ dependencies = [
 [[package]]
 name = "cubek-quant"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=939e449c278671b4cc4315ee83f891bfe36dc27f#939e449c278671b4cc4315ee83f891bfe36dc27f"
+source = "git+https://github.com/tracel-ai/cubek?rev=622d6714f12104f21314f7173bf841f697caf5ca#622d6714f12104f21314f7173bf841f697caf5ca"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2441,11 +2441,12 @@ dependencies = [
 [[package]]
 name = "cubek-random"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=939e449c278671b4cc4315ee83f891bfe36dc27f#939e449c278671b4cc4315ee83f891bfe36dc27f"
+source = "git+https://github.com/tracel-ai/cubek?rev=622d6714f12104f21314f7173bf841f697caf5ca#622d6714f12104f21314f7173bf841f697caf5ca"
 dependencies = [
  "cubecl",
  "cubecl-common",
  "cubecl-environment",
+ "cubek-std",
  "half",
  "num-traits",
  "rand 0.10.1",
@@ -2455,7 +2456,7 @@ dependencies = [
 [[package]]
 name = "cubek-reduce"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=939e449c278671b4cc4315ee83f891bfe36dc27f#939e449c278671b4cc4315ee83f891bfe36dc27f"
+source = "git+https://github.com/tracel-ai/cubek?rev=622d6714f12104f21314f7173bf841f697caf5ca#622d6714f12104f21314f7173bf841f697caf5ca"
 dependencies = [
  "cubecl",
  "cubek-std",
@@ -2468,7 +2469,7 @@ dependencies = [
 [[package]]
 name = "cubek-std"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=939e449c278671b4cc4315ee83f891bfe36dc27f#939e449c278671b4cc4315ee83f891bfe36dc27f"
+source = "git+https://github.com/tracel-ai/cubek?rev=622d6714f12104f21314f7173bf841f697caf5ca#622d6714f12104f21314f7173bf841f697caf5ca"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2478,7 +2479,7 @@ dependencies = [
 [[package]]
 name = "cubek-tile"
 version = "0.3.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubek?rev=939e449c278671b4cc4315ee83f891bfe36dc27f#939e449c278671b4cc4315ee83f891bfe36dc27f"
+source = "git+https://github.com/tracel-ai/cubek?rev=622d6714f12104f21314f7173bf841f697caf5ca#622d6714f12104f21314f7173bf841f697caf5ca"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -5777,7 +5778,7 @@ dependencies = [
  "combine",
  "downcast-rs",
  "dyn-clone",
- "hashbrown 0.13.2",
+ "hashbrown 0.17.0",
  "hi_sparse_bitset",
  "indexmap",
  "inventory",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,11 +93,11 @@ tempfile = "3.24.0"
 thiserror = { version = "2", default-features = false }
 toml = { version = "1.1.2", default-features = false, features = ["parse", "serde"] }
 
-burn = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "9cdb20df7ab3ff5572518cb0dae370a3cf85ed02" }
-burn-flex = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "9cdb20df7ab3ff5572518cb0dae370a3cf85ed02" }
-burn-pack = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "9cdb20df7ab3ff5572518cb0dae370a3cf85ed02" }
-burn-store = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "9cdb20df7ab3ff5572518cb0dae370a3cf85ed02" }
-burn-tensor = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "9cdb20df7ab3ff5572518cb0dae370a3cf85ed02" }
+burn = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "a467575b5642fb135384d928ae9c0c7f1e0765be" }
+burn-flex = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "a467575b5642fb135384d928ae9c0c7f1e0765be" }
+burn-pack = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "a467575b5642fb135384d928ae9c0c7f1e0765be" }
+burn-store = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "a467575b5642fb135384d928ae9c0c7f1e0765be" }
+burn-tensor = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "a467575b5642fb135384d928ae9c0c7f1e0765be" }
 
 ### For local development. ###
 # burn = { path = "../burn/crates/burn", default-features = false }

--- a/DESIGN-CUSTOM-OPS.md
+++ b/DESIGN-CUSTOM-OPS.md
@@ -625,8 +625,9 @@ pub use onnx_ir::{
     TensorData, TensorType,
 };
 
-// Snapshot type used by collect_snapshots (from burn-store).
-pub use burn_store::TensorSnapshot;
+// Burnpack tensor type used by collect_snapshots, plus the constructors for it.
+pub use burn_pack::{Error as PackError, Tensor as PackTensor};
+pub use burn_store::bridge;
 
 // Token-stream crates. TokenStream values must come from the same proc-macro2
 // build burn-onnx links; cargo unifies 1.x in practice, but re-exporting
@@ -665,7 +666,7 @@ impl<'a> Imports<'a> {
 Corrections to v1 in this list: `arg_to_ident` lives in `node_traits.rs:168`
 (not `argument_helpers.rs`) and is currently not re-exported anywhere, so the
 `ext` re-export is its promotion point. `create_lazy_snapshot`
-(`node_traits.rs:197`) is what built-in nodes use to build `TensorSnapshot`s
+(`node_traits.rs:197`) is what built-in nodes use to build `PackTensor`s
 from constant inputs; custom ops with weights need it for `collect_snapshots`,
 so it is part of the curated surface.
 
@@ -696,7 +697,7 @@ All trait inputs and outputs come from the public `ext` surface (4.6, 5.0).
 ```rust
 // crates/burn-onnx/src/import/burn/custom_op.rs (new)
 use crate::ext::{
-    ArgType, CodegenContext, CustomNode, Field, Imports, ProcessError, TensorSnapshot,
+    ArgType, CodegenContext, CustomNode, Field, Imports, PackTensor, ProcessError,
 };
 use proc_macro2::TokenStream;
 
@@ -732,7 +733,7 @@ pub trait CustomOp: Send + Sync + 'static {
 
     /// Optional: weights/snapshot collection (parallels NodeCodegen).
     fn collect_snapshots(&self, _node: &CustomNode, _field_name: &str)
-        -> Result<Vec<TensorSnapshot>, ProcessError> { Ok(vec![]) }
+        -> Result<Vec<PackTensor>, ProcessError> { Ok(vec![]) }
 }
 ```
 
@@ -755,7 +756,7 @@ pub trait OpOverride: Send + Sync + 'static {
     fn register_imports(&self, _imports: &mut Imports<'_>) {}
     fn field(&self, _node: &Node) -> Result<Option<Field>, ProcessError> { Ok(None) }
     fn collect_snapshots(&self, _node: &Node, _field_name: &str)
-        -> Result<Vec<TensorSnapshot>, ProcessError> { Ok(vec![]) }
+        -> Result<Vec<PackTensor>, ProcessError> { Ok(vec![]) }
 }
 ```
 

--- a/crates/burn-onnx/Cargo.toml
+++ b/crates/burn-onnx/Cargo.toml
@@ -55,10 +55,7 @@ onnx-ir = { workspace = true, optional = true }
 
 burn = { workspace = true, optional = true }
 burn-pack = { workspace = true, optional = true, features = ["std"] }
-burn-store = { workspace = true, optional = true, features = [
-    "std",
-    "burnpack",
-] }
+burn-store = { workspace = true, optional = true, features = ["std"] }
 
 clap = { version = "4", optional = true, features = ["derive"] }
 derive-new = { workspace = true, optional = true }

--- a/crates/burn-onnx/src/import/burn/custom_op.rs
+++ b/crates/burn-onnx/src/import/burn/custom_op.rs
@@ -15,7 +15,7 @@ use proc_macro2::TokenStream;
 
 use crate::burn::node_traits::Field;
 use crate::ext::{CodegenContext, Imports};
-use burn_store::TensorSnapshot;
+use burn_pack::Tensor as PackTensor;
 
 /// Codegen hook for one custom (non-built-in) ONNX operator.
 ///
@@ -78,7 +78,7 @@ pub trait CustomOp: Send + Sync + 'static {
         &self,
         _node: &CustomNode,
         _field_name: &str,
-    ) -> Result<Vec<TensorSnapshot>, ProcessError> {
+    ) -> Result<Vec<PackTensor>, ProcessError> {
         Ok(vec![])
     }
 }
@@ -122,7 +122,7 @@ pub trait OpOverride: Send + Sync + 'static {
         &self,
         _node: &Node,
         _field_name: &str,
-    ) -> Result<Vec<TensorSnapshot>, ProcessError> {
+    ) -> Result<Vec<PackTensor>, ProcessError> {
         Ok(vec![])
     }
 }

--- a/crates/burn-onnx/src/import/burn/graph.rs
+++ b/crates/burn-onnx/src/import/burn/graph.rs
@@ -8,8 +8,7 @@ use crate::burn::node_codegen::{
 use crate::burn::partition::{
     MIN_GRAPH_SIZE, Partition, reorder_constants_to_consumers, try_partition,
 };
-use burn_pack::{Tensor, Writer};
-use burn_store::TensorSnapshot;
+use burn_pack::{Tensor as PackTensor, Writer};
 use onnx_ir::{Node, ir::ArgType};
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
@@ -79,29 +78,10 @@ impl BurnGraph {
         // run before it (codegen() re-checks for direct codegen users).
         self.validate_hooks_in_subgraphs();
 
-        // Collect all tensor snapshots from nodes
-        let snapshots = self.collect_all_snapshots();
-
-        // Materialize snapshots into the tensor-agnostic burnpack representation.
-        // This is currently eager because burn-pack doesn't accept lazy tensor providers.
-        // See https://github.com/tracel-ai/burn/issues/5219.
-        // FIXME: this is a regression that should be fixed for the official release
-        let tensors = snapshots
-            .iter()
-            .map(|snapshot| {
-                let data = snapshot.to_data().map_err(|e| (snapshot.full_path(), e))?;
-                Ok(Tensor::new(
-                    snapshot.full_path(),
-                    snapshot.dtype,
-                    snapshot.shape.clone(),
-                    snapshot.tensor_id.map(|id| id.val()),
-                    data.bytes,
-                ))
-            })
-            .collect::<Result<Vec<_>, (String, burn_store::TensorSnapshotError)>>()
-            .unwrap_or_else(|(path, e)| {
-                panic!("Failed to materialize tensor snapshot {path}: {e}")
-            });
+        // Collect all tensor snapshots from nodes. Each one stays deferred: the writer
+        // draws its bytes one at a time, so peak memory is bounded by the largest single
+        // tensor rather than by the whole model.
+        let tensors = self.collect_all_snapshots();
 
         // Write burnpack file
         let burnpack_file = out_file.with_extension("bpk");
@@ -128,7 +108,7 @@ impl BurnGraph {
     /// When partitioned into submodules, snapshot paths are prefixed with the submodule
     /// field name (e.g. "submodule1.linear1.weight") so that `load_from` routes weights
     /// to the correct nested module.
-    fn collect_all_snapshots(&mut self) -> Vec<TensorSnapshot> {
+    fn collect_all_snapshots(&mut self) -> Vec<PackTensor> {
         let partition = self.compute_partition();
 
         if let Some(partition) = partition {
@@ -159,7 +139,7 @@ impl BurnGraph {
         result
     }
 
-    fn collect_snapshots_flat(&self) -> Vec<TensorSnapshot> {
+    fn collect_snapshots_flat(&self) -> Vec<PackTensor> {
         let mut snapshots = Vec::new();
         let mut field_name_counts: HashMap<String, usize> = HashMap::new();
         collect_snapshots_from_nodes(
@@ -172,7 +152,7 @@ impl BurnGraph {
         snapshots
     }
 
-    fn collect_snapshots_partitioned(&self, partition: &Partition) -> Vec<TensorSnapshot> {
+    fn collect_snapshots_partitioned(&self, partition: &Partition) -> Vec<PackTensor> {
         let mut snapshots = Vec::new();
 
         for (chunk_idx, range) in partition.chunks.iter().enumerate() {
@@ -1110,7 +1090,7 @@ fn collect_snapshots_from_nodes(
     nodes: &[Node],
     prefix: &str,
     field_name_counts: &mut HashMap<String, usize>,
-    snapshots: &mut Vec<TensorSnapshot>,
+    snapshots: &mut Vec<PackTensor>,
     hooks: &HookRegistry,
 ) {
     // Hook-free for the same reason as collect_subgraph_fields_recursive:
@@ -1120,7 +1100,7 @@ fn collect_snapshots_from_nodes(
         subgraph: &onnx_ir::OnnxGraph,
         prefix: &str,
         field_name_counts: &mut HashMap<String, usize>,
-        snapshots: &mut Vec<TensorSnapshot>,
+        snapshots: &mut Vec<PackTensor>,
     ) {
         for node in &subgraph.nodes {
             if let Some(field) = NodeCodegen::field(node) {
@@ -1368,19 +1348,15 @@ mod tests {
             &self,
             _node: &onnx_ir::CustomNode,
             field_name: &str,
-        ) -> Result<Vec<TensorSnapshot>, onnx_ir::ProcessError> {
+        ) -> Result<Vec<PackTensor>, onnx_ir::ProcessError> {
             use burn::module::ParamId;
             use burn::tensor::TensorData;
-            let data_fn = TensorSnapshot::data_fn(|| {
-                Ok(TensorData::new(vec![0.5f32, 1.0, 1.5, 2.0], [4usize]))
-            });
-            Ok(vec![TensorSnapshot::from_closure(
-                data_fn,
+            Ok(vec![burn_store::bridge::deferred(
+                format!("{field_name}.state"),
                 burn::tensor::DType::F32,
                 [4usize].into(),
-                vec![field_name.to_string(), "state".to_string()],
-                vec!["Struct:StatefulFft".to_string()],
-                ParamId::new(),
+                Some(ParamId::new().val()),
+                || Ok(TensorData::new(vec![0.5f32, 1.0, 1.5, 2.0], [4usize])),
             )])
         }
     }
@@ -1400,7 +1376,7 @@ mod tests {
         let snapshots =
             crate::burn::node_codegen::node_collect_snapshots(node, "fft_state", &registry);
         assert_eq!(snapshots.len(), 1);
-        assert_eq!(snapshots[0].full_path(), "fft_state.state");
+        assert_eq!(snapshots[0].name, "fft_state.state");
 
         // The generated struct and forward reference the hook's field
         let code = format_tokens(graph.codegen());

--- a/crates/burn-onnx/src/import/burn/node/batch_norm.rs
+++ b/crates/burn-onnx/src/import/burn/node/batch_norm.rs
@@ -1,5 +1,5 @@
 use super::prelude::*;
-use burn_store::TensorSnapshot;
+use burn_pack::Tensor as PackTensor;
 use onnx_ir::node::batch_norm::{BatchNormConfig, BatchNormalizationNode};
 
 impl NodeCodegen for BatchNormalizationNode {
@@ -103,7 +103,7 @@ impl NodeCodegen for BatchNormalizationNode {
         }
     }
 
-    fn collect_snapshots(&self, field_name: &str) -> Vec<TensorSnapshot> {
+    fn collect_snapshots(&self, field_name: &str) -> Vec<PackTensor> {
         match &self.config {
             BatchNormConfig::Static(_) => {
                 use crate::burn::node_traits::create_lazy_snapshot;
@@ -111,18 +111,14 @@ impl NodeCodegen for BatchNormalizationNode {
 
                 if let Some(gamma_input) = self.inputs.get(1) {
                     let gamma_path = format!("{}.gamma", field_name);
-                    if let Some(snapshot) =
-                        create_lazy_snapshot(gamma_input, &gamma_path, "BatchNorm")
-                    {
+                    if let Some(snapshot) = create_lazy_snapshot(gamma_input, &gamma_path) {
                         snapshots.push(snapshot);
                     }
                 }
 
                 if let Some(beta_input) = self.inputs.get(2) {
                     let beta_path = format!("{}.beta", field_name);
-                    if let Some(snapshot) =
-                        create_lazy_snapshot(beta_input, &beta_path, "BatchNorm")
-                    {
+                    if let Some(snapshot) = create_lazy_snapshot(beta_input, &beta_path) {
                         snapshots.push(snapshot);
                     }
                 }
@@ -130,7 +126,7 @@ impl NodeCodegen for BatchNormalizationNode {
                 if let Some(running_mean_input) = self.inputs.get(3) {
                     let running_mean_path = format!("{}.running_mean", field_name);
                     if let Some(snapshot) =
-                        create_lazy_snapshot(running_mean_input, &running_mean_path, "BatchNorm")
+                        create_lazy_snapshot(running_mean_input, &running_mean_path)
                     {
                         snapshots.push(snapshot);
                     }
@@ -139,7 +135,7 @@ impl NodeCodegen for BatchNormalizationNode {
                 if let Some(running_var_input) = self.inputs.get(4) {
                     let running_var_path = format!("{}.running_var", field_name);
                     if let Some(snapshot) =
-                        create_lazy_snapshot(running_var_input, &running_var_path, "BatchNorm")
+                        create_lazy_snapshot(running_var_input, &running_var_path)
                     {
                         snapshots.push(snapshot);
                     }

--- a/crates/burn-onnx/src/import/burn/node/constant.rs
+++ b/crates/burn-onnx/src/import/burn/node/constant.rs
@@ -1,5 +1,5 @@
 use super::prelude::*;
-use burn_store::TensorSnapshot;
+use burn_pack::Tensor as PackTensor;
 use onnx_ir::ir::TensorDataExt;
 
 impl NodeCodegen for onnx_ir::node::constant::ConstantNode {
@@ -186,7 +186,7 @@ impl NodeCodegen for onnx_ir::node::constant::ConstantNode {
         Some(Field::new(self.name.clone(), ty, init))
     }
 
-    fn collect_snapshots(&self, field_name: &str) -> Vec<TensorSnapshot> {
+    fn collect_snapshots(&self, field_name: &str) -> Vec<PackTensor> {
         use crate::burn::node_traits::create_lazy_snapshot;
 
         let output = self.outputs.first().unwrap();
@@ -198,7 +198,7 @@ impl NodeCodegen for onnx_ir::node::constant::ConstantNode {
             ArgType::Tensor(_) | ArgType::ScalarTensor(_) => {
                 if let Some(input) = self.inputs.first() {
                     // Use the field name as the path since constants are stored as single params
-                    if let Some(snapshot) = create_lazy_snapshot(input, field_name, "Constant") {
+                    if let Some(snapshot) = create_lazy_snapshot(input, field_name) {
                         vec![snapshot]
                     } else {
                         vec![]

--- a/crates/burn-onnx/src/import/burn/node/conv1d.rs
+++ b/crates/burn-onnx/src/import/burn/node/conv1d.rs
@@ -1,5 +1,5 @@
 use super::prelude::*;
-use burn_store::TensorSnapshot;
+use burn_pack::Tensor as PackTensor;
 
 impl NodeCodegen for onnx_ir::conv1d::Conv1dNode {
     fn inputs(&self) -> &[Argument] {
@@ -69,14 +69,14 @@ impl NodeCodegen for onnx_ir::conv1d::Conv1dNode {
         imports.register("burn::nn::conv::Conv1dConfig");
     }
 
-    fn collect_snapshots(&self, field_name: &str) -> Vec<TensorSnapshot> {
+    fn collect_snapshots(&self, field_name: &str) -> Vec<PackTensor> {
         use crate::burn::node_traits::create_lazy_snapshot;
         let mut snapshots = vec![];
 
         // Weight tensor (input index 1)
         if let Some(weight_input) = self.inputs.get(1) {
             let weight_path = format!("{}.weight", field_name);
-            if let Some(snapshot) = create_lazy_snapshot(weight_input, &weight_path, "Conv1d") {
+            if let Some(snapshot) = create_lazy_snapshot(weight_input, &weight_path) {
                 snapshots.push(snapshot);
             }
         }
@@ -84,7 +84,7 @@ impl NodeCodegen for onnx_ir::conv1d::Conv1dNode {
         // Bias tensor if present (input index 2)
         if let Some(bias_input) = self.inputs.get(2) {
             let bias_path = format!("{}.bias", field_name);
-            if let Some(snapshot) = create_lazy_snapshot(bias_input, &bias_path, "Conv1d") {
+            if let Some(snapshot) = create_lazy_snapshot(bias_input, &bias_path) {
                 snapshots.push(snapshot);
             }
         }

--- a/crates/burn-onnx/src/import/burn/node/conv2d.rs
+++ b/crates/burn-onnx/src/import/burn/node/conv2d.rs
@@ -1,5 +1,5 @@
 use super::prelude::*;
-use burn_store::TensorSnapshot;
+use burn_pack::Tensor as PackTensor;
 
 impl NodeCodegen for onnx_ir::conv2d::Conv2dNode {
     fn inputs(&self) -> &[Argument] {
@@ -51,7 +51,7 @@ impl NodeCodegen for onnx_ir::conv2d::Conv2dNode {
         ))
     }
 
-    fn collect_snapshots(&self, field_name: &str) -> Vec<TensorSnapshot> {
+    fn collect_snapshots(&self, field_name: &str) -> Vec<PackTensor> {
         use crate::burn::node_traits::create_lazy_snapshot;
 
         let mut snapshots = vec![];
@@ -59,7 +59,7 @@ impl NodeCodegen for onnx_ir::conv2d::Conv2dNode {
         // Weight tensor (input index 1)
         if let Some(weight_input) = self.inputs.get(1) {
             let weight_path = format!("{}.weight", field_name);
-            if let Some(snapshot) = create_lazy_snapshot(weight_input, &weight_path, "Conv2d") {
+            if let Some(snapshot) = create_lazy_snapshot(weight_input, &weight_path) {
                 snapshots.push(snapshot);
             }
         }
@@ -69,7 +69,7 @@ impl NodeCodegen for onnx_ir::conv2d::Conv2dNode {
             && let Some(bias_input) = self.inputs.get(2)
         {
             let bias_path = format!("{}.bias", field_name);
-            if let Some(snapshot) = create_lazy_snapshot(bias_input, &bias_path, "Conv2d") {
+            if let Some(snapshot) = create_lazy_snapshot(bias_input, &bias_path) {
                 snapshots.push(snapshot);
             }
         }

--- a/crates/burn-onnx/src/import/burn/node/conv3d.rs
+++ b/crates/burn-onnx/src/import/burn/node/conv3d.rs
@@ -1,5 +1,5 @@
 use super::prelude::*;
-use burn_store::TensorSnapshot;
+use burn_pack::Tensor as PackTensor;
 
 impl NodeCodegen for onnx_ir::conv3d::Conv3dNode {
     fn inputs(&self) -> &[Argument] {
@@ -68,14 +68,14 @@ impl NodeCodegen for onnx_ir::conv3d::Conv3dNode {
         imports.register("burn::nn::conv::Conv3dConfig");
     }
 
-    fn collect_snapshots(&self, field_name: &str) -> Vec<TensorSnapshot> {
+    fn collect_snapshots(&self, field_name: &str) -> Vec<PackTensor> {
         use crate::burn::node_traits::create_lazy_snapshot;
         let mut snapshots = vec![];
 
         // Weight tensor (input index 1)
         if let Some(weight_input) = self.inputs.get(1) {
             let weight_path = format!("{}.weight", field_name);
-            if let Some(snapshot) = create_lazy_snapshot(weight_input, &weight_path, "Conv3d") {
+            if let Some(snapshot) = create_lazy_snapshot(weight_input, &weight_path) {
                 snapshots.push(snapshot);
             }
         }
@@ -83,7 +83,7 @@ impl NodeCodegen for onnx_ir::conv3d::Conv3dNode {
         // Bias tensor if present (input index 2)
         if let Some(bias_input) = self.inputs.get(2) {
             let bias_path = format!("{}.bias", field_name);
-            if let Some(snapshot) = create_lazy_snapshot(bias_input, &bias_path, "Conv3d") {
+            if let Some(snapshot) = create_lazy_snapshot(bias_input, &bias_path) {
                 snapshots.push(snapshot);
             }
         }

--- a/crates/burn-onnx/src/import/burn/node/conv_transpose_1d.rs
+++ b/crates/burn-onnx/src/import/burn/node/conv_transpose_1d.rs
@@ -1,5 +1,5 @@
 use super::prelude::*;
-use burn_store::TensorSnapshot;
+use burn_pack::Tensor as PackTensor;
 
 impl NodeCodegen for onnx_ir::node::conv_transpose1d::ConvTranspose1dNode {
     fn inputs(&self) -> &[Argument] {
@@ -60,7 +60,7 @@ impl NodeCodegen for onnx_ir::node::conv_transpose1d::ConvTranspose1dNode {
         imports.register("burn::nn::conv::ConvTranspose1dConfig");
     }
 
-    fn collect_snapshots(&self, field_name: &str) -> Vec<TensorSnapshot> {
+    fn collect_snapshots(&self, field_name: &str) -> Vec<PackTensor> {
         use crate::burn::node_traits::create_lazy_snapshot;
 
         let mut snapshots = vec![];
@@ -71,9 +71,7 @@ impl NodeCodegen for onnx_ir::node::conv_transpose1d::ConvTranspose1dNode {
         // These layouts match! No transformation needed.
         if let Some(weight_input) = self.inputs.get(1) {
             let weight_path = format!("{}.weight", field_name);
-            if let Some(snapshot) =
-                create_lazy_snapshot(weight_input, &weight_path, "ConvTranspose1d")
-            {
+            if let Some(snapshot) = create_lazy_snapshot(weight_input, &weight_path) {
                 snapshots.push(snapshot);
             }
         }
@@ -83,8 +81,7 @@ impl NodeCodegen for onnx_ir::node::conv_transpose1d::ConvTranspose1dNode {
             && let Some(bias_input) = self.inputs.get(2)
         {
             let bias_path = format!("{}.bias", field_name);
-            if let Some(snapshot) = create_lazy_snapshot(bias_input, &bias_path, "ConvTranspose1d")
-            {
+            if let Some(snapshot) = create_lazy_snapshot(bias_input, &bias_path) {
                 snapshots.push(snapshot);
             }
         }

--- a/crates/burn-onnx/src/import/burn/node/conv_transpose_2d.rs
+++ b/crates/burn-onnx/src/import/burn/node/conv_transpose_2d.rs
@@ -1,5 +1,5 @@
 use super::prelude::*;
-use burn_store::TensorSnapshot;
+use burn_pack::Tensor as PackTensor;
 
 impl NodeCodegen for onnx_ir::node::conv_transpose2d::ConvTranspose2dNode {
     fn inputs(&self) -> &[Argument] {
@@ -59,7 +59,7 @@ impl NodeCodegen for onnx_ir::node::conv_transpose2d::ConvTranspose2dNode {
         imports.register("burn::nn::conv::ConvTranspose2dConfig");
     }
 
-    fn collect_snapshots(&self, field_name: &str) -> Vec<TensorSnapshot> {
+    fn collect_snapshots(&self, field_name: &str) -> Vec<PackTensor> {
         use crate::burn::node_traits::create_lazy_snapshot;
 
         let mut snapshots = vec![];
@@ -70,9 +70,7 @@ impl NodeCodegen for onnx_ir::node::conv_transpose2d::ConvTranspose2dNode {
         // These layouts match! No transformation needed.
         if let Some(weight_input) = self.inputs.get(1) {
             let weight_path = format!("{}.weight", field_name);
-            if let Some(snapshot) =
-                create_lazy_snapshot(weight_input, &weight_path, "ConvTranspose2d")
-            {
+            if let Some(snapshot) = create_lazy_snapshot(weight_input, &weight_path) {
                 snapshots.push(snapshot);
             }
         }
@@ -82,8 +80,7 @@ impl NodeCodegen for onnx_ir::node::conv_transpose2d::ConvTranspose2dNode {
             && let Some(bias_input) = self.inputs.get(2)
         {
             let bias_path = format!("{}.bias", field_name);
-            if let Some(snapshot) = create_lazy_snapshot(bias_input, &bias_path, "ConvTranspose2d")
-            {
+            if let Some(snapshot) = create_lazy_snapshot(bias_input, &bias_path) {
                 snapshots.push(snapshot);
             }
         }

--- a/crates/burn-onnx/src/import/burn/node/conv_transpose_3d.rs
+++ b/crates/burn-onnx/src/import/burn/node/conv_transpose_3d.rs
@@ -1,5 +1,5 @@
 use super::prelude::*;
-use burn_store::TensorSnapshot;
+use burn_pack::Tensor as PackTensor;
 
 impl NodeCodegen for onnx_ir::node::conv_transpose3d::ConvTranspose3dNode {
     fn inputs(&self) -> &[Argument] {
@@ -59,7 +59,7 @@ impl NodeCodegen for onnx_ir::node::conv_transpose3d::ConvTranspose3dNode {
         imports.register("burn::nn::conv::ConvTranspose3dConfig");
     }
 
-    fn collect_snapshots(&self, field_name: &str) -> Vec<TensorSnapshot> {
+    fn collect_snapshots(&self, field_name: &str) -> Vec<PackTensor> {
         use crate::burn::node_traits::create_lazy_snapshot;
 
         let mut snapshots = vec![];
@@ -70,9 +70,7 @@ impl NodeCodegen for onnx_ir::node::conv_transpose3d::ConvTranspose3dNode {
         // These layouts match! No transformation needed.
         if let Some(weight_input) = self.inputs.get(1) {
             let weight_path = format!("{}.weight", field_name);
-            if let Some(snapshot) =
-                create_lazy_snapshot(weight_input, &weight_path, "ConvTranspose3d")
-            {
+            if let Some(snapshot) = create_lazy_snapshot(weight_input, &weight_path) {
                 snapshots.push(snapshot);
             }
         }
@@ -82,8 +80,7 @@ impl NodeCodegen for onnx_ir::node::conv_transpose3d::ConvTranspose3dNode {
             && let Some(bias_input) = self.inputs.get(2)
         {
             let bias_path = format!("{}.bias", field_name);
-            if let Some(snapshot) = create_lazy_snapshot(bias_input, &bias_path, "ConvTranspose3d")
-            {
+            if let Some(snapshot) = create_lazy_snapshot(bias_input, &bias_path) {
                 snapshots.push(snapshot);
             }
         }

--- a/crates/burn-onnx/src/import/burn/node/deform_conv.rs
+++ b/crates/burn-onnx/src/import/burn/node/deform_conv.rs
@@ -1,5 +1,5 @@
 use super::prelude::*;
-use burn_store::TensorSnapshot;
+use burn_pack::Tensor as PackTensor;
 use onnx_ir::deform_conv::DeformConvNode;
 use onnx_ir::padding::PaddingConfig2d;
 
@@ -83,14 +83,14 @@ impl NodeCodegen for DeformConvNode {
         ))
     }
 
-    fn collect_snapshots(&self, field_name: &str) -> Vec<TensorSnapshot> {
+    fn collect_snapshots(&self, field_name: &str) -> Vec<PackTensor> {
         use crate::burn::node_traits::create_lazy_snapshot;
 
         let mut snapshots = vec![];
 
         if let Some(weight_input) = self.inputs.get(1) {
             let weight_path = format!("{}.weight", field_name);
-            if let Some(snapshot) = create_lazy_snapshot(weight_input, &weight_path, "DeformConv") {
+            if let Some(snapshot) = create_lazy_snapshot(weight_input, &weight_path) {
                 snapshots.push(snapshot);
             }
         }
@@ -99,7 +99,7 @@ impl NodeCodegen for DeformConvNode {
             && !bias_input.is_optional()
         {
             let bias_path = format!("{}.bias", field_name);
-            if let Some(snapshot) = create_lazy_snapshot(bias_input, &bias_path, "DeformConv") {
+            if let Some(snapshot) = create_lazy_snapshot(bias_input, &bias_path) {
                 snapshots.push(snapshot);
             }
         }

--- a/crates/burn-onnx/src/import/burn/node/group_norm.rs
+++ b/crates/burn-onnx/src/import/burn/node/group_norm.rs
@@ -1,6 +1,6 @@
 use super::broadcast_helpers::channel_broadcast_shape;
 use super::prelude::*;
-use burn_store::TensorSnapshot;
+use burn_pack::Tensor as PackTensor;
 use onnx_ir::node::group_norm::GroupNormalizationNode;
 
 /// True when both scale (input[1]) and bias (input[2]) were lifted to static
@@ -44,21 +44,21 @@ impl NodeCodegen for GroupNormalizationNode {
         ))
     }
 
-    fn collect_snapshots(&self, field_name: &str) -> Vec<TensorSnapshot> {
+    fn collect_snapshots(&self, field_name: &str) -> Vec<PackTensor> {
         use crate::burn::node_traits::create_lazy_snapshot;
 
         let mut snapshots = vec![];
 
         if let Some(gamma_input) = self.inputs.get(1) {
             let gamma_path = format!("{}.gamma", field_name);
-            if let Some(snapshot) = create_lazy_snapshot(gamma_input, &gamma_path, "GroupNorm") {
+            if let Some(snapshot) = create_lazy_snapshot(gamma_input, &gamma_path) {
                 snapshots.push(snapshot);
             }
         }
 
         if let Some(beta_input) = self.inputs.get(2) {
             let beta_path = format!("{}.beta", field_name);
-            if let Some(snapshot) = create_lazy_snapshot(beta_input, &beta_path, "GroupNorm") {
+            if let Some(snapshot) = create_lazy_snapshot(beta_input, &beta_path) {
                 snapshots.push(snapshot);
             }
         }

--- a/crates/burn-onnx/src/import/burn/node/gru.rs
+++ b/crates/burn-onnx/src/import/burn/node/gru.rs
@@ -21,7 +21,8 @@ use super::prelude::*;
 use super::rnn_common::{
     self, BiasLayout, GateLayout, ModuleExpr, state_direction_axis, y_direction_axis,
 };
-use burn_store::TensorSnapshot;
+use burn_pack::Tensor as PackTensor;
+use burn_store::bridge;
 use onnx_ir::gru::{GruActivationFunction, GruDirection};
 
 /// Collect tensor snapshots for GRU burnpack serialization.
@@ -40,7 +41,7 @@ fn collect_gru_snapshots(
     field_name: &str,
     inputs: &[Argument],
     config: &onnx_ir::gru::GruConfig,
-) -> Vec<TensorSnapshot> {
+) -> Vec<PackTensor> {
     use crate::burn::node_traits::extract_node_data;
     use burn::tensor::Tensor;
 
@@ -134,12 +135,7 @@ fn collect_gru_snapshots(
                 "{}.{}{}.input_transform.weight",
                 field_name, dir_prefix, gate_name
             );
-            snapshots.push(create_snapshot_from_data(
-                w_gate_data,
-                &path,
-                "Linear",
-                dtype,
-            ));
+            snapshots.push(create_snapshot_from_data(w_gate_data, &path, dtype));
 
             // Input transform bias: Wb for this gate
             if let Some(ref b) = b_dir {
@@ -153,7 +149,7 @@ fn collect_gru_snapshots(
                     "{}.{}{}.input_transform.bias",
                     field_name, dir_prefix, gate_name
                 );
-                snapshots.push(create_snapshot_from_data(bias_data, &path, "Linear", dtype));
+                snapshots.push(create_snapshot_from_data(bias_data, &path, dtype));
             }
 
             // Hidden transform weight: ONNX [hidden_size, hidden_size] -> Burn [hidden_size, hidden_size]
@@ -167,12 +163,7 @@ fn collect_gru_snapshots(
                 "{}.{}{}.hidden_transform.weight",
                 field_name, dir_prefix, gate_name
             );
-            snapshots.push(create_snapshot_from_data(
-                r_gate_data,
-                &path,
-                "Linear",
-                dtype,
-            ));
+            snapshots.push(create_snapshot_from_data(r_gate_data, &path, dtype));
 
             // Hidden transform bias: Rb for this gate
             if let Some(b) = &b_dir {
@@ -186,7 +177,7 @@ fn collect_gru_snapshots(
                     "{}.{}{}.hidden_transform.bias",
                     field_name, dir_prefix, gate_name
                 );
-                snapshots.push(create_snapshot_from_data(bias_data, &path, "Linear", dtype));
+                snapshots.push(create_snapshot_from_data(bias_data, &path, dtype));
             }
         }
     }
@@ -194,34 +185,18 @@ fn collect_gru_snapshots(
     snapshots
 }
 
-/// Create a TensorSnapshot from TensorData.
+/// Create a burnpack tensor from TensorData already in hand.
 fn create_snapshot_from_data(
     data: burn::tensor::TensorData,
     path: &str,
-    container_type: &str,
     dtype: burn::tensor::DType,
-) -> TensorSnapshot {
+) -> PackTensor {
     use burn::module::ParamId;
-    use burn_store::TensorSnapshotError;
 
+    // No-op when `data` already has the declared dtype; defensive otherwise.
     let data = data.convert_dtype(dtype);
 
-    let shape = data.shape.clone();
-    let path_stack: Vec<String> = path.split('.').map(String::from).collect();
-    let container_stack = vec![format!("Struct:{}", container_type)];
-
-    let data_fn = TensorSnapshot::data_fn(
-        move || -> Result<burn::tensor::TensorData, TensorSnapshotError> { Ok(data.clone()) },
-    );
-
-    TensorSnapshot::from_closure(
-        data_fn,
-        dtype,
-        shape,
-        path_stack,
-        container_stack,
-        ParamId::new(),
-    )
+    bridge::from_data(data, path.to_string(), Some(ParamId::new().val()))
 }
 
 /// Generate forward code for unidirectional (forward/reverse) GRU.
@@ -513,7 +488,7 @@ impl NodeCodegen for onnx_ir::gru::GruNode {
         rnn_common::field(&self.name, &self.inputs, ty, init)
     }
 
-    fn collect_snapshots(&self, field_name: &str) -> Vec<TensorSnapshot> {
+    fn collect_snapshots(&self, field_name: &str) -> Vec<PackTensor> {
         collect_gru_snapshots(field_name, &self.inputs, &self.config)
     }
 

--- a/crates/burn-onnx/src/import/burn/node/instance_norm.rs
+++ b/crates/burn-onnx/src/import/burn/node/instance_norm.rs
@@ -1,6 +1,6 @@
 use super::broadcast_helpers::channel_broadcast_shape;
 use super::prelude::*;
-use burn_store::TensorSnapshot;
+use burn_pack::Tensor as PackTensor;
 use onnx_ir::node::instance_norm::InstanceNormalizationNode;
 
 /// True when both scale (input[1]) and bias (input[2]) were lifted to static
@@ -43,21 +43,21 @@ impl NodeCodegen for InstanceNormalizationNode {
         ))
     }
 
-    fn collect_snapshots(&self, field_name: &str) -> Vec<TensorSnapshot> {
+    fn collect_snapshots(&self, field_name: &str) -> Vec<PackTensor> {
         use crate::burn::node_traits::create_lazy_snapshot;
 
         let mut snapshots = vec![];
 
         if let Some(gamma_input) = self.inputs.get(1) {
             let gamma_path = format!("{}.gamma", field_name);
-            if let Some(snapshot) = create_lazy_snapshot(gamma_input, &gamma_path, "InstanceNorm") {
+            if let Some(snapshot) = create_lazy_snapshot(gamma_input, &gamma_path) {
                 snapshots.push(snapshot);
             }
         }
 
         if let Some(beta_input) = self.inputs.get(2) {
             let beta_path = format!("{}.beta", field_name);
-            if let Some(snapshot) = create_lazy_snapshot(beta_input, &beta_path, "InstanceNorm") {
+            if let Some(snapshot) = create_lazy_snapshot(beta_input, &beta_path) {
                 snapshots.push(snapshot);
             }
         }

--- a/crates/burn-onnx/src/import/burn/node/layer_norm.rs
+++ b/crates/burn-onnx/src/import/burn/node/layer_norm.rs
@@ -1,4 +1,4 @@
-use burn_store::TensorSnapshot;
+use burn_pack::Tensor as PackTensor;
 
 use super::prelude::*;
 
@@ -35,7 +35,7 @@ impl NodeCodegen for onnx_ir::node::layer_norm::LayerNormalizationNode {
         ))
     }
 
-    fn collect_snapshots(&self, field_name: &str) -> Vec<TensorSnapshot> {
+    fn collect_snapshots(&self, field_name: &str) -> Vec<PackTensor> {
         use crate::burn::node_traits::create_lazy_snapshot;
 
         let mut snapshots = vec![];
@@ -43,7 +43,7 @@ impl NodeCodegen for onnx_ir::node::layer_norm::LayerNormalizationNode {
         // Gamma (scale) tensor at input index 1
         if let Some(gamma_input) = self.inputs.get(1) {
             let gamma_path = format!("{}.gamma", field_name);
-            if let Some(snapshot) = create_lazy_snapshot(gamma_input, &gamma_path, "LayerNorm") {
+            if let Some(snapshot) = create_lazy_snapshot(gamma_input, &gamma_path) {
                 snapshots.push(snapshot);
             }
         }
@@ -53,7 +53,7 @@ impl NodeCodegen for onnx_ir::node::layer_norm::LayerNormalizationNode {
             && let Some(beta_input) = self.inputs.get(2)
         {
             let beta_path = format!("{}.beta", field_name);
-            if let Some(snapshot) = create_lazy_snapshot(beta_input, &beta_path, "LayerNorm") {
+            if let Some(snapshot) = create_lazy_snapshot(beta_input, &beta_path) {
                 snapshots.push(snapshot);
             }
         }

--- a/crates/burn-onnx/src/import/burn/node/linear.rs
+++ b/crates/burn-onnx/src/import/burn/node/linear.rs
@@ -1,5 +1,5 @@
 use super::prelude::*;
-use burn_store::TensorSnapshot;
+use burn_pack::Tensor as PackTensor;
 
 impl NodeCodegen for onnx_ir::linear::LinearNode {
     fn inputs(&self) -> &[Argument] {
@@ -46,7 +46,7 @@ impl NodeCodegen for onnx_ir::linear::LinearNode {
         Some(Field::new(self.name.clone(), quote! { Linear }, init_code))
     }
 
-    fn collect_snapshots(&self, field_name: &str) -> Vec<TensorSnapshot> {
+    fn collect_snapshots(&self, field_name: &str) -> Vec<PackTensor> {
         use crate::burn::node_traits::create_lazy_snapshot;
 
         let mut snapshots = vec![];
@@ -55,7 +55,7 @@ impl NodeCodegen for onnx_ir::linear::LinearNode {
         // No transposition needed - LinearLayout::Col handles ONNX [out, in] format
         if let Some(weight_input) = self.inputs.get(1) {
             let weight_path = format!("{}.weight", field_name);
-            if let Some(snapshot) = create_lazy_snapshot(weight_input, &weight_path, "Linear") {
+            if let Some(snapshot) = create_lazy_snapshot(weight_input, &weight_path) {
                 snapshots.push(snapshot);
             }
         }
@@ -63,7 +63,7 @@ impl NodeCodegen for onnx_ir::linear::LinearNode {
         // Bias tensor (input index 2, optional)
         if let Some(bias_input) = self.inputs.get(2) {
             let bias_path = format!("{}.bias", field_name);
-            if let Some(snapshot) = create_lazy_snapshot(bias_input, &bias_path, "Linear") {
+            if let Some(snapshot) = create_lazy_snapshot(bias_input, &bias_path) {
                 snapshots.push(snapshot);
             }
         }

--- a/crates/burn-onnx/src/import/burn/node/lstm.rs
+++ b/crates/burn-onnx/src/import/burn/node/lstm.rs
@@ -24,7 +24,8 @@ use super::rnn_common::{
     y_direction_axis,
 };
 use burn::nn::activation::ActivationConfig;
-use burn_store::TensorSnapshot;
+use burn_pack::Tensor as PackTensor;
+use burn_store::bridge;
 use onnx_ir::lstm::{LstmActivationFunction, LstmDirection};
 
 /// Convert ONNX activation function to Burn ActivationConfig.
@@ -75,7 +76,7 @@ fn collect_lstm_snapshots(
     field_name: &str,
     inputs: &[Argument],
     config: &onnx_ir::lstm::LstmConfig,
-) -> Vec<TensorSnapshot> {
+) -> Vec<PackTensor> {
     use crate::burn::node_traits::extract_node_data;
     use burn::tensor::Tensor;
 
@@ -175,12 +176,7 @@ fn collect_lstm_snapshots(
                 "{}.{}{}.input_transform.weight",
                 field_name, dir_prefix, gate_name
             );
-            snapshots.push(create_snapshot_from_data(
-                w_gate_data,
-                &path,
-                "Linear",
-                dtype,
-            ));
+            snapshots.push(create_snapshot_from_data(w_gate_data, &path, dtype));
 
             // Input transform bias: Wb + Rb for this gate
             if let Some(ref b) = b_dir {
@@ -198,7 +194,7 @@ fn collect_lstm_snapshots(
                     "{}.{}{}.input_transform.bias",
                     field_name, dir_prefix, gate_name
                 );
-                snapshots.push(create_snapshot_from_data(bias_data, &path, "Linear", dtype));
+                snapshots.push(create_snapshot_from_data(bias_data, &path, dtype));
             }
 
             // Hidden transform weight: slice from R and transpose
@@ -213,12 +209,7 @@ fn collect_lstm_snapshots(
                 "{}.{}{}.hidden_transform.weight",
                 field_name, dir_prefix, gate_name
             );
-            snapshots.push(create_snapshot_from_data(
-                r_gate_data,
-                &path,
-                "Linear",
-                dtype,
-            ));
+            snapshots.push(create_snapshot_from_data(r_gate_data, &path, dtype));
 
             // Hidden transform bias: zeros (combined bias is in input_transform)
             if b_dir.is_some() {
@@ -229,9 +220,7 @@ fn collect_lstm_snapshots(
                     "{}.{}{}.hidden_transform.bias",
                     field_name, dir_prefix, gate_name
                 );
-                snapshots.push(create_snapshot_from_data(
-                    zeros_data, &path, "Linear", dtype,
-                ));
+                snapshots.push(create_snapshot_from_data(zeros_data, &path, dtype));
             }
         }
     }
@@ -239,7 +228,7 @@ fn collect_lstm_snapshots(
     snapshots
 }
 
-/// Create a TensorSnapshot from TensorData.
+/// Create a burnpack tensor from TensorData already in hand.
 ///
 /// Normalizes the data back to the target dtype as a safety net. The upstream
 /// weight-slicing pipeline already pins the dtype when building the intermediate
@@ -250,31 +239,14 @@ fn collect_lstm_snapshots(
 fn create_snapshot_from_data(
     data: burn::tensor::TensorData,
     path: &str,
-    container_type: &str,
     dtype: burn::tensor::DType,
-) -> TensorSnapshot {
+) -> PackTensor {
     use burn::module::ParamId;
-    use burn_store::TensorSnapshotError;
 
     // No-op when `data` already has the declared dtype; defensive otherwise.
     let data = data.convert_dtype(dtype);
 
-    let shape = data.shape.clone();
-    let path_stack: Vec<String> = path.split('.').map(String::from).collect();
-    let container_stack = vec![format!("Struct:{}", container_type)];
-
-    let data_fn = TensorSnapshot::data_fn(
-        move || -> Result<burn::tensor::TensorData, TensorSnapshotError> { Ok(data.clone()) },
-    );
-
-    TensorSnapshot::from_closure(
-        data_fn,
-        dtype,
-        shape,
-        path_stack,
-        container_stack,
-        ParamId::new(),
-    )
+    bridge::from_data(data, path.to_string(), Some(ParamId::new().val()))
 }
 
 /// Convert ActivationConfig to tokens for code generation
@@ -402,7 +374,7 @@ impl NodeCodegen for onnx_ir::lstm::LstmNode {
         rnn_common::field(&self.name, &self.inputs, ty, init)
     }
 
-    fn collect_snapshots(&self, field_name: &str) -> Vec<TensorSnapshot> {
+    fn collect_snapshots(&self, field_name: &str) -> Vec<PackTensor> {
         collect_lstm_snapshots(field_name, &self.inputs, &self.config)
     }
 

--- a/crates/burn-onnx/src/import/burn/node/prelu.rs
+++ b/crates/burn-onnx/src/import/burn/node/prelu.rs
@@ -1,7 +1,7 @@
 use super::broadcast_helpers;
 use super::prelude::*;
 use burn::tensor::Shape;
-use burn_store::TensorSnapshot;
+use burn_pack::Tensor as PackTensor;
 use onnx_ir::ir::ArgType;
 use onnx_ir::prelu::PReluNode;
 
@@ -49,14 +49,14 @@ impl NodeCodegen for PReluNode {
         ))
     }
 
-    fn collect_snapshots(&self, field_name: &str) -> Vec<TensorSnapshot> {
+    fn collect_snapshots(&self, field_name: &str) -> Vec<PackTensor> {
         use crate::burn::node_traits::create_lazy_snapshot;
 
         let mut snapshots = vec![];
 
         if let Some(alpha_input) = self.inputs.get(1) {
             let alpha_path = format!("{}.alpha", field_name);
-            if let Some(mut snapshot) = create_lazy_snapshot(alpha_input, &alpha_path, "PRelu") {
+            if let Some(mut snapshot) = create_lazy_snapshot(alpha_input, &alpha_path) {
                 snapshot.shape = Shape::from([num_parameters(self)]);
                 snapshots.push(snapshot);
             }

--- a/crates/burn-onnx/src/import/burn/node/rnn.rs
+++ b/crates/burn-onnx/src/import/burn/node/rnn.rs
@@ -20,7 +20,8 @@ use super::rnn_common::{
     y_direction_axis,
 };
 use burn::nn::activation::ActivationConfig;
-use burn_store::TensorSnapshot;
+use burn_pack::Tensor as PackTensor;
+use burn_store::bridge;
 use onnx_ir::rnn::{RnnActivationFunction, RnnDirection};
 
 /// Convert ONNX activation function to Burn ActivationConfig.
@@ -70,7 +71,7 @@ fn collect_rnn_snapshots(
     field_name: &str,
     inputs: &[Argument],
     config: &onnx_ir::rnn::RnnConfig,
-) -> Vec<TensorSnapshot> {
+) -> Vec<PackTensor> {
     use crate::burn::node_traits::extract_node_data;
     use burn::tensor::Tensor;
 
@@ -168,12 +169,7 @@ fn collect_rnn_snapshots(
             "{}.{}{}.input_transform.weight",
             field_name, dir_prefix, gate_name
         );
-        snapshots.push(create_snapshot_from_data(
-            w_gate_data,
-            &path,
-            "Linear",
-            dtype,
-        ));
+        snapshots.push(create_snapshot_from_data(w_gate_data, &path, dtype));
 
         // Input transform bias: Wb + Rb for this gate
         if let Some(ref b) = b_dir {
@@ -191,7 +187,7 @@ fn collect_rnn_snapshots(
                 "{}.{}{}.input_transform.bias",
                 field_name, dir_prefix, gate_name
             );
-            snapshots.push(create_snapshot_from_data(bias_data, &path, "Linear", dtype));
+            snapshots.push(create_snapshot_from_data(bias_data, &path, dtype));
         }
 
         // Hidden transform weight: slice from R and transpose
@@ -206,12 +202,7 @@ fn collect_rnn_snapshots(
             "{}.{}{}.hidden_transform.weight",
             field_name, dir_prefix, gate_name
         );
-        snapshots.push(create_snapshot_from_data(
-            r_gate_data,
-            &path,
-            "Linear",
-            dtype,
-        ));
+        snapshots.push(create_snapshot_from_data(r_gate_data, &path, dtype));
 
         // Hidden transform bias: zeros (combined bias is in input_transform)
         if b_dir.is_some() {
@@ -222,16 +213,14 @@ fn collect_rnn_snapshots(
                 "{}.{}{}.hidden_transform.bias",
                 field_name, dir_prefix, gate_name
             );
-            snapshots.push(create_snapshot_from_data(
-                zeros_data, &path, "Linear", dtype,
-            ));
+            snapshots.push(create_snapshot_from_data(zeros_data, &path, dtype));
         }
     }
 
     snapshots
 }
 
-/// Create a TensorSnapshot from TensorData.
+/// Create a burnpack tensor from TensorData already in hand.
 ///
 /// Normalizes the data back to the target dtype as a safety net. The upstream
 /// weight-slicing pipeline already pins the dtype when building the intermediate
@@ -242,31 +231,14 @@ fn collect_rnn_snapshots(
 fn create_snapshot_from_data(
     data: burn::tensor::TensorData,
     path: &str,
-    container_type: &str,
     dtype: burn::tensor::DType,
-) -> TensorSnapshot {
+) -> PackTensor {
     use burn::module::ParamId;
-    use burn_store::TensorSnapshotError;
 
     // No-op when `data` already has the declared dtype; defensive otherwise.
     let data = data.convert_dtype(dtype);
 
-    let shape = data.shape.clone();
-    let path_stack: Vec<String> = path.split('.').map(String::from).collect();
-    let container_stack = vec![format!("Struct:{}", container_type)];
-
-    let data_fn = TensorSnapshot::data_fn(
-        move || -> Result<burn::tensor::TensorData, TensorSnapshotError> { Ok(data.clone()) },
-    );
-
-    TensorSnapshot::from_closure(
-        data_fn,
-        dtype,
-        shape,
-        path_stack,
-        container_stack,
-        ParamId::new(),
-    )
+    bridge::from_data(data, path.to_string(), Some(ParamId::new().val()))
 }
 
 /// Convert ActivationConfig to tokens for code generation
@@ -371,7 +343,7 @@ impl NodeCodegen for onnx_ir::rnn::RnnNode {
         rnn_common::field(&self.name, &self.inputs, ty, init)
     }
 
-    fn collect_snapshots(&self, field_name: &str) -> Vec<TensorSnapshot> {
+    fn collect_snapshots(&self, field_name: &str) -> Vec<PackTensor> {
         collect_rnn_snapshots(field_name, &self.inputs, &self.config)
     }
 

--- a/crates/burn-onnx/src/import/burn/node_codegen.rs
+++ b/crates/burn-onnx/src/import/burn/node_codegen.rs
@@ -8,7 +8,7 @@ use crate::burn::custom_op::{CustomOp, HookRegistry};
 use crate::burn::scope::ScopeAtPosition;
 use crate::burn::{BurnImports, Field};
 use crate::ext::{CodegenContext, Imports};
-use burn_store::TensorSnapshot;
+use burn_pack::Tensor as PackTensor;
 
 // ============================================================================
 // Hook-aware dispatch
@@ -92,7 +92,7 @@ pub(crate) fn node_collect_snapshots(
     node: &Node,
     field_name: &str,
     hooks: &HookRegistry,
-) -> Vec<TensorSnapshot> {
+) -> Vec<PackTensor> {
     if let Some(over) = hooks.override_for(&node.node_type()) {
         return expect_hook(
             over.collect_snapshots(node, field_name),
@@ -165,7 +165,7 @@ macro_rules! impl_node_codegen_dispatch {
                 }
             }
 
-            fn collect_snapshots(&self, field_name: &str) -> Vec<TensorSnapshot> {
+            fn collect_snapshots(&self, field_name: &str) -> Vec<PackTensor> {
                 match self {
                     $(Node::$variant(n) => n.collect_snapshots(field_name),)*
                     _ => vec![],

--- a/crates/burn-onnx/src/import/burn/node_traits.rs
+++ b/crates/burn-onnx/src/import/burn/node_traits.rs
@@ -318,4 +318,38 @@ mod tests {
 
         assert!(create_lazy_snapshot(&arg, "deform_conv1.bias").is_none());
     }
+
+    /// An unlifted constant fails when the writer draws its bytes, and that failure has to
+    /// name both ends: the burnpack path to locate it in the model, and the ONNX argument to
+    /// locate it in the graph. The path comes from burn-pack, whose writer annotates every
+    /// provider error with the tensor it was drawing; the argument name comes from the
+    /// closure here. Neither alone is enough to act on.
+    #[test]
+    fn unlifted_constant_write_failure_names_path_and_argument() {
+        use onnx_ir::ir::{ArgType, Argument, TensorType, ValueSource};
+
+        let mut arg = Argument::new(
+            "onnx_initializer_7",
+            ArgType::Tensor(TensorType {
+                dtype: DType::F32,
+                rank: 1,
+                static_shape: Some(vec![Some(3)]),
+            }),
+        );
+        // Claims to be a constant, but nothing ever lifted a value into the store.
+        arg.value_source = ValueSource::Constant;
+
+        let tensor = create_lazy_snapshot(&arg, "conv1.weight").expect("a constant is snapshotted");
+
+        let err = burn_pack::Writer::new(vec![tensor])
+            .into_bytes()
+            .expect_err("an unlifted constant must fail the write");
+
+        let msg = err.to_string();
+        assert!(msg.contains("conv1.weight"), "missing burnpack path: {msg}");
+        assert!(
+            msg.contains("onnx_initializer_7"),
+            "missing ONNX argument name: {msg}"
+        );
+    }
 }

--- a/crates/burn-onnx/src/import/burn/node_traits.rs
+++ b/crates/burn-onnx/src/import/burn/node_traits.rs
@@ -1,7 +1,8 @@
 extern crate alloc;
 
 use burn::tensor::Shape;
-use burn_store::{TensorSnapshot, TensorSnapshotError};
+use burn_pack::{Error as PackError, Tensor as PackTensor};
+use burn_store::bridge;
 use proc_macro2::{Ident, Span, TokenStream};
 
 use onnx_ir::Argument;
@@ -128,7 +129,7 @@ pub trait NodeCodegen: std::fmt::Debug {
     /// # Notes
     ///
     /// For nodes without learnable parameters, the default implementation returns an empty vec.
-    fn collect_snapshots(&self, _field_name: &str) -> Vec<TensorSnapshot> {
+    fn collect_snapshots(&self, _field_name: &str) -> Vec<PackTensor> {
         vec![]
     }
 }
@@ -185,25 +186,21 @@ pub fn arg_to_ident(arg: &Argument) -> proc_macro2::Ident {
 // device's default `FloatDType`, which can silently truncate f64 weights to
 // f32 before they enter the snapshot pipeline.
 
-/// Create a lazy tensor snapshot from an ONNX argument.
+/// Create a lazy burnpack tensor from an ONNX argument.
 ///
-/// This creates a TensorSnapshot that lazily loads tensor data only when needed.
-/// The closure captures the argument and calls `value()` only when `to_data()` is invoked.
+/// The returned tensor carries only metadata until its bytes are drawn: the closure
+/// captures the argument and calls `value()` only when the writer asks for the data.
+/// That keeps a save's peak memory bounded by the largest single tensor.
 ///
 /// # Arguments
 ///
 /// * `input` - The ONNX argument containing tensor data
 /// * `path` - The tensor path (e.g., "linear1.weight")
-/// * `container_type` - The container type (e.g., "Linear")
 ///
 /// # Returns
 ///
-/// A TensorSnapshot with lazy data loading
-pub fn create_lazy_snapshot(
-    input: &Argument,
-    path: &str,
-    container_type: &str,
-) -> Option<TensorSnapshot> {
+/// A deferred [`PackTensor`], or `None` when the input carries no static data
+pub fn create_lazy_snapshot(input: &Argument, path: &str) -> Option<PackTensor> {
     use burn::module::ParamId;
     use burn::tensor::TensorData;
     use onnx_ir::ir::ArgType;
@@ -230,32 +227,25 @@ pub fn create_lazy_snapshot(
     // Clone the input for the closure (lightweight, doesn't copy tensor data)
     let input_clone = input.clone();
 
-    // Create a lazy closure that only loads data when called
-    let data_fn = TensorSnapshot::data_fn(move || -> Result<TensorData, TensorSnapshotError> {
-        let mut data = input_clone.value().ok_or_else(|| {
-            TensorSnapshotError::DataError(format!(
-                "Failed to extract tensor data for '{}'",
-                input_clone.name
-            ))
-        })?;
-        // Scalar data has shape [], but Param<Tensor<1>> expects shape [1]
-        if is_scalar && data.shape.is_empty() {
-            data.shape = Shape::from([1]);
-        }
-        Ok(data)
-    });
-
-    // Parse path into path_stack
-    let path_stack: Vec<String> = path.split('.').map(String::from).collect();
-    let container_stack = vec![format!("Struct:{}", container_type)];
-
-    Some(TensorSnapshot::from_closure(
-        data_fn,
+    // Only loads data when the writer draws the bytes.
+    Some(bridge::deferred(
+        path.to_string(),
         dtype,
         shape,
-        path_stack,
-        container_stack,
-        ParamId::new(),
+        Some(ParamId::new().val()),
+        move || -> Result<TensorData, PackError> {
+            let mut data = input_clone.value().ok_or_else(|| {
+                PackError::ValidationError(format!(
+                    "Failed to extract tensor data for '{}'",
+                    input_clone.name
+                ))
+            })?;
+            // Scalar data has shape [], but Param<Tensor<1>> expects shape [1]
+            if is_scalar && data.shape.is_empty() {
+                data.shape = Shape::from([1]);
+            }
+            Ok(data)
+        },
     ))
 }
 
@@ -309,7 +299,7 @@ mod tests {
             }),
         );
         assert_eq!(arg.value_source, ValueSource::Dynamic);
-        assert!(create_lazy_snapshot(&arg, "prelu1.alpha", "PRelu").is_none());
+        assert!(create_lazy_snapshot(&arg, "prelu1.alpha").is_none());
     }
 
     #[test]
@@ -326,6 +316,6 @@ mod tests {
         );
         assert_eq!(arg.value_source, ValueSource::Optional);
 
-        assert!(create_lazy_snapshot(&arg, "deform_conv1.bias", "DeformConv").is_none());
+        assert!(create_lazy_snapshot(&arg, "deform_conv1.bias").is_none());
     }
 }

--- a/crates/burn-onnx/src/import/ext.rs
+++ b/crates/burn-onnx/src/import/ext.rs
@@ -25,7 +25,8 @@ pub use onnx_ir::{
     TensorData, TensorType,
 };
 
-pub use burn_store::TensorSnapshot;
+pub use burn_pack::{Error as PackError, Tensor as PackTensor};
+pub use burn_store::bridge;
 
 pub use proc_macro2;
 pub use quote;

--- a/crates/model-checks/albert/Cargo.toml
+++ b/crates/model-checks/albert/Cargo.toml
@@ -14,7 +14,7 @@ metal = ["burn/metal", "burn/autotune", "burn/fusion"]
 
 [dependencies]
 burn = { workspace = true }
-burn-store = { workspace = true, features = ["std", "burnpack", "pytorch"] }
+burn-store = { workspace = true, features = ["std", "pytorch"] }
 model-checks-common = { workspace = true }
 
 [build-dependencies]

--- a/crates/model-checks/alexnet/Cargo.toml
+++ b/crates/model-checks/alexnet/Cargo.toml
@@ -13,7 +13,7 @@ metal = ["burn/metal", "burn/autotune", "burn/fusion"]
 
 [dependencies]
 burn = { workspace = true }
-burn-store = { workspace = true, features = ["std", "burnpack", "pytorch"] }
+burn-store = { workspace = true, features = ["std", "pytorch"] }
 model-checks-common = { workspace = true }
 
 [build-dependencies]

--- a/crates/model-checks/all-minilm-l6-v2/Cargo.toml
+++ b/crates/model-checks/all-minilm-l6-v2/Cargo.toml
@@ -14,7 +14,7 @@ metal = ["burn/metal", "burn/autotune", "burn/fusion"]
 
 [dependencies]
 burn = { workspace = true }
-burn-store = { workspace = true, features = ["std", "burnpack", "pytorch"] }
+burn-store = { workspace = true, features = ["std", "pytorch"] }
 model-checks-common = { workspace = true }
 
 [build-dependencies]

--- a/crates/model-checks/arcface/Cargo.toml
+++ b/crates/model-checks/arcface/Cargo.toml
@@ -14,7 +14,7 @@ metal = ["burn/metal", "burn/autotune", "burn/fusion"]
 
 [dependencies]
 burn = { workspace = true }
-burn-store = { workspace = true, features = ["std", "burnpack", "pytorch"] }
+burn-store = { workspace = true, features = ["std", "pytorch"] }
 model-checks-common = { workspace = true }
 
 [build-dependencies]

--- a/crates/model-checks/clip-vit-b-32-text/Cargo.toml
+++ b/crates/model-checks/clip-vit-b-32-text/Cargo.toml
@@ -14,7 +14,7 @@ metal = ["burn/metal", "burn/autotune", "burn/fusion"]
 
 [dependencies]
 burn = { workspace = true }
-burn-store = { workspace = true, features = ["std", "burnpack", "pytorch"] }
+burn-store = { workspace = true, features = ["std", "pytorch"] }
 model-checks-common = { workspace = true }
 
 [build-dependencies]

--- a/crates/model-checks/clip-vit-b-32-vision/Cargo.toml
+++ b/crates/model-checks/clip-vit-b-32-vision/Cargo.toml
@@ -14,7 +14,7 @@ metal = ["burn/metal", "burn/autotune", "burn/fusion"]
 
 [dependencies]
 burn = { workspace = true }
-burn-store = { workspace = true, features = ["std", "burnpack", "pytorch"] }
+burn-store = { workspace = true, features = ["std", "pytorch"] }
 model-checks-common = { workspace = true }
 
 [build-dependencies]

--- a/crates/model-checks/densenet121/Cargo.toml
+++ b/crates/model-checks/densenet121/Cargo.toml
@@ -13,7 +13,7 @@ metal = ["burn/metal", "burn/autotune", "burn/fusion"]
 
 [dependencies]
 burn = { workspace = true }
-burn-store = { workspace = true, features = ["std", "burnpack", "pytorch"] }
+burn-store = { workspace = true, features = ["std", "pytorch"] }
 model-checks-common = { workspace = true }
 
 [build-dependencies]

--- a/crates/model-checks/depth-anything-v2/Cargo.toml
+++ b/crates/model-checks/depth-anything-v2/Cargo.toml
@@ -14,7 +14,7 @@ metal = ["burn/metal", "burn/autotune", "burn/fusion"]
 
 [dependencies]
 burn = { workspace = true }
-burn-store = { workspace = true, features = ["std", "burnpack", "pytorch"] }
+burn-store = { workspace = true, features = ["std", "pytorch"] }
 model-checks-common = { workspace = true }
 
 [build-dependencies]

--- a/crates/model-checks/depth-pro/Cargo.toml
+++ b/crates/model-checks/depth-pro/Cargo.toml
@@ -14,7 +14,7 @@ metal = ["burn/metal", "burn/autotune", "burn/fusion"]
 
 [dependencies]
 burn = { workspace = true }
-burn-store = { workspace = true, features = ["std", "burnpack", "pytorch"] }
+burn-store = { workspace = true, features = ["std", "pytorch"] }
 model-checks-common = { workspace = true }
 
 [build-dependencies]

--- a/crates/model-checks/inception-v1/Cargo.toml
+++ b/crates/model-checks/inception-v1/Cargo.toml
@@ -13,7 +13,7 @@ metal = ["burn/metal", "burn/autotune", "burn/fusion"]
 
 [dependencies]
 burn = { workspace = true }
-burn-store = { workspace = true, features = ["std", "burnpack", "pytorch"] }
+burn-store = { workspace = true, features = ["std", "pytorch"] }
 model-checks-common = { workspace = true }
 
 [build-dependencies]

--- a/crates/model-checks/inception-v2/Cargo.toml
+++ b/crates/model-checks/inception-v2/Cargo.toml
@@ -13,7 +13,7 @@ metal = ["burn/metal", "burn/autotune", "burn/fusion"]
 
 [dependencies]
 burn = { workspace = true }
-burn-store = { workspace = true, features = ["std", "burnpack", "pytorch"] }
+burn-store = { workspace = true, features = ["std", "pytorch"] }
 model-checks-common = { workspace = true }
 
 [build-dependencies]

--- a/crates/model-checks/kokoro/Cargo.toml
+++ b/crates/model-checks/kokoro/Cargo.toml
@@ -18,7 +18,7 @@ bisect = []
 
 [dependencies]
 burn = { workspace = true }
-burn-store = { workspace = true, features = ["std", "burnpack"] }
+burn-store = { workspace = true, features = ["std"] }
 model-checks-common = { workspace = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/model-checks/mediapipe-face-detector/Cargo.toml
+++ b/crates/model-checks/mediapipe-face-detector/Cargo.toml
@@ -14,7 +14,7 @@ metal = ["burn/metal", "burn/autotune", "burn/fusion"]
 
 [dependencies]
 burn = { workspace = true }
-burn-store = { workspace = true, features = ["std", "burnpack", "pytorch"] }
+burn-store = { workspace = true, features = ["std", "pytorch"] }
 model-checks-common = { workspace = true }
 
 [build-dependencies]

--- a/crates/model-checks/mobilenet-v2/Cargo.toml
+++ b/crates/model-checks/mobilenet-v2/Cargo.toml
@@ -13,7 +13,7 @@ metal = ["burn/metal", "burn/autotune", "burn/fusion"]
 
 [dependencies]
 burn = { workspace = true }
-burn-store = { workspace = true, features = ["std", "burnpack", "pytorch"] }
+burn-store = { workspace = true, features = ["std", "pytorch"] }
 model-checks-common = { workspace = true }
 
 [build-dependencies]

--- a/crates/model-checks/modernbert-base/Cargo.toml
+++ b/crates/model-checks/modernbert-base/Cargo.toml
@@ -14,7 +14,7 @@ metal = ["burn/metal", "burn/autotune", "burn/fusion"]
 
 [dependencies]
 burn = { workspace = true }
-burn-store = { workspace = true, features = ["std", "burnpack", "pytorch"] }
+burn-store = { workspace = true, features = ["std", "pytorch"] }
 model-checks-common = { workspace = true }
 
 [build-dependencies]

--- a/crates/model-checks/qwen/Cargo.toml
+++ b/crates/model-checks/qwen/Cargo.toml
@@ -14,7 +14,7 @@ metal = ["burn/metal", "burn/autotune", "burn/fusion"]
 
 [dependencies]
 burn = { workspace = true }
-burn-store = { workspace = true, features = ["std", "burnpack", "pytorch"] }
+burn-store = { workspace = true, features = ["std", "pytorch"] }
 model-checks-common = { workspace = true }
 
 [build-dependencies]

--- a/crates/model-checks/resnet50/Cargo.toml
+++ b/crates/model-checks/resnet50/Cargo.toml
@@ -13,7 +13,7 @@ metal = ["burn/metal", "burn/autotune", "burn/fusion"]
 
 [dependencies]
 burn = { workspace = true }
-burn-store = { workspace = true, features = ["std", "burnpack", "pytorch"] }
+burn-store = { workspace = true, features = ["std", "pytorch"] }
 model-checks-common = { workspace = true }
 
 [build-dependencies]

--- a/crates/model-checks/rf-detr/Cargo.toml
+++ b/crates/model-checks/rf-detr/Cargo.toml
@@ -14,7 +14,7 @@ metal = ["burn/metal", "burn/autotune", "burn/fusion"]
 
 [dependencies]
 burn = { workspace = true }
-burn-store = { workspace = true, features = ["std", "burnpack", "pytorch"] }
+burn-store = { workspace = true, features = ["std", "pytorch"] }
 model-checks-common = { workspace = true }
 
 [build-dependencies]

--- a/crates/model-checks/rtmw3d/Cargo.toml
+++ b/crates/model-checks/rtmw3d/Cargo.toml
@@ -14,7 +14,7 @@ metal = ["burn/metal", "burn/autotune", "burn/fusion"]
 
 [dependencies]
 burn = { workspace = true }
-burn-store = { workspace = true, features = ["std", "burnpack", "pytorch"] }
+burn-store = { workspace = true, features = ["std", "pytorch"] }
 model-checks-common = { workspace = true }
 
 [build-dependencies]

--- a/crates/model-checks/shufflenet/Cargo.toml
+++ b/crates/model-checks/shufflenet/Cargo.toml
@@ -13,7 +13,7 @@ metal = ["burn/metal", "burn/autotune", "burn/fusion"]
 
 [dependencies]
 burn = { workspace = true }
-burn-store = { workspace = true, features = ["std", "burnpack", "pytorch"] }
+burn-store = { workspace = true, features = ["std", "pytorch"] }
 model-checks-common = { workspace = true }
 
 [build-dependencies]

--- a/crates/model-checks/silero-vad/Cargo.toml
+++ b/crates/model-checks/silero-vad/Cargo.toml
@@ -14,7 +14,7 @@ metal = ["burn/metal", "burn/autotune", "burn/fusion"]
 
 [dependencies]
 burn = { workspace = true }
-burn-store = { workspace = true, features = ["std", "burnpack"] }
+burn-store = { workspace = true, features = ["std"] }
 model-checks-common = { workspace = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/model-checks/smollm/Cargo.toml
+++ b/crates/model-checks/smollm/Cargo.toml
@@ -14,7 +14,7 @@ metal = ["burn/metal", "burn/autotune", "burn/fusion"]
 
 [dependencies]
 burn = { workspace = true }
-burn-store = { workspace = true, features = ["std", "burnpack", "pytorch"] }
+burn-store = { workspace = true, features = ["std", "pytorch"] }
 model-checks-common = { workspace = true }
 
 [build-dependencies]

--- a/crates/model-checks/squeezenet/Cargo.toml
+++ b/crates/model-checks/squeezenet/Cargo.toml
@@ -13,7 +13,7 @@ metal = ["burn/metal", "burn/autotune", "burn/fusion"]
 
 [dependencies]
 burn = { workspace = true }
-burn-store = { workspace = true, features = ["std", "burnpack", "pytorch"] }
+burn-store = { workspace = true, features = ["std", "pytorch"] }
 model-checks-common = { workspace = true }
 
 [build-dependencies]

--- a/crates/model-checks/stable-diffusion-xl/Cargo.toml
+++ b/crates/model-checks/stable-diffusion-xl/Cargo.toml
@@ -14,7 +14,7 @@ metal = ["burn/metal", "burn/autotune", "burn/fusion"]
 
 [dependencies]
 burn = { workspace = true }
-burn-store = { workspace = true, features = ["std", "burnpack", "pytorch"] }
+burn-store = { workspace = true, features = ["std", "pytorch"] }
 model-checks-common = { workspace = true }
 
 [build-dependencies]

--- a/crates/model-checks/vgg19/Cargo.toml
+++ b/crates/model-checks/vgg19/Cargo.toml
@@ -13,7 +13,7 @@ metal = ["burn/metal", "burn/autotune", "burn/fusion"]
 
 [dependencies]
 burn = { workspace = true }
-burn-store = { workspace = true, features = ["std", "burnpack", "pytorch"] }
+burn-store = { workspace = true, features = ["std", "pytorch"] }
 model-checks-common = { workspace = true }
 
 [build-dependencies]

--- a/crates/model-checks/yolo/Cargo.toml
+++ b/crates/model-checks/yolo/Cargo.toml
@@ -14,7 +14,7 @@ metal = ["burn/metal", "burn/autotune", "burn/fusion"]
 
 [dependencies]
 burn = { workspace = true }
-burn-store = { workspace = true, features = ["std", "burnpack", "pytorch"] }
+burn-store = { workspace = true, features = ["std", "pytorch"] }
 model-checks-common = { workspace = true }
 
 [build-dependencies]

--- a/crates/model-checks/zfnet512/Cargo.toml
+++ b/crates/model-checks/zfnet512/Cargo.toml
@@ -13,7 +13,7 @@ metal = ["burn/metal", "burn/autotune", "burn/fusion"]
 
 [dependencies]
 burn = { workspace = true }
-burn-store = { workspace = true, features = ["std", "burnpack", "pytorch"] }
+burn-store = { workspace = true, features = ["std", "pytorch"] }
 model-checks-common = { workspace = true }
 
 [build-dependencies]

--- a/crates/onnx-official-tests/Cargo.toml
+++ b/crates/onnx-official-tests/Cargo.toml
@@ -23,7 +23,7 @@ toml = { workspace = true }
 
 [dev-dependencies]
 burn = { workspace = true }
-burn-store = { workspace = true, features = ["std", "burnpack"] }
+burn-store = { workspace = true, features = ["std"] }
 float-cmp = { workspace = true }
 
 [build-dependencies]

--- a/crates/onnx-tests/Cargo.toml
+++ b/crates/onnx-tests/Cargo.toml
@@ -13,7 +13,7 @@ test-metal = ["burn/metal"]
 
 [dev-dependencies]
 burn = { workspace = true }
-burn-store = { workspace = true, features = ["std", "burnpack"] }
+burn-store = { workspace = true, features = ["std"] }
 serde = { workspace = true }
 float-cmp = { workspace = true }
 insta = { workspace = true }

--- a/examples/custom-op-hooks/Cargo.toml
+++ b/examples/custom-op-hooks/Cargo.toml
@@ -10,7 +10,7 @@ workspace = true
 
 [dependencies]
 burn = { workspace = true, features = ["flex"] }
-burn-store = { workspace = true, features = ["std", "burnpack"] }
+burn-store = { workspace = true, features = ["std"] }
 
 [build-dependencies]
 burn-onnx = { workspace = true, features = ["default"] }

--- a/examples/image-classification-web/Cargo.toml
+++ b/examples/image-classification-web/Cargo.toml
@@ -19,7 +19,7 @@ default = []
 burn = { workspace = true, default-features = false, features = [
     "flex", "webgpu",
 ] }
-burn-store = { workspace = true, default-features = false, features = ["burnpack"] }
+burn-store = { workspace = true, default-features = false }
 
 log = { workspace = true }
 serde = { workspace = true }

--- a/examples/onnx-inference/Cargo.toml
+++ b/examples/onnx-inference/Cargo.toml
@@ -11,7 +11,7 @@ workspace = true
 
 [dependencies]
 burn = { workspace = true, features = ["flex", "dataset", "vision"] }
-burn-store = { workspace = true, features = ["std", "burnpack"] }
+burn-store = { workspace = true, features = ["std"] }
 serde = { workspace = true }
 
 [build-dependencies]

--- a/examples/onnx-inference/README.md
+++ b/examples/onnx-inference/README.md
@@ -26,11 +26,11 @@ https://huggingface.co/datasets/ylecun/mnist/viewer/mnist/test?row=15
 
 ## How to import
 
-1. Add `burn-store` with the `burnpack` feature to your `Cargo.toml` dependencies:
+1. Add `burn-store` to your `Cargo.toml` dependencies:
    ```toml
    [dependencies]
    burn = { version = "0.21", features = ["flex"] }
-   burn-store = { version = "0.21", features = ["burnpack"] }
+   burn-store = { version = "0.21" }
 
    [build-dependencies]
    burn-onnx = { version = "0.21" }

--- a/examples/raspberry-pi-pico/Cargo.toml
+++ b/examples/raspberry-pi-pico/Cargo.toml
@@ -31,7 +31,7 @@ embedded-alloc = "0.7.0"
 
 burn = { workspace = true, features = ["flex"] }
 burn-flex = { workspace = true, features = ["critical-section"] }
-burn-store = { workspace = true, features = ["burnpack"] }
+burn-store = { workspace = true }
 
 [build-dependencies]
 burn-onnx = { workspace = true, features = ["default"] }

--- a/scoreboard/runner/Cargo.lock
+++ b/scoreboard/runner/Cargo.lock
@@ -35,9 +35,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
- "getrandom 0.3.4",
  "once_cell",
- "serde",
  "version_check",
  "zerocopy",
 ]
@@ -104,7 +102,7 @@ checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -141,6 +139,8 @@ dependencies = [
  "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
+ "portable-atomic",
+ "portable-atomic-util",
 ]
 
 [[package]]
@@ -190,7 +190,7 @@ dependencies = [
  "anyhow",
  "arrayvec",
  "log",
- "nom 8.0.0",
+ "nom",
  "num-rational",
  "v_frame",
 ]
@@ -202,6 +202,81 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "375082f007bd67184fb9c0374614b29f9aaa604ec301635f72338bb65386a53d"
 dependencies = [
  "arrayvec",
+]
+
+[[package]]
+name = "awint"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d48b7360a36d335663e8f20b7f439029debf52b5a0a749d6e936405f25045288"
+dependencies = [
+ "awint_core",
+ "awint_dag",
+ "awint_ext",
+ "awint_macro_internals",
+ "awint_macros",
+]
+
+[[package]]
+name = "awint_core"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8280079e78217ace721501f35dbf551dadf0ab63863504169316cea1bbac872"
+dependencies = [
+ "awint_internals",
+ "const_fn",
+]
+
+[[package]]
+name = "awint_dag"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73977ba1786a5e127272f08b865b60f5d548576a0925de1daa5703cc9ba78a8d"
+dependencies = [
+ "awint_ext",
+ "awint_macro_internals",
+ "awint_macros",
+ "smallvec",
+]
+
+[[package]]
+name = "awint_ext"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1b30d3640d9f94dd9f55f655773c5238c11be6f95ab36d24308b7ae34c9bbc"
+dependencies = [
+ "awint_core",
+ "const_fn",
+]
+
+[[package]]
+name = "awint_internals"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173937e3f4e233d93362fc1e28ab23808cb31671a1923033706cb44ed4e5d10c"
+dependencies = [
+ "const_fn",
+]
+
+[[package]]
+name = "awint_macro_internals"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2c6a23f64f14c3b566c2c04124015f78c5fb93e8275a6574e0118747ee60de6"
+dependencies = [
+ "awint_ext",
+ "proc-macro2",
+ "triple_arena",
+]
+
+[[package]]
+name = "awint_macros"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e50a2862c6002a424fc9bb4982ec33ab679cb4ad04a174e2a52c2ecc3ea4c7"
+dependencies = [
+ "awint_internals",
+ "awint_macro_internals",
 ]
 
 [[package]]
@@ -221,12 +296,6 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -238,40 +307,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
-name = "bincode"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
-dependencies = [
- "serde",
- "unty",
-]
-
-[[package]]
-name = "bindgen"
-version = "0.71.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
-dependencies = [
- "bitflags",
- "cexpr",
- "clang-sys",
- "itertools 0.13.0",
- "log",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash 2.1.2",
- "shlex",
- "syn",
-]
-
-[[package]]
 name = "bit-set"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ddef2995421ab6a5c779542c81ee77c115206f4ad9d5a8e05f4ff49716a3dd"
+checksum = "09ec2f926cc3060f09db9ebc5b52823d85268d24bb917e472c0c4bea35780a7d"
 dependencies = [
  "bit-vec",
 ]
@@ -290,9 +329,9 @@ checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 dependencies = [
  "serde_core",
 ]
@@ -342,11 +381,23 @@ checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
 dependencies = [
  "darling 0.23.0",
  "ident_case",
- "prettyplease",
+ "prettyplease 0.2.37",
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "buildid"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b8e278b5bdc31756d01d65c17662e23692e0dbaa19e65adae9b58fc4683bc09"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "log",
+ "winapi",
 ]
 
 [[package]]
@@ -363,32 +414,21 @@ checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "burn"
-version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=b71e848ba6a7b91cbab5b8ebb7ed63885df9f8e3#b71e848ba6a7b91cbab5b8ebb7ed63885df9f8e3"
+version = "0.22.0-pre.2"
+source = "git+https://github.com/tracel-ai/burn?rev=a467575b5642fb135384d928ae9c0c7f1e0765be#a467575b5642fb135384d928ae9c0c7f1e0765be"
 dependencies = [
- "burn-autodiff",
- "burn-candle",
  "burn-core",
- "burn-cpu",
- "burn-cuda",
- "burn-dispatch",
- "burn-flex",
- "burn-ndarray",
  "burn-nn",
  "burn-optim",
- "burn-rocm",
- "burn-router",
  "burn-std",
  "burn-store",
- "burn-tch",
  "burn-vision",
- "burn-wgpu",
 ]
 
 [[package]]
 name = "burn-autodiff"
-version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=b71e848ba6a7b91cbab5b8ebb7ed63885df9f8e3#b71e848ba6a7b91cbab5b8ebb7ed63885df9f8e3"
+version = "0.22.0-pre.2"
+source = "git+https://github.com/tracel-ai/burn?rev=a467575b5642fb135384d928ae9c0c7f1e0765be#a467575b5642fb135384d928ae9c0c7f1e0765be"
 dependencies = [
  "burn-backend",
  "burn-std",
@@ -398,13 +438,14 @@ dependencies = [
  "num-traits",
  "parking_lot",
  "portable-atomic",
- "spin",
+ "portable-atomic-util",
+ "spin 0.11.1",
 ]
 
 [[package]]
 name = "burn-backend"
-version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=b71e848ba6a7b91cbab5b8ebb7ed63885df9f8e3#b71e848ba6a7b91cbab5b8ebb7ed63885df9f8e3"
+version = "0.22.0-pre.2"
+source = "git+https://github.com/tracel-ai/burn?rev=a467575b5642fb135384d928ae9c0c7f1e0765be#a467575b5642fb135384d928ae9c0c7f1e0765be"
 dependencies = [
  "burn-std",
  "bytemuck",
@@ -413,38 +454,38 @@ dependencies = [
  "enumset",
  "hashbrown 0.16.1",
  "num-traits",
+ "oneshot",
  "portable-atomic-util",
  "rand 0.10.1",
- "rand_distr 0.6.0",
+ "rand_distr",
  "serde",
- "spin",
- "thiserror 2.0.18",
+ "spin 0.11.1",
 ]
 
 [[package]]
-name = "burn-candle"
-version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=b71e848ba6a7b91cbab5b8ebb7ed63885df9f8e3#b71e848ba6a7b91cbab5b8ebb7ed63885df9f8e3"
+name = "burn-backend-extension"
+version = "0.22.0-pre.2"
+source = "git+https://github.com/tracel-ai/burn?rev=a467575b5642fb135384d928ae9c0c7f1e0765be#a467575b5642fb135384d928ae9c0c7f1e0765be"
 dependencies = [
- "burn-backend",
- "burn-std",
- "candle-core",
- "derive-new",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "burn-core"
-version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=b71e848ba6a7b91cbab5b8ebb7ed63885df9f8e3#b71e848ba6a7b91cbab5b8ebb7ed63885df9f8e3"
+version = "0.22.0-pre.2"
+source = "git+https://github.com/tracel-ai/burn?rev=a467575b5642fb135384d928ae9c0c7f1e0765be#a467575b5642fb135384d928ae9c0c7f1e0765be"
 dependencies = [
  "ahash",
- "bincode",
+ "burn-backend",
+ "burn-backend-extension",
  "burn-derive",
+ "burn-dispatch",
+ "burn-pack",
  "burn-std",
  "burn-tensor",
- "data-encoding",
  "derive-new",
- "flate2",
  "half",
  "hashbrown 0.16.1",
  "log",
@@ -453,17 +494,15 @@ dependencies = [
  "portable-atomic-util",
  "rand 0.10.1",
  "regex",
- "rmp-serde",
  "serde",
  "serde_json",
- "spin",
- "uuid",
+ "spin 0.11.1",
 ]
 
 [[package]]
 name = "burn-cpu"
-version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=b71e848ba6a7b91cbab5b8ebb7ed63885df9f8e3#b71e848ba6a7b91cbab5b8ebb7ed63885df9f8e3"
+version = "0.22.0-pre.2"
+source = "git+https://github.com/tracel-ai/burn?rev=a467575b5642fb135384d928ae9c0c7f1e0765be#a467575b5642fb135384d928ae9c0c7f1e0765be"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -472,8 +511,8 @@ dependencies = [
 
 [[package]]
 name = "burn-cubecl"
-version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=b71e848ba6a7b91cbab5b8ebb7ed63885df9f8e3#b71e848ba6a7b91cbab5b8ebb7ed63885df9f8e3"
+version = "0.22.0-pre.2"
+source = "git+https://github.com/tracel-ai/burn?rev=a467575b5642fb135384d928ae9c0c7f1e0765be#a467575b5642fb135384d928ae9c0c7f1e0765be"
 dependencies = [
  "burn-backend",
  "burn-cubecl-fusion",
@@ -491,8 +530,8 @@ dependencies = [
 
 [[package]]
 name = "burn-cubecl-fusion"
-version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=b71e848ba6a7b91cbab5b8ebb7ed63885df9f8e3#b71e848ba6a7b91cbab5b8ebb7ed63885df9f8e3"
+version = "0.22.0-pre.2"
+source = "git+https://github.com/tracel-ai/burn?rev=a467575b5642fb135384d928ae9c0c7f1e0765be#a467575b5642fb135384d928ae9c0c7f1e0765be"
 dependencies = [
  "burn-backend",
  "burn-fusion",
@@ -502,14 +541,15 @@ dependencies = [
  "cubek",
  "derive-new",
  "hashbrown 0.16.1",
+ "rmp-serde",
  "serde",
- "spin",
+ "spin 0.11.1",
 ]
 
 [[package]]
 name = "burn-cuda"
-version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=b71e848ba6a7b91cbab5b8ebb7ed63885df9f8e3#b71e848ba6a7b91cbab5b8ebb7ed63885df9f8e3"
+version = "0.22.0-pre.2"
+source = "git+https://github.com/tracel-ai/burn?rev=a467575b5642fb135384d928ae9c0c7f1e0765be#a467575b5642fb135384d928ae9c0c7f1e0765be"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -518,19 +558,19 @@ dependencies = [
 
 [[package]]
 name = "burn-derive"
-version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=b71e848ba6a7b91cbab5b8ebb7ed63885df9f8e3#b71e848ba6a7b91cbab5b8ebb7ed63885df9f8e3"
+version = "0.22.0-pre.2"
+source = "git+https://github.com/tracel-ai/burn?rev=a467575b5642fb135384d928ae9c0c7f1e0765be#a467575b5642fb135384d928ae9c0c7f1e0765be"
 dependencies = [
  "derive-new",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "burn-dispatch"
-version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=b71e848ba6a7b91cbab5b8ebb7ed63885df9f8e3#b71e848ba6a7b91cbab5b8ebb7ed63885df9f8e3"
+version = "0.22.0-pre.2"
+source = "git+https://github.com/tracel-ai/burn?rev=a467575b5642fb135384d928ae9c0c7f1e0765be#a467575b5642fb135384d928ae9c0c7f1e0765be"
 dependencies = [
  "burn-autodiff",
  "burn-backend",
@@ -546,10 +586,9 @@ dependencies = [
 
 [[package]]
 name = "burn-flex"
-version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=b71e848ba6a7b91cbab5b8ebb7ed63885df9f8e3#b71e848ba6a7b91cbab5b8ebb7ed63885df9f8e3"
+version = "0.22.0-pre.2"
+source = "git+https://github.com/tracel-ai/burn?rev=a467575b5642fb135384d928ae9c0c7f1e0765be#a467575b5642fb135384d928ae9c0c7f1e0765be"
 dependencies = [
- "aligned-vec",
  "burn-backend",
  "burn-ir",
  "burn-std",
@@ -557,15 +596,16 @@ dependencies = [
  "gemm",
  "half",
  "libm",
- "macerator",
  "num-traits",
- "rayon",
+ "once_cell",
+ "portable-atomic",
+ "portable-atomic-util",
 ]
 
 [[package]]
 name = "burn-fusion"
-version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=b71e848ba6a7b91cbab5b8ebb7ed63885df9f8e3#b71e848ba6a7b91cbab5b8ebb7ed63885df9f8e3"
+version = "0.22.0-pre.2"
+source = "git+https://github.com/tracel-ai/burn?rev=a467575b5642fb135384d928ae9c0c7f1e0765be#a467575b5642fb135384d928ae9c0c7f1e0765be"
 dependencies = [
  "burn-backend",
  "burn-ir",
@@ -575,14 +615,14 @@ dependencies = [
  "log",
  "serde",
  "smallvec",
- "spin",
+ "spin 0.11.1",
  "tracing",
 ]
 
 [[package]]
 name = "burn-ir"
-version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=b71e848ba6a7b91cbab5b8ebb7ed63885df9f8e3#b71e848ba6a7b91cbab5b8ebb7ed63885df9f8e3"
+version = "0.22.0-pre.2"
+source = "git+https://github.com/tracel-ai/burn?rev=a467575b5642fb135384d928ae9c0c7f1e0765be#a467575b5642fb135384d928ae9c0c7f1e0765be"
 dependencies = [
  "burn-backend",
  "hashbrown 0.16.1",
@@ -591,11 +631,10 @@ dependencies = [
 
 [[package]]
 name = "burn-ndarray"
-version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=b71e848ba6a7b91cbab5b8ebb7ed63885df9f8e3#b71e848ba6a7b91cbab5b8ebb7ed63885df9f8e3"
+version = "0.22.0-pre.2"
+source = "git+https://github.com/tracel-ai/burn?rev=a467575b5642fb135384d928ae9c0c7f1e0765be#a467575b5642fb135384d928ae9c0c7f1e0765be"
 dependencies = [
  "atomic_float",
- "burn-autodiff",
  "burn-backend",
  "burn-ir",
  "burn-std",
@@ -613,8 +652,8 @@ dependencies = [
 
 [[package]]
 name = "burn-nn"
-version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=b71e848ba6a7b91cbab5b8ebb7ed63885df9f8e3#b71e848ba6a7b91cbab5b8ebb7ed63885df9f8e3"
+version = "0.22.0-pre.2"
+source = "git+https://github.com/tracel-ai/burn?rev=a467575b5642fb135384d928ae9c0c7f1e0765be#a467575b5642fb135384d928ae9c0c7f1e0765be"
 dependencies = [
  "burn-core",
  "num-traits",
@@ -632,10 +671,12 @@ dependencies = [
 
 [[package]]
 name = "burn-optim"
-version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=b71e848ba6a7b91cbab5b8ebb7ed63885df9f8e3#b71e848ba6a7b91cbab5b8ebb7ed63885df9f8e3"
+version = "0.22.0-pre.2"
+source = "git+https://github.com/tracel-ai/burn?rev=a467575b5642fb135384d928ae9c0c7f1e0765be#a467575b5642fb135384d928ae9c0c7f1e0765be"
 dependencies = [
  "burn-core",
+ "burn-derive",
+ "burn-pack",
  "derive-new",
  "hashbrown 0.16.1",
  "log",
@@ -644,9 +685,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "burn-pack"
+version = "0.22.0-pre.2"
+source = "git+https://github.com/tracel-ai/burn?rev=a467575b5642fb135384d928ae9c0c7f1e0765be#a467575b5642fb135384d928ae9c0c7f1e0765be"
+dependencies = [
+ "burn-std",
+ "byteorder",
+ "ciborium",
+ "serde",
+]
+
+[[package]]
 name = "burn-rocm"
-version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=b71e848ba6a7b91cbab5b8ebb7ed63885df9f8e3#b71e848ba6a7b91cbab5b8ebb7ed63885df9f8e3"
+version = "0.22.0-pre.2"
+source = "git+https://github.com/tracel-ai/burn?rev=a467575b5642fb135384d928ae9c0c7f1e0765be#a467575b5642fb135384d928ae9c0c7f1e0765be"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -654,58 +706,53 @@ dependencies = [
 ]
 
 [[package]]
-name = "burn-router"
-version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=b71e848ba6a7b91cbab5b8ebb7ed63885df9f8e3#b71e848ba6a7b91cbab5b8ebb7ed63885df9f8e3"
-dependencies = [
- "burn-backend",
- "burn-ir",
- "burn-std",
- "hashbrown 0.16.1",
- "log",
- "spin",
-]
-
-[[package]]
 name = "burn-std"
-version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=b71e848ba6a7b91cbab5b8ebb7ed63885df9f8e3#b71e848ba6a7b91cbab5b8ebb7ed63885df9f8e3"
+version = "0.22.0-pre.2"
+source = "git+https://github.com/tracel-ai/burn?rev=a467575b5642fb135384d928ae9c0c7f1e0765be#a467575b5642fb135384d928ae9c0c7f1e0765be"
 dependencies = [
+ "ahash",
  "bytemuck",
  "bytes",
- "cubecl",
  "cubecl-common",
+ "cubecl-environment",
  "cubecl-zspace",
+ "data-encoding",
+ "derive-new",
+ "enumset",
  "half",
+ "hashbrown 0.16.1",
  "num-traits",
+ "portable-atomic-util",
+ "rand 0.10.1",
+ "rand_distr",
  "serde",
  "smallvec",
- "spin",
+ "spin 0.11.1",
+ "thiserror 2.0.18",
+ "uuid",
 ]
 
 [[package]]
 name = "burn-store"
-version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=b71e848ba6a7b91cbab5b8ebb7ed63885df9f8e3#b71e848ba6a7b91cbab5b8ebb7ed63885df9f8e3"
+version = "0.22.0-pre.2"
+source = "git+https://github.com/tracel-ai/burn?rev=a467575b5642fb135384d928ae9c0c7f1e0765be#a467575b5642fb135384d928ae9c0c7f1e0765be"
 dependencies = [
  "burn-core",
- "burn-tensor",
+ "burn-pack",
  "byteorder",
  "bytes",
- "ciborium",
  "half",
  "hashbrown 0.16.1",
  "memmap2",
  "regex",
  "safetensors 0.7.0",
- "serde",
  "textdistance",
 ]
 
 [[package]]
 name = "burn-tch"
-version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=b71e848ba6a7b91cbab5b8ebb7ed63885df9f8e3#b71e848ba6a7b91cbab5b8ebb7ed63885df9f8e3"
+version = "0.22.0-pre.2"
+source = "git+https://github.com/tracel-ai/burn?rev=a467575b5642fb135384d928ae9c0c7f1e0765be#a467575b5642fb135384d928ae9c0c7f1e0765be"
 dependencies = [
  "burn-backend",
  "cc",
@@ -717,10 +764,11 @@ dependencies = [
 
 [[package]]
 name = "burn-tensor"
-version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=b71e848ba6a7b91cbab5b8ebb7ed63885df9f8e3#b71e848ba6a7b91cbab5b8ebb7ed63885df9f8e3"
+version = "0.22.0-pre.2"
+source = "git+https://github.com/tracel-ai/burn?rev=a467575b5642fb135384d928ae9c0c7f1e0765be#a467575b5642fb135384d928ae9c0c7f1e0765be"
 dependencies = [
  "burn-backend",
+ "burn-dispatch",
  "burn-std",
  "colored",
  "derive-new",
@@ -730,14 +778,14 @@ dependencies = [
 
 [[package]]
 name = "burn-vision"
-version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=b71e848ba6a7b91cbab5b8ebb7ed63885df9f8e3#b71e848ba6a7b91cbab5b8ebb7ed63885df9f8e3"
+version = "0.22.0-pre.2"
+source = "git+https://github.com/tracel-ai/burn?rev=a467575b5642fb135384d928ae9c0c7f1e0765be#a467575b5642fb135384d928ae9c0c7f1e0765be"
 dependencies = [
  "aligned-vec",
  "bon",
- "burn-flex",
+ "burn-core",
  "burn-ir",
- "burn-tensor",
+ "burn-std",
  "bytemuck",
  "derive-new",
  "half",
@@ -751,8 +799,8 @@ dependencies = [
 
 [[package]]
 name = "burn-wgpu"
-version = "0.21.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=b71e848ba6a7b91cbab5b8ebb7ed63885df9f8e3#b71e848ba6a7b91cbab5b8ebb7ed63885df9f8e3"
+version = "0.22.0-pre.2"
+source = "git+https://github.com/tracel-ai/burn?rev=a467575b5642fb135384d928ae9c0c7f1e0765be#a467575b5642fb135384d928ae9c0c7f1e0765be"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -776,7 +824,7 @@ checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -821,48 +869,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "candle-core"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bd9895436c1ba5dc1037a19935d084b838db066ff4e15ef7dded020b7c12a4a"
-dependencies = [
- "byteorder",
- "float8",
- "gemm",
- "half",
- "libm",
- "memmap2",
- "num-traits",
- "num_cpus",
- "rand 0.9.4",
- "rand_distr 0.5.1",
- "rayon",
- "safetensors 0.7.0",
- "thiserror 2.0.18",
- "tokenizers",
- "yoke",
- "zip 7.2.0",
-]
-
-[[package]]
-name = "caseless"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6fd507454086c8edfd769ca6ada439193cdb209c7681712ef6275cccbfe5d8"
-dependencies = [
- "unicode-normalization",
-]
-
-[[package]]
-name = "castaway"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "cc"
 version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -875,15 +881,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom 7.1.3",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -891,9 +888,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
@@ -944,17 +941,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "clang-sys"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
-dependencies = [
- "glob",
- "libc",
- "libloading 0.8.9",
-]
-
-[[package]]
 name = "codespan-reporting"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -981,32 +967,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "compact_str"
-version = "0.9.0"
+name = "combine"
+version = "4.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
+checksum = "cfc320937d09e6de266b31b9afb480f197d7a861be86be7cb2ea7e5d1bfffc5e"
 dependencies = [
- "castaway",
- "cfg-if",
- "itoa",
- "rustversion",
- "ryu",
- "serde",
- "static_assertions",
-]
-
-[[package]]
-name = "comrak"
-version = "0.39.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fefab951771fc3beeed0773ce66a4f7b706273fc6c4c95b08dd1615744abcf5"
-dependencies = [
- "caseless",
- "entities",
+ "bytes",
  "memchr",
- "slug",
- "typed-arena",
- "unicode_categories",
 ]
 
 [[package]]
@@ -1016,6 +983,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
+ "portable-atomic",
 ]
 
 [[package]]
@@ -1039,6 +1007,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const_fn"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413d67b29ef1021b4d60f4aa1e925ca031751e213832b4b1d588fae623c05c60"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1052,18 +1026,18 @@ checksum = "136d3e02915a2cea4d74caa8681e2d44b1c3254bdbf17d11d41d587ff858832c"
 
 [[package]]
 name = "convert_case"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baaaa0ecca5b51987b9423ccdc971514dd8b0bb7b4060b983d3664dad3f1f89f"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
 ]
 
 [[package]]
 name = "convert_case"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+checksum = "affbf0190ed2caf063e3def54ff444b449371d55c58e513a95ab98eca50adb49"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -1144,12 +1118,13 @@ dependencies = [
 
 [[package]]
 name = "cubecl"
-version = "0.10.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=21c97057491dd8d06157897d30072e79179237c7#21c97057491dd8d06157897d30072e79179237c7"
+version = "0.11.0-pre.2"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4057f39e7fe025323e032bab8fc7600d16414f5e#4057f39e7fe025323e032bab8fc7600d16414f5e"
 dependencies = [
  "cubecl-core",
  "cubecl-cpu",
  "cubecl-cuda",
+ "cubecl-environment",
  "cubecl-hip",
  "cubecl-ir",
  "cubecl-runtime",
@@ -1160,53 +1135,37 @@ dependencies = [
 
 [[package]]
 name = "cubecl-common"
-version = "0.10.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=21c97057491dd8d06157897d30072e79179237c7#21c97057491dd8d06157897d30072e79179237c7"
+version = "0.11.0-pre.2"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4057f39e7fe025323e032bab8fc7600d16414f5e#4057f39e7fe025323e032bab8fc7600d16414f5e"
 dependencies = [
- "backtrace",
  "bytemuck",
- "bytes",
- "cfg-if",
  "cfg_aliases",
- "ciborium",
+ "cubecl-environment",
  "derive-new",
  "derive_more",
- "dirs",
- "embassy-futures",
- "embassy-time",
  "float4",
  "float8",
- "futures-lite",
  "half",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "log",
  "num-traits",
- "oneshot",
- "parking_lot",
  "portable-atomic",
  "portable-atomic-util",
- "rand 0.10.1",
- "sanitize-filename",
  "serde",
- "serde_bytes",
- "serde_json",
- "spin",
- "toml",
- "tracing",
+ "spin 0.12.3",
  "tynm",
- "wasm-bindgen-futures",
- "web-time",
  "xxhash-rust",
 ]
 
 [[package]]
 name = "cubecl-core"
-version = "0.10.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=21c97057491dd8d06157897d30072e79179237c7#21c97057491dd8d06157897d30072e79179237c7"
+version = "0.11.0-pre.2"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4057f39e7fe025323e032bab8fc7600d16414f5e#4057f39e7fe025323e032bab8fc7600d16414f5e"
 dependencies = [
  "bitflags",
  "bytemuck",
  "cubecl-common",
+ "cubecl-environment",
  "cubecl-ir",
  "cubecl-macros",
  "cubecl-runtime",
@@ -1216,10 +1175,13 @@ dependencies = [
  "enumset",
  "float-ord",
  "half",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
+ "itertools 0.15.0",
  "log",
+ "num-integer",
  "num-traits",
  "paste",
+ "pliron",
  "serde",
  "serde_json",
  "tracing",
@@ -1228,50 +1190,58 @@ dependencies = [
 
 [[package]]
 name = "cubecl-cpp"
-version = "0.10.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=21c97057491dd8d06157897d30072e79179237c7#21c97057491dd8d06157897d30072e79179237c7"
+version = "0.11.0-pre.2"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4057f39e7fe025323e032bab8fc7600d16414f5e#4057f39e7fe025323e032bab8fc7600d16414f5e"
 dependencies = [
  "bytemuck",
  "cubecl-common",
  "cubecl-core",
+ "cubecl-environment",
  "cubecl-opt",
  "cubecl-runtime",
  "derive-new",
+ "derive_more",
  "half",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "log",
+ "num-traits",
+ "paste",
+ "pliron",
+ "sanitize-filename",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "cubecl-cpu"
-version = "0.10.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=21c97057491dd8d06157897d30072e79179237c7#21c97057491dd8d06157897d30072e79179237c7"
+version = "0.11.0-pre.2"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4057f39e7fe025323e032bab8fc7600d16414f5e#4057f39e7fe025323e032bab8fc7600d16414f5e"
 dependencies = [
- "bytemuck",
+ "crossbeam-utils",
  "cubecl-common",
  "cubecl-core",
- "cubecl-opt",
+ "cubecl-environment",
+ "cubecl-llvm",
  "cubecl-runtime",
  "cubecl-std",
  "derive-new",
- "half",
+ "libc",
  "log",
- "paste",
- "serde",
+ "pliron",
+ "spin 0.12.3",
  "sysinfo",
- "tracel-llvm",
- "tracel-llvm-bundler",
+ "winapi",
 ]
 
 [[package]]
 name = "cubecl-cuda"
-version = "0.10.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=21c97057491dd8d06157897d30072e79179237c7#21c97057491dd8d06157897d30072e79179237c7"
+version = "0.11.0-pre.2"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4057f39e7fe025323e032bab8fc7600d16414f5e#4057f39e7fe025323e032bab8fc7600d16414f5e"
 dependencies = [
  "bytemuck",
  "cubecl-common",
  "cubecl-core",
  "cubecl-cpp",
+ "cubecl-environment",
  "cubecl-runtime",
  "cudarc",
  "derive-new",
@@ -1282,14 +1252,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "cubecl-environment"
+version = "0.11.0-pre.2"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4057f39e7fe025323e032bab8fc7600d16414f5e#4057f39e7fe025323e032bab8fc7600d16414f5e"
+dependencies = [
+ "async-channel",
+ "backtrace",
+ "bytemuck",
+ "bytes",
+ "cfg-if",
+ "cfg_aliases",
+ "ciborium",
+ "embassy-futures",
+ "embassy-time",
+ "etcetera",
+ "foldhash 0.2.0",
+ "futures-lite",
+ "hashbrown 0.17.0",
+ "log",
+ "oneshot",
+ "parking_lot",
+ "portable-atomic",
+ "portable-atomic-util",
+ "rand 0.10.1",
+ "rusqlite",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "spin 0.12.3",
+ "toml",
+ "tracing",
+ "wasm-bindgen-futures",
+ "web-time",
+]
+
+[[package]]
 name = "cubecl-hip"
-version = "0.10.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=21c97057491dd8d06157897d30072e79179237c7#21c97057491dd8d06157897d30072e79179237c7"
+version = "0.11.0-pre.2"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4057f39e7fe025323e032bab8fc7600d16414f5e#4057f39e7fe025323e032bab8fc7600d16414f5e"
 dependencies = [
  "bytemuck",
  "cubecl-common",
  "cubecl-core",
  "cubecl-cpp",
+ "cubecl-environment",
  "cubecl-hip-sys",
  "cubecl-runtime",
  "derive-new",
@@ -1312,10 +1318,12 @@ dependencies = [
 
 [[package]]
 name = "cubecl-ir"
-version = "0.10.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=21c97057491dd8d06157897d30072e79179237c7#21c97057491dd8d06157897d30072e79179237c7"
+version = "0.11.0-pre.2"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4057f39e7fe025323e032bab8fc7600d16414f5e#4057f39e7fe025323e032bab8fc7600d16414f5e"
 dependencies = [
+ "bumpalo",
  "cubecl-common",
+ "cubecl-environment",
  "cubecl-macros-internal",
  "derive-new",
  "derive_more",
@@ -1324,122 +1332,161 @@ dependencies = [
  "fnv",
  "foldhash 0.2.0",
  "half",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
+ "internment",
+ "itertools 0.15.0",
+ "num",
  "num-traits",
+ "pliron",
  "portable-atomic",
+ "rustc_apfloat",
  "serde",
+ "spin 0.12.3",
+ "thiserror 2.0.18",
  "variadics_please",
 ]
 
 [[package]]
+name = "cubecl-llvm"
+version = "0.11.0-pre.2"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4057f39e7fe025323e032bab8fc7600d16414f5e#4057f39e7fe025323e032bab8fc7600d16414f5e"
+dependencies = [
+ "cubecl-core",
+ "cubecl-environment",
+ "cubecl-opt",
+ "cubecl-runtime",
+ "derive-new",
+ "half",
+ "llvm-sys",
+ "pliron",
+ "pliron-llvm",
+ "tracel-llvm-bundler",
+]
+
+[[package]]
 name = "cubecl-macros"
-version = "0.10.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=21c97057491dd8d06157897d30072e79179237c7#21c97057491dd8d06157897d30072e79179237c7"
+version = "0.11.0-pre.2"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4057f39e7fe025323e032bab8fc7600d16414f5e#4057f39e7fe025323e032bab8fc7600d16414f5e"
 dependencies = [
  "cubecl-common",
- "darling 0.23.0",
+ "darling 0.24.1",
  "derive-new",
+ "derive_more",
  "ident_case",
  "inflections",
- "prettyplease",
+ "itertools 0.15.0",
+ "prettyplease 0.3.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.4",
 ]
 
 [[package]]
 name = "cubecl-macros-internal"
-version = "0.10.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=21c97057491dd8d06157897d30072e79179237c7#21c97057491dd8d06157897d30072e79179237c7"
+version = "0.11.0-pre.2"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4057f39e7fe025323e032bab8fc7600d16414f5e#4057f39e7fe025323e032bab8fc7600d16414f5e"
 dependencies = [
- "darling 0.23.0",
+ "darling 0.24.1",
+ "inflections",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.4",
 ]
 
 [[package]]
 name = "cubecl-opt"
-version = "0.10.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=21c97057491dd8d06157897d30072e79179237c7#21c97057491dd8d06157897d30072e79179237c7"
+version = "0.11.0-pre.2"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4057f39e7fe025323e032bab8fc7600d16414f5e#4057f39e7fe025323e032bab8fc7600d16414f5e"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
+ "cubecl-environment",
  "cubecl-ir",
+ "derive-new",
  "float-ord",
+ "hashbrown 0.17.0",
+ "itertools 0.15.0",
  "log",
  "num",
- "petgraph",
+ "pliron",
  "smallvec",
  "stable-vec",
+ "thiserror 2.0.18",
  "type-map",
 ]
 
 [[package]]
 name = "cubecl-runtime"
-version = "0.10.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=21c97057491dd8d06157897d30072e79179237c7#21c97057491dd8d06157897d30072e79179237c7"
+version = "0.11.0-pre.2"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4057f39e7fe025323e032bab8fc7600d16414f5e#4057f39e7fe025323e032bab8fc7600d16414f5e"
 dependencies = [
  "ahash",
- "async-channel",
+ "buildid",
  "bytemuck",
  "cfg-if",
  "cfg_aliases",
  "cubecl-common",
+ "cubecl-environment",
  "cubecl-ir",
  "cubecl-zspace",
  "derive-new",
  "derive_more",
- "dirs",
  "enumset",
- "hashbrown 0.16.1",
+ "futures-util",
+ "hashbrown 0.17.0",
+ "itertools 0.15.0",
  "log",
  "md5",
+ "pliron",
  "serde",
  "serde_json",
- "spin",
  "thiserror 2.0.18",
  "toml",
  "tracing",
  "wasm-bindgen-futures",
- "web-time",
 ]
 
 [[package]]
 name = "cubecl-std"
-version = "0.10.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=21c97057491dd8d06157897d30072e79179237c7#21c97057491dd8d06157897d30072e79179237c7"
+version = "0.11.0-pre.2"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4057f39e7fe025323e032bab8fc7600d16414f5e#4057f39e7fe025323e032bab8fc7600d16414f5e"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
+ "cubecl-environment",
  "cubecl-runtime",
  "half",
  "num-traits",
  "paste",
  "serde",
- "spin",
+ "spin 0.12.3",
  "variadics_please",
 ]
 
 [[package]]
 name = "cubecl-wgpu"
-version = "0.10.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=21c97057491dd8d06157897d30072e79179237c7#21c97057491dd8d06157897d30072e79179237c7"
+version = "0.11.0-pre.2"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4057f39e7fe025323e032bab8fc7600d16414f5e#4057f39e7fe025323e032bab8fc7600d16414f5e"
 dependencies = [
- "async-channel",
  "bytemuck",
  "cfg-if",
  "cfg_aliases",
  "cubecl-common",
  "cubecl-core",
+ "cubecl-cpp",
+ "cubecl-environment",
  "cubecl-ir",
+ "cubecl-opt",
  "cubecl-runtime",
  "derive-new",
  "derive_more",
  "half",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
+ "itertools 0.15.0",
  "log",
+ "pliron",
  "sanitize-filename",
+ "thiserror 2.0.18",
  "tracing",
  "wasm-bindgen-futures",
  "wgpu",
@@ -1447,8 +1494,8 @@ dependencies = [
 
 [[package]]
 name = "cubecl-zspace"
-version = "0.10.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=21c97057491dd8d06157897d30072e79179237c7#21c97057491dd8d06157897d30072e79179237c7"
+version = "0.11.0-pre.2"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4057f39e7fe025323e032bab8fc7600d16414f5e#4057f39e7fe025323e032bab8fc7600d16414f5e"
 dependencies = [
  "derive-new",
  "serde",
@@ -1457,14 +1504,16 @@ dependencies = [
 
 [[package]]
 name = "cubek"
-version = "0.2.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=adbe9ba657a8a67103d419c21158d0a1a9386635#adbe9ba657a8a67103d419c21158d0a1a9386635"
+version = "0.3.0-pre.2"
+source = "git+https://github.com/tracel-ai/cubek?rev=622d6714f12104f21314f7173bf841f697caf5ca#622d6714f12104f21314f7173bf841f697caf5ca"
 dependencies = [
  "cubecl",
  "cubek-attention",
  "cubek-convolution",
  "cubek-fft",
+ "cubek-interpolate",
  "cubek-matmul",
+ "cubek-pool",
  "cubek-quant",
  "cubek-random",
  "cubek-reduce",
@@ -1473,8 +1522,8 @@ dependencies = [
 
 [[package]]
 name = "cubek-attention"
-version = "0.2.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=adbe9ba657a8a67103d419c21158d0a1a9386635#adbe9ba657a8a67103d419c21158d0a1a9386635"
+version = "0.3.0-pre.2"
+source = "git+https://github.com/tracel-ai/cubek?rev=622d6714f12104f21314f7173bf841f697caf5ca#622d6714f12104f21314f7173bf841f697caf5ca"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -1487,8 +1536,8 @@ dependencies = [
 
 [[package]]
 name = "cubek-convolution"
-version = "0.2.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=adbe9ba657a8a67103d419c21158d0a1a9386635#adbe9ba657a8a67103d419c21158d0a1a9386635"
+version = "0.3.0-pre.2"
+source = "git+https://github.com/tracel-ai/cubek?rev=622d6714f12104f21314f7173bf841f697caf5ca#622d6714f12104f21314f7173bf841f697caf5ca"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -1503,44 +1552,69 @@ dependencies = [
 
 [[package]]
 name = "cubek-fft"
-version = "0.2.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=adbe9ba657a8a67103d419c21158d0a1a9386635#adbe9ba657a8a67103d419c21158d0a1a9386635"
+version = "0.3.0-pre.2"
+source = "git+https://github.com/tracel-ai/cubek?rev=622d6714f12104f21314f7173bf841f697caf5ca#622d6714f12104f21314f7173bf841f697caf5ca"
 dependencies = [
  "cubecl",
- "cubek-test-utils",
+]
+
+[[package]]
+name = "cubek-interpolate"
+version = "0.3.0-pre.2"
+source = "git+https://github.com/tracel-ai/cubek?rev=622d6714f12104f21314f7173bf841f697caf5ca#622d6714f12104f21314f7173bf841f697caf5ca"
+dependencies = [
+ "cubecl",
+ "cubecl-common",
+ "half",
+ "serde",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "cubek-matmul"
-version = "0.2.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=adbe9ba657a8a67103d419c21158d0a1a9386635#adbe9ba657a8a67103d419c21158d0a1a9386635"
+version = "0.3.0-pre.2"
+source = "git+https://github.com/tracel-ai/cubek?rev=622d6714f12104f21314f7173bf841f697caf5ca#622d6714f12104f21314f7173bf841f697caf5ca"
 dependencies = [
  "bytemuck",
  "cubecl",
  "cubecl-common",
  "cubek-std",
+ "cubek-tile",
  "half",
  "serde",
 ]
 
 [[package]]
-name = "cubek-quant"
-version = "0.2.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=adbe9ba657a8a67103d419c21158d0a1a9386635#adbe9ba657a8a67103d419c21158d0a1a9386635"
+name = "cubek-pool"
+version = "0.3.0-pre.2"
+source = "git+https://github.com/tracel-ai/cubek?rev=622d6714f12104f21314f7173bf841f697caf5ca#622d6714f12104f21314f7173bf841f697caf5ca"
 dependencies = [
  "cubecl",
  "cubecl-common",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "cubek-quant"
+version = "0.3.0-pre.2"
+source = "git+https://github.com/tracel-ai/cubek?rev=622d6714f12104f21314f7173bf841f697caf5ca#622d6714f12104f21314f7173bf841f697caf5ca"
+dependencies = [
+ "cubecl",
+ "cubecl-common",
+ "cubek-tile",
  "half",
  "serde",
 ]
 
 [[package]]
 name = "cubek-random"
-version = "0.2.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=adbe9ba657a8a67103d419c21158d0a1a9386635#adbe9ba657a8a67103d419c21158d0a1a9386635"
+version = "0.3.0-pre.2"
+source = "git+https://github.com/tracel-ai/cubek?rev=622d6714f12104f21314f7173bf841f697caf5ca#622d6714f12104f21314f7173bf841f697caf5ca"
 dependencies = [
  "cubecl",
  "cubecl-common",
+ "cubecl-environment",
+ "cubek-std",
  "half",
  "num-traits",
  "rand 0.10.1",
@@ -1549,8 +1623,8 @@ dependencies = [
 
 [[package]]
 name = "cubek-reduce"
-version = "0.2.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=adbe9ba657a8a67103d419c21158d0a1a9386635#adbe9ba657a8a67103d419c21158d0a1a9386635"
+version = "0.3.0-pre.2"
+source = "git+https://github.com/tracel-ai/cubek?rev=622d6714f12104f21314f7173bf841f697caf5ca#622d6714f12104f21314f7173bf841f697caf5ca"
 dependencies = [
  "cubecl",
  "cubek-std",
@@ -1562,8 +1636,8 @@ dependencies = [
 
 [[package]]
 name = "cubek-std"
-version = "0.2.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=adbe9ba657a8a67103d419c21158d0a1a9386635#adbe9ba657a8a67103d419c21158d0a1a9386635"
+version = "0.3.0-pre.2"
+source = "git+https://github.com/tracel-ai/cubek?rev=622d6714f12104f21314f7173bf841f697caf5ca#622d6714f12104f21314f7173bf841f697caf5ca"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -1571,24 +1645,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "cubek-test-utils"
-version = "0.2.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=adbe9ba657a8a67103d419c21158d0a1a9386635#adbe9ba657a8a67103d419c21158d0a1a9386635"
+name = "cubek-tile"
+version = "0.3.0-pre.2"
+source = "git+https://github.com/tracel-ai/cubek?rev=622d6714f12104f21314f7173bf841f697caf5ca#622d6714f12104f21314f7173bf841f697caf5ca"
 dependencies = [
  "bytemuck",
  "cubecl",
  "cubecl-common",
- "cubek-quant",
- "cubek-random",
  "half",
  "serde",
 ]
 
 [[package]]
 name = "cudarc"
-version = "0.19.4"
+version = "0.19.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f071cd6a7b5d51607df76aa2d426aaabc7a74bc6bdb885b8afa63a880572ad9b"
+checksum = "804764d10e844da09765a7b2ca9641a0851523d1702efb0d7299d73e31b86e80"
 dependencies = [
  "libloading 0.9.0",
 ]
@@ -1624,6 +1696,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed17f5901b6630b993ca003def43f2f8ef4014fc13b047b57aad617ff32bc2ec"
+dependencies = [
+ "darling_core 0.24.1",
+ "darling_macro 0.24.1",
+]
+
+[[package]]
 name = "darling_core"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1634,7 +1716,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1647,7 +1729,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1660,7 +1742,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6837e2cf7485aaae18f86181d2f0e9a7ed297a025e220aeabf63fdebd3a2ddff"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1671,7 +1766,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1682,7 +1777,7 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1693,16 +1788,18 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core 0.23.0",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
-name = "dary_heap"
-version = "0.3.9"
+name = "darling_macro"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b1e3a325bc115f096c8b77bbf027a7c2592230e70be2d985be950d3d5e60ebe"
+checksum = "2ac7135c3ef02b2f7833bbeb1be5ba7f966dcde8a87c6b87f65a778d71a02785"
 dependencies = [
- "serde",
+ "darling_core 0.24.1",
+ "quote",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1728,38 +1825,7 @@ checksum = "2cdc8d50f426189eef89dac62fabfa0abb27d5cc008f25bf4156a0203325becc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
-]
-
-[[package]]
-name = "derive_builder"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
-dependencies = [
- "derive_builder_macro",
-]
-
-[[package]]
-name = "derive_builder_core"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
-dependencies = [
- "darling 0.20.11",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "derive_builder_macro"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
-dependencies = [
- "derive_builder_core",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1781,15 +1847,9 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn",
+ "syn 2.0.117",
  "unicode-xid",
 ]
-
-[[package]]
-name = "deunicode"
-version = "1.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04"
 
 [[package]]
 name = "digest"
@@ -1841,7 +1901,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1861,6 +1921,18 @@ checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
 ]
+
+[[package]]
+name = "downcast-rs"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "dyn-stack"
@@ -1941,12 +2013,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "entities"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5320ae4c3782150d900b79807611a59a99fc9a1d61d686faafc24b93fc8d7ca"
-
-[[package]]
 name = "enum-as-inner"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1955,14 +2021,14 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "enumset"
-version = "1.1.10"
+version = "1.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25b07a8dfbbbfc0064c0a6bdf9edcf966de6b1c33ce344bdeca3b41615452634"
+checksum = "ccc5801fd11762e24d1e420d01d2ac518f2a2ca4329d4fbb6639f2412b6204e0"
 dependencies = [
  "enumset_derive",
  "serde",
@@ -1970,14 +2036,14 @@ dependencies = [
 
 [[package]]
 name = "enumset_derive"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43e744e4ea338060faee68ed933e46e722fb7f3617e722a5772d7e856d8b3ce"
+checksum = "4bd536557b58c682b217b8fb199afdff47cd3eff260623f19e77074eb073d63a"
 dependencies = [
  "darling 0.21.3",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1997,7 +2063,7 @@ checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2017,10 +2083,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "esaxx-rs"
-version = "0.1.10"
+name = "etcetera"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
+checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "event-listener"
@@ -2031,6 +2101,8 @@ dependencies = [
  "concurrent-queue",
  "parking",
  "pin-project-lite",
+ "portable-atomic",
+ "portable-atomic-util",
 ]
 
 [[package]]
@@ -2057,6 +2129,18 @@ dependencies = [
  "smallvec",
  "zune-inflate",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
@@ -2097,12 +2181,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
-name = "fixedbitset"
-version = "0.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
-
-[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2131,9 +2209,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2d1f04709a8ac06e8e8042875a3c466cc4832d3c1a18dbcb9dba3c6e83046bc"
 dependencies = [
  "half",
- "num-traits",
- "rand 0.9.4",
- "rand_distr 0.5.1",
 ]
 
 [[package]]
@@ -2291,7 +2366,6 @@ dependencies = [
  "paste",
  "pulp",
  "raw-cpuid",
- "rayon",
  "seq-macro",
  "sysctl",
 ]
@@ -2310,7 +2384,6 @@ dependencies = [
  "num-traits",
  "paste",
  "raw-cpuid",
- "rayon",
  "seq-macro",
 ]
 
@@ -2423,12 +2496,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "glob"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
-
-[[package]]
 name = "glow"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2464,26 +2531,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gpu-descriptor"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b89c83349105e3732062a895becfc71a8f921bb71ecbbdd8ff99263e3b53a0ca"
-dependencies = [
- "bitflags",
- "gpu-descriptor-types",
- "hashbrown 0.15.5",
-]
-
-[[package]]
-name = "gpu-descriptor-types"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2512,8 +2559,6 @@ dependencies = [
  "cfg-if",
  "crunchy",
  "num-traits",
- "rand 0.9.4",
- "rand_distr 0.5.1",
  "serde",
  "zerocopy",
 ]
@@ -2533,6 +2578,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -2554,6 +2601,22 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32069d97bb81e38fa67eab65e3393bf804bb85969f2bc06bf13f64aef5aba248"
+dependencies = [
+ "hashbrown 0.17.0",
+]
 
 [[package]]
 name = "heck"
@@ -2568,10 +2631,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
-name = "hexf-parse"
-version = "0.2.1"
+name = "hi_sparse_bitset"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
+checksum = "244cabe6369d69e97280fccda8e43c82387aa4af83a2c491791ec421cfe94e45"
+dependencies = [
+ "wide",
+]
 
 [[package]]
 name = "hmac"
@@ -2664,7 +2730,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -2864,6 +2930,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "internment"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "636d4b0f6a39fd684effe2a73f5310df16a3fa7954c26d36833e98f44d1977a2"
+dependencies = [
+ "hashbrown 0.15.5",
+ "serde",
+]
+
+[[package]]
 name = "interpolate_name"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2871,7 +2947,16 @@ checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "inventory"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -2892,18 +2977,18 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
 
 [[package]]
 name = "itertools"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
 dependencies = [
  "either",
 ]
@@ -2939,7 +3024,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2954,13 +3039,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -3075,6 +3159,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.38.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1d20bef17f513b9b3004532233187769cd072d790971f4e4da0e346eb6401e8"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "linkme"
+version = "0.3.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3045e122bd98aef8ec3ad58ce84f0791f64e70163d1a02710af4aa11a4d54cc5"
+dependencies = [
+ "linkme-impl",
+]
+
+[[package]]
+name = "linkme-impl"
+version = "0.3.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77060ebe535362c3da75682cd17b0431017b6e7c5661e714fc69a7ad017d1301"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3091,6 +3206,20 @@ name = "litrs"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
+name = "llvm-sys"
+version = "221.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2abcc34a3b190f03c2a61b555f218f529589ff13657bdd2ff8ac3e85f2abe6bb"
+dependencies = [
+ "anyhow",
+ "cc",
+ "lazy_static",
+ "libc",
+ "regex-lite",
+ "semver",
+]
 
 [[package]]
 name = "lock_api"
@@ -3124,9 +3253,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "macerator"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da28a09eacf3db6bff7314ed22c3304520fdbc8755630543378c4f92a592b049"
+checksum = "2ddeaadb76e307b1d2b4836adee77910d405b9f6c1ca031bc81a7a398e2b22f2"
 dependencies = [
  "bytemuck",
  "cfg_aliases",
@@ -3140,31 +3269,15 @@ dependencies = [
 
 [[package]]
 name = "macerator-macros"
-version = "0.1.5"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed5ce85961d618ce9794bdf822bfe96fe9dd341aa5b033b454f7a8d96e79b9b1"
+checksum = "d2a397d020af346358830d6f28579f26283003ce87af3dd79173ac9ee2d3ac28"
 dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
-
-[[package]]
-name = "macro_rules_attribute"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65049d7923698040cd0b1ddcced9b0eb14dd22c5f86ae59c3740eab64a676520"
-dependencies = [
- "macro_rules_attribute-proc_macro",
- "paste",
-]
-
-[[package]]
-name = "macro_rules_attribute-proc_macro"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670fdfda89751bc4a84ac13eaa63e205cf0fd22b4c9a5fbfa085b63c1f1d3a30"
 
 [[package]]
 name = "matrixmultiply"
@@ -3205,14 +3318,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
 dependencies = [
  "libc",
- "stable_deref_trait",
 ]
-
-[[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -3242,28 +3348,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a0b3262dc837d2513fe2ef31ff8461352ef932dcca31ba0c0abe33547cf6b9b"
 
 [[package]]
-name = "monostate"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3341a273f6c9d5bef1908f17b7267bbab0e95c9bf69a0d4dcf8e9e1b2c76ef67"
-dependencies = [
- "monostate-impl",
- "serde",
- "serde_core",
-]
-
-[[package]]
-name = "monostate-impl"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4db6d5580af57bf992f59068d4ea26fd518574ff48d7639b255a36f9de6e7e9"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "moxcms"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3274,10 +3358,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "naga"
-version = "29.0.1"
+name = "mutants"
+version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2630921705b9b01dcdd0b6864b9562ca3c1951eecd0f0c4f5f04f61e412647"
+checksum = "bc0287524726960e07b119cebd01678f852f147742ae0d925e6a520dca956126"
+
+[[package]]
+name = "naga"
+version = "30.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a616d2fb8c89516ac2723a581f69d6c18576046bed761bd6b305e5618e6ae130"
 dependencies = [
  "arrayvec",
  "bit-set",
@@ -3286,17 +3376,29 @@ dependencies = [
  "cfg_aliases",
  "codespan-reporting",
  "half",
- "hashbrown 0.16.1",
- "hexf-parse",
+ "hashbrown 0.17.0",
  "indexmap",
  "libm",
  "log",
+ "naga-types",
  "num-traits",
  "once_cell",
  "rustc-hash 1.1.0",
  "spirv",
  "thiserror 2.0.18",
  "unicode-ident",
+]
+
+[[package]]
+name = "naga-types"
+version = "30.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "590afbf58a6f4f62873cd5cff4468061844bafa1cdf399cc954537c22d768d49"
+dependencies = [
+ "hashbrown 0.17.0",
+ "indexmap",
+ "rustc-hash 1.1.0",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3366,16 +3468,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b51ed7824b6e07d354605f4abb3d9d300350701299da96642ee084f5ce631550"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
 ]
 
 [[package]]
@@ -3450,7 +3542,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3525,6 +3617,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
 name = "objc2-encode"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3552,6 +3656,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "objc2-metal"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3564,6 +3679,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-open-directory"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb82bed227edf5201dfedf072bba4015a33d3d4a98519837295a90f0a23f676d"
+dependencies = [
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-quartz-core"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3572,6 +3698,7 @@ dependencies = [
  "bitflags",
  "objc2",
  "objc2-core-foundation",
+ "objc2-core-graphics",
  "objc2-foundation",
  "objc2-metal",
 ]
@@ -3590,34 +3717,22 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
+
+[[package]]
+name = "once_vec"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b61fbf7ec37342ce171d9f5e3b82be74bda6c4e84e3b28338a03d553913e6aa"
 
 [[package]]
 name = "oneshot"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe21416a02c693fb9f980befcb230ecc70b0b3d1cc4abf88b9675c4c1457f0c"
-
-[[package]]
-name = "onig"
-version = "6.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc3cbf698f9438986c11a880c90a6d04b9de27575afd28bbf45b154b6c709e2"
-dependencies = [
- "bitflags",
- "libc",
- "once_cell",
- "onig_sys",
-]
-
-[[package]]
-name = "onig_sys"
-version = "69.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e68317604e77e53b85896388e1a803c1d21b74c899ec9e5e1112db90735edd7"
-dependencies = [
- "cc",
- "pkg-config",
-]
 
 [[package]]
 name = "option-ext"
@@ -3705,18 +3820,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
-name = "petgraph"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
-dependencies = [
- "fixedbitset",
- "hashbrown 0.15.5",
- "indexmap",
- "serde",
-]
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3735,6 +3838,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
+name = "pliron"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e51eb8628227038376c81dcb1752db90a90af24a1e38b27582c7dab235149d7"
+dependencies = [
+ "awint",
+ "combine",
+ "downcast-rs",
+ "dyn-clone",
+ "hashbrown 0.17.0",
+ "hi_sparse_bitset",
+ "indexmap",
+ "inventory",
+ "linkme",
+ "log",
+ "once_vec",
+ "pliron-derive",
+ "regex",
+ "rustc-hash 2.1.2",
+ "rustc_apfloat",
+ "slotmap",
+ "smallvec",
+ "spin 0.10.0",
+ "thiserror 2.0.18",
+ "utf8-chars",
+]
+
+[[package]]
+name = "pliron-derive"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f878ccd6bfd39a9373175774b96785daab296dc1870bc72ff7d285151f613a56"
+dependencies = [
+ "combine",
+ "convert_case 0.11.0",
+ "indexmap",
+ "proc-macro2",
+ "quote",
+ "rustc-hash 2.1.2",
+ "syn 3.0.4",
+]
+
+[[package]]
+name = "pliron-llvm"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "511535a077e4f72f83c437cde2636a6f525809a370b3078c0d1d5d53612ad052"
+dependencies = [
+ "bitflags",
+ "llvm-sys",
+ "log",
+ "pliron",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "png"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3749,10 +3908,11 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 dependencies = [
+ "critical-section",
  "serde",
 ]
 
@@ -3802,7 +3962,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bfe0f4c752e450fc2faf62654f1c134747922825d5b04ca717b8874f41a40c0"
+dependencies = [
+ "proc-macro2",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -3830,7 +4000,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52717f9a02b6965224f95ca2a81e2e0c5c43baacd28ca057577988930b6c3d5b"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4031,16 +4201,6 @@ checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_distr"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
-dependencies = [
- "num-traits",
- "rand 0.9.4",
-]
-
-[[package]]
-name = "rand_distr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d431c2703ccf129de4d45253c03f49ebb22b97d6ad79ee3ecfc7e3f4862c1d8"
@@ -4149,17 +4309,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rayon-cond"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964d0cf57a3e7a06e8183d14a8b527195c706b7983549cd5462d5aa3747438f"
-dependencies = [
- "either",
- "itertools 0.14.0",
- "rayon",
-]
-
-[[package]]
 name = "rayon-core"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4174,6 +4323,12 @@ name = "reborrow"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03251193000f4bd3b042892be858ee50e8b3719f2b08e5833ac4353724632430"
+
+[[package]]
+name = "recasting"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70aeee1a07922bfe7c79e148553dee262248d2493d9778eee7551b9b5d7cc651"
 
 [[package]]
 name = "redox_syscall"
@@ -4228,6 +4383,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4245,7 +4406,7 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-channel",
  "futures-core",
@@ -4320,6 +4481,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "rsqlite-vfs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
+dependencies = [
+ "hashbrown 0.16.1",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.40.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23f2a97da3e3873c73cb2a2e71b35c40ff95e0b1eefa8d72d8499a6928c3b5b3"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+ "sqlite-wasm-rs",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4336,6 +4522,16 @@ name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustc_apfloat"
+version = "0.2.3+llvm-462a31f5a5ab"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "486c2179b4796f65bfe2ee33679acf0927ac83ecf583ad6c91c3b4570911b9ad"
+dependencies = [
+ "bitflags",
+ "smallvec",
+]
 
 [[package]]
 name = "rustc_version"
@@ -4406,6 +4602,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "safe_arch"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42c6efa15875e6ecb39ca61fb0b0c1a40b84fac5a5ffe71eef7d1000c8eb3f5f"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "safetensors"
@@ -4501,7 +4706,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4597,16 +4802,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "slug"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "882a80f72ee45de3cc9a5afeb2da0331d58df69e4e7d8eeb5d3c7784ae67e724"
-dependencies = [
- "deunicode",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4632,6 +4827,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
 dependencies = [
  "lock_api",
+]
+
+[[package]]
+name = "spin"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a1655da78f3df8cecf4239a02d5c8b0966e485b0edc06f5f23cec7bcf460e61"
+dependencies = [
+ "lock_api",
+ "portable-atomic",
+]
+
+[[package]]
+name = "spin"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0134f9043ed38b087ac4f7d4af44c79e2c9e5094421fe3164f435ce585953b10"
+dependencies = [
+ "lock_api",
  "portable-atomic",
 ]
 
@@ -4645,15 +4859,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "spm_precompiled"
-version = "0.1.4"
+name = "sqlite-wasm-rs"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5851699c4033c63636f7ea4cf7b7c1f1bf06d0cc03cfb42e711de5a5c46cf326"
+checksum = "dc3efc0da82635d7e1ced0053bbbfa8c7ab9645d0bf36ceb4f7127bb85315d75"
 dependencies = [
- "base64 0.13.1",
- "nom 7.1.3",
- "serde",
- "unicode-segmentation",
+ "cc",
+ "js-sys",
+ "rsqlite-vfs",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -4698,6 +4912,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4714,7 +4939,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4733,15 +4958,16 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.38.4"
+version = "0.39.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
+checksum = "d2071df9448915b71c4fe6d25deaf1c22f12bd234f01540b77312bb8e41361e6"
 dependencies = [
  "libc",
  "memchr",
  "ntapi",
  "objc2-core-foundation",
  "objc2-io-kit",
+ "objc2-open-directory",
  "windows",
 ]
 
@@ -4770,7 +4996,7 @@ dependencies = [
  "safetensors 0.3.3",
  "thiserror 1.0.69",
  "torch-sys",
- "zip 0.6.6",
+ "zip",
 ]
 
 [[package]]
@@ -4825,7 +5051,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4836,7 +5062,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4905,39 +5131,6 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
-
-[[package]]
-name = "tokenizers"
-version = "0.22.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b238e22d44a15349529690fb07bd645cf58149a1b1e44d6cb5bd1641ff1a6223"
-dependencies = [
- "ahash",
- "aho-corasick",
- "compact_str",
- "dary_heap",
- "derive_builder",
- "esaxx-rs",
- "getrandom 0.3.4",
- "itertools 0.14.0",
- "log",
- "macro_rules_attribute",
- "monostate",
- "onig",
- "paste",
- "rand 0.9.4",
- "rayon",
- "rayon-cond",
- "regex",
- "regex-syntax",
- "serde",
- "serde_json",
- "spm_precompiled",
- "thiserror 2.0.18",
- "unicode-normalization-alignments",
- "unicode-segmentation",
- "unicode_categories",
-]
 
 [[package]]
 name = "tokio"
@@ -5027,7 +5220,7 @@ dependencies = [
  "serde",
  "serde_json",
  "ureq",
- "zip 0.6.6",
+ "zip",
 ]
 
 [[package]]
@@ -5076,23 +5269,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
-name = "tracel-llvm"
-version = "20.1.4-7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "982535db9eb1a30ac0f2c50239a0eec3e5cf50993a88e92b04747bd2f4d365b2"
-dependencies = [
- "tracel-mlir-rs",
- "tracel-mlir-sys",
-]
-
-[[package]]
 name = "tracel-llvm-bundler"
-version = "20.1.4-7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c75b8e477cb8d49d907afab029ca74d48459f5b88c27bdb4c6cd6acb5e61977"
+version = "22.1.4-6"
+source = "git+https://github.com/tracel-ai/tracel-llvm.git?rev=0853480b12e88872d9e3aea23246cfcd8c6205a5#0853480b12e88872d9e3aea23246cfcd8c6205a5"
 dependencies = [
  "anyhow",
  "bytes",
+ "cc",
  "constcat",
  "dirs",
  "liblzma",
@@ -5103,55 +5286,6 @@ dependencies = [
  "sha2",
  "tar",
  "walkdir",
-]
-
-[[package]]
-name = "tracel-mlir-rs"
-version = "20.1.4-7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a478a35efd68d0ba73f747adfb7923b121c64e7f5be9cd8364ca1dcb772d5c"
-dependencies = [
- "tracel-mlir-rs-macros",
- "tracel-mlir-sys",
-]
-
-[[package]]
-name = "tracel-mlir-rs-macros"
-version = "20.1.4-7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a94f36868c3b10b1825945223d99d106c73f4d249f063caa4651deeb9379344"
-dependencies = [
- "comrak",
- "convert_case 0.8.0",
- "proc-macro2",
- "quote",
- "regex",
- "syn",
- "tracel-llvm-bundler",
- "tracel-tblgen-rs",
- "unindent",
-]
-
-[[package]]
-name = "tracel-mlir-sys"
-version = "20.1.4-7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02f26d31af0c225a6d2e3d65d012fd6de848c9fc776897b152ee83b7d1bd15c4"
-dependencies = [
- "tracel-llvm-bundler",
-]
-
-[[package]]
-name = "tracel-tblgen-rs"
-version = "20.1.4-7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00d2581070380418ccc33b500f3739e4d4869421fdb477fcea51ff97c6253a52"
-dependencies = [
- "bindgen",
- "cc",
- "paste",
- "thiserror 2.0.18",
- "tracel-llvm-bundler",
 ]
 
 [[package]]
@@ -5173,7 +5307,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5183,6 +5317,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "triple_arena"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a99051ec05383f70bcab71884d39083a455257795e71cb780048a4bc890f3b8"
+dependencies = [
+ "recasting",
 ]
 
 [[package]]
@@ -5197,7 +5340,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a21cdb0fc8f85c98b1ec812bc4cd69faf6c0fa2fc17d44ea3c2cdd38dc08e999"
 dependencies = [
- "nom 8.0.0",
+ "nom",
 ]
 
 [[package]]
@@ -5210,18 +5353,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "typed-arena"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
-
-[[package]]
-name = "typed-path"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
-
-[[package]]
 name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5232,24 +5363,6 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
-name = "unicode-normalization"
-version = "0.1.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
-dependencies = [
- "tinyvec",
-]
-
-[[package]]
-name = "unicode-normalization-alignments"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43f613e4fa046e69818dd287fdc4bc78175ff20331479dab6e1b0f98d57062de"
-dependencies = [
- "smallvec",
-]
 
 [[package]]
 name = "unicode-segmentation"
@@ -5270,16 +5383,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
-name = "unicode_categories"
-version = "0.1.1"
+name = "unsynn"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
-
-[[package]]
-name = "unindent"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
+checksum = "501a7adf1a4bd9951501e5c66621e972ef8874d787628b7f90e64f936ef7ec0a"
+dependencies = [
+ "mutants",
+ "proc-macro2",
+ "rustc-hash 2.1.2",
+]
 
 [[package]]
 name = "untrusted"
@@ -5288,18 +5400,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
-name = "unty"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
-
-[[package]]
 name = "ureq"
 version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "flate2",
  "log",
  "once_cell",
@@ -5321,6 +5427,15 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+]
+
+[[package]]
+name = "utf8-chars"
+version = "3.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92498c67ea3511b37eccff13b573ed871faf0ce9c4056ab032bd01a681f445a0"
+dependencies = [
+ "arrayvec",
 ]
 
 [[package]]
@@ -5348,14 +5463,19 @@ dependencies = [
 
 [[package]]
 name = "variadics_please"
-version = "1.1.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41b6d82be61465f97d42bd1d15bf20f3b0a3a0905018f38f9d6f6962055b0b5c"
+checksum = "b53d0f7f2d0182759a549f1f313ce16b07d8f9ba93098157b5fa10ee3e61117f"
 dependencies = [
- "proc-macro2",
  "quote",
- "syn",
+ "unsynn",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -5414,9 +5534,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5427,9 +5547,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5437,9 +5557,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5447,22 +5567,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
 ]
@@ -5515,9 +5635,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5559,9 +5679,9 @@ checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "wgpu"
-version = "29.0.1"
+version = "30.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72c239a9a747bbd379590985bac952c2e53cb19873f7072b3370c6a6a8e06837"
+checksum = "527ccdf43dd5b2e8676eed9984ce00e2bbb0a1b85b70c1969dcb6cd2eb55ab9e"
 dependencies = [
  "arrayvec",
  "bitflags",
@@ -5569,7 +5689,7 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "document-features",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "js-sys",
  "log",
  "naga",
@@ -5589,9 +5709,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "29.0.1"
+version = "30.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e80ac6cf1895df6342f87d975162108f9d98772a0d74bc404ab7304ac29469e"
+checksum = "14c018fce9b6270aa203c2fdd56f3cce996713534bd757e4ea58c8560b121f14"
 dependencies = [
  "arrayvec",
  "bit-set",
@@ -5600,10 +5720,11 @@ dependencies = [
  "bytemuck",
  "cfg_aliases",
  "document-features",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "indexmap",
  "log",
  "naga",
+ "naga-types",
  "once_cell",
  "parking_lot",
  "portable-atomic",
@@ -5622,36 +5743,36 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core-deps-apple"
-version = "29.0.0"
+version = "30.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43acd053312501689cd92a01a9638d37f3e41a5fd9534875efa8917ee2d11ac0"
+checksum = "061f3d319a40d39d00b1ecc2c33b89fe21d4e6fe01859df3500a3a8ecccd6b68"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-emscripten"
-version = "29.0.0"
+version = "30.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef043bf135cc68b6f667c55ff4e345ce2b5924d75bad36a47921b0287ca4b24a"
+checksum = "d98b86cf4abf524a902dd35f18ca6a3f08fc2ae9847c8f10b48e30491b1f0b86"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-windows-linux-android"
-version = "29.0.0"
+version = "30.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "725d5c006a8c02967b6d93ef04f6537ec4593313e330cfe86d9d3f946eb90f28"
+checksum = "7586165fd5f6d881cb9ce4bb71f40d6caab2c0f1837e3fc1d9788a197fb6004f"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-hal"
-version = "29.0.1"
+version = "30.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89a47aef47636562f3937285af4c44b4b5b404b46577471411cc5313a921da7e"
+checksum = "b6b7fb58561a792bc237628ba0792e332de418fefe145f13b5ed8201e6d52f58"
 dependencies = [
  "android_system_properties",
  "arrayvec",
@@ -5665,17 +5786,18 @@ dependencies = [
  "glow",
  "glutin_wgl_sys",
  "gpu-allocator",
- "gpu-descriptor",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "js-sys",
  "khronos-egl",
  "libc",
  "libloading 0.8.9",
  "log",
  "naga",
+ "naga-types",
  "ndk-sys",
  "objc2",
  "objc2-core-foundation",
+ "objc2-core-graphics",
  "objc2-foundation",
  "objc2-metal",
  "objc2-quartz-core",
@@ -5690,6 +5812,7 @@ dependencies = [
  "raw-window-metal",
  "renderdoc-sys",
  "smallvec",
+ "static_assertions",
  "thiserror 2.0.18",
  "wasm-bindgen",
  "wayland-sys",
@@ -5698,13 +5821,14 @@ dependencies = [
  "wgpu-types",
  "windows",
  "windows-core",
+ "windows-result",
 ]
 
 [[package]]
 name = "wgpu-naga-bridge"
-version = "29.0.1"
+version = "30.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4684f4410da0cf95a4cb63bb5edaac022461dedb6adf0b64d0d9b5f6890d51"
+checksum = "d2f62e73117bb7a62bfd9c5a5841438a823f6566c6442a808ee269d2d055c081"
 dependencies = [
  "naga",
  "wgpu-types",
@@ -5712,16 +5836,28 @@ dependencies = [
 
 [[package]]
 name = "wgpu-types"
-version = "29.0.1"
+version = "30.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec2675540fb1a5cfa5ef122d3d5f390e2c75711a0b946410f2d6ac3a0f77d1f6"
+checksum = "99dad6f1fbdbbdb4c278a6508b059d44688f5cebddf78d005a46a31340269286"
 dependencies = [
  "bitflags",
  "bytemuck",
  "js-sys",
  "log",
+ "naga-types",
  "raw-window-handle",
+ "static_assertions",
  "web-sys",
+]
+
+[[package]]
+name = "wide"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de2aaf408e58689c2096682331b1f42bb2d9f2ed6b11560407d023cd0a6c634e"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
 ]
 
 [[package]]
@@ -5808,7 +5944,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5819,7 +5955,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6062,8 +6198,8 @@ dependencies = [
  "anyhow",
  "heck",
  "indexmap",
- "prettyplease",
- "syn",
+ "prettyplease 0.2.37",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -6076,10 +6212,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
 dependencies = [
  "anyhow",
- "prettyplease",
+ "prettyplease 0.2.37",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -6174,7 +6310,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -6195,7 +6331,7 @@ checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6215,7 +6351,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -6255,7 +6391,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6276,18 +6412,6 @@ dependencies = [
  "sha1",
  "time",
  "zstd",
-]
-
-[[package]]
-name = "zip"
-version = "7.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42e33efc22a0650c311c2ef19115ce232583abbe80850bc8b66509ebef02de0"
-dependencies = [
- "crc32fast",
- "indexmap",
- "memchr",
- "typed-path",
 ]
 
 [[package]]

--- a/scoreboard/runner/Cargo.toml
+++ b/scoreboard/runner/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2024"
 [workspace]
 
 [dependencies]
-burn = { git = "https://github.com/tracel-ai/burn", default-features = false, features = ["std", "flex"], rev = "b71e848ba6a7b91cbab5b8ebb7ed63885df9f8e3" }
-burn-store = { git = "https://github.com/tracel-ai/burn", default-features = false, features = ["burnpack", "std"], rev = "b71e848ba6a7b91cbab5b8ebb7ed63885df9f8e3" }
+burn = { git = "https://github.com/tracel-ai/burn", default-features = false, features = ["std", "flex"], rev = "a467575b5642fb135384d928ae9c0c7f1e0765be" }
+burn-store = { git = "https://github.com/tracel-ai/burn", default-features = false, features = ["std"], rev = "a467575b5642fb135384d928ae9c0c7f1e0765be" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 


### PR DESCRIPTION
Bumps the burn rev to [`a467575b`](https://github.com/tracel-ai/burn/commit/a467575b5642fb135384d928ae9c0c7f1e0765be) and migrates off `TensorSnapshot`.

burn's [#5411](https://github.com/tracel-ai/burn/pull/5411) (`refactor(store)!: replace TensorSnapshot with burn_pack::Tensor`) removes `TensorSnapshot`, deletes the `burn-store/burnpack` feature, and makes `burn-pack` a non-optional dependency of `burn-store`. Without this, the daily bump PR cannot compile.

## Changes

- `create_lazy_snapshot` returns a deferred `burn_pack::Tensor` built with `bridge::deferred`. Its `container_type` argument is gone: burn-pack no longer carries module metadata (`"Struct:Linear"`) on the tensor, and burn-onnx never read it back. That metadata now rides the live traversal stack upstream, where only `ModuleAdapter` needs it.
- `graph.rs` no longer materializes every snapshot before handing them to the writer. This resolves the eager-write FIXME ([burn#5219](https://github.com/tracel-ai/burn/issues/5219)): the writer draws one tensor at a time, so peak memory during a save is bounded by the largest single tensor instead of by the whole model.
- `ext.rs` exports `PackTensor`, `PackError` and `bridge` in place of `TensorSnapshot`.
- Drops the removed `burnpack` feature from the 35 manifests that requested it.

`bridge::deferred` validates the declared dtype and shape against what the provider returns. A wrong static shape now fails the write loudly instead of producing a pack whose header disagrees with its bytes.

## Note on the custom-op hook API

`create_lazy_snapshot` losing its third argument is a breaking change to the `ext` surface used by custom-op hooks. That API is unreleased, so no migration path is provided.

## Verification

- Full default-member workspace compiles; `cargo fmt --check`, `cargo xtask check lint`, and the no-std build gate are clean.
- All `.bpk` files under `onnx-tests` and `onnx-official-tests` were regenerated through the new deferred path, so the new dtype/shape validation ran against every test model.
- 935 `burn-onnx` tests and 609 `onnx-tests` pass. The latter includes the weight-bearing `conv`, `batch_norm` and `linear` tests, which construct via `Model::default()`, load the regenerated `.bpk`, and assert numeric sums against PyTorch references.

## scoreboard/runner

`scoreboard/runner` is a separate workspace carrying its own burn pin, so the root `Cargo.toml` substitution in `bump-burn.yml` never touched it. It last moved on 2026-04-27 and had drifted four months behind the workspace.

It is bumped to the same rev here and drops the removed `burnpack` feature. `bump-burn.yml` now rewrites that file as well: it cannot reuse the root `OLD -> NEW` substitution because the two pins are independent, so it rewrites whatever 40-hex sha the file holds, and updates the runner's lockfile too.

Verified: the runner builds against the new rev with `burn-store` at `features = ["std"]`, and the workflow's substitution was tested against a copy of the manifest.
