### PR TITLE
fix(burnpack): stream tensor writes via deferred providers

### DIFF
--- a/DESIGN-CUSTOM-OPS.md
+++ b/DESIGN-CUSTOM-OPS.md
@@ -15,7 +15,7 @@ them.
 
 Post-implementation review revisions (2026-08-12):
 
-- Trait methods that produce data (`forward`, `field`, `collect_snapshots` on
+- Trait methods that produce data (`forward`, `field`, `collect_tensors` on
   both `CustomOp` and `OpOverride`) return `Result<_, ProcessError>` so a hook
   can reject a configuration it cannot handle. Code generation itself has no
   recoverable error channel (`BurnGraph::codegen` returns a `TokenStream`), so
@@ -38,7 +38,7 @@ Post-implementation review revisions (2026-08-12):
   unconditionally overwriting `outputs[0]`.
 - `BurnGraph` rejects custom ops and override targets inside If/Loop/Scan
   bodies up front (subgraph body codegen is hook-free by design in v1), so
-  the field/snapshot collection and forward codegen halves cannot disagree.
+  the field/tensor collection and forward codegen halves cannot disagree.
 
 ## 1. Goals
 
@@ -616,7 +616,7 @@ single curated `burn_onnx::ext` module:
 ```rust
 // crates/burn-onnx/src/import/ext.rs (new) -- the ONLY entry point users import
 pub use crate::burn::custom_op::{CustomOp, OpOverride};
-pub use crate::burn::node_traits::{arg_to_ident, create_lazy_snapshot, Field};
+pub use crate::burn::node_traits::{arg_to_ident, create_deferred_tensor, Field};
 
 // Re-export the onnx-ir types users need so they need not depend on the
 // exact onnx-ir version directly.
@@ -625,7 +625,7 @@ pub use onnx_ir::{
     TensorData, TensorType,
 };
 
-// Burnpack tensor type used by collect_snapshots, plus the constructors for it.
+// Burnpack tensor type used by collect_tensors, plus the constructors for it.
 pub use burn_pack::{Error as PackError, Tensor as PackTensor};
 pub use burn_store::bridge;
 
@@ -665,9 +665,9 @@ impl<'a> Imports<'a> {
 
 Corrections to v1 in this list: `arg_to_ident` lives in `node_traits.rs:168`
 (not `argument_helpers.rs`) and is currently not re-exported anywhere, so the
-`ext` re-export is its promotion point. `create_lazy_snapshot`
+`ext` re-export is its promotion point. `create_deferred_tensor`
 (`node_traits.rs:197`) is what built-in nodes use to build `PackTensor`s
-from constant inputs; custom ops with weights need it for `collect_snapshots`,
+from constant inputs; custom ops with weights need it for `collect_tensors`,
 so it is part of the curated surface.
 
 Why wrappers instead of exposing `ScopeAtPosition` / `BurnImports`: the honest
@@ -731,15 +731,15 @@ pub trait CustomOp: Send + Sync + 'static {
     /// Optional: declare a module field (e.g. learnable params or RNG state).
     fn field(&self, _node: &CustomNode) -> Result<Option<Field>, ProcessError> { Ok(None) }
 
-    /// Optional: weights/snapshot collection (parallels NodeCodegen).
-    fn collect_snapshots(&self, _node: &CustomNode, _field_name: &str)
+    /// Optional: weights/tensor collection (parallels NodeCodegen).
+    fn collect_tensors(&self, _node: &CustomNode, _field_name: &str)
         -> Result<Vec<PackTensor>, ProcessError> { Ok(vec![]) }
 }
 ```
 
 `OpOverride` matches by `NodeType` instead of `(op_type, domain)` and receives
 the typed `Node`. It exposes the same overridable codegen surface as `CustomOp`
-(`forward`, `register_imports`, `field`, `collect_snapshots`) so the dispatch in
+(`forward`, `register_imports`, `field`, `collect_tensors`) so the dispatch in
 5.3 has a method to call for each. It deliberately has no `infer_output_types`:
 the built-in processor already produced correct types, and overrides are
 codegen-only (see open question 2).
@@ -755,7 +755,7 @@ pub trait OpOverride: Send + Sync + 'static {
 
     fn register_imports(&self, _imports: &mut Imports<'_>) {}
     fn field(&self, _node: &Node) -> Result<Option<Field>, ProcessError> { Ok(None) }
-    fn collect_snapshots(&self, _node: &Node, _field_name: &str)
+    fn collect_tensors(&self, _node: &Node, _field_name: &str)
         -> Result<Vec<PackTensor>, ProcessError> { Ok(vec![]) }
 }
 ```
@@ -855,7 +855,7 @@ impl NodeCodegen for Node {
         self.field_builtin()
     }
 
-    // register_imports() and collect_snapshots() take `&HookRegistry` and follow
+    // register_imports() and collect_tensors() take `&HookRegistry` and follow
     // the same pattern: override first, then Custom hook, then builtin.
 }
 ```
@@ -867,7 +867,7 @@ coverage pre-pass before codegen, so a miss here is a burn-onnx bug.)
 Threading: `BurnGraph` owns the `HookRegistry` (handed to it by `ModelGen`) and
 passes `&HookRegistry` into every `NodeCodegen` call site. All of those live in
 `graph.rs` (verified: `register_imports` at 475, `forward` at 688, `field` at
-885, `collect_snapshots` at 997; the `inputs`/`outputs` reads at 738/741 are
+885, `collect_tensors` at 997; the `inputs`/`outputs` reads at 738/741 are
 structural and unchanged). `partition.rs` has no direct `NodeCodegen` calls, so
 partitioned models pick up hooks for free through `graph.rs`.
 `ScopeAtPosition` itself does not carry the registry; this keeps it out of the
@@ -875,7 +875,7 @@ scope's clone-tracking state.
 
 Implementation correction: the hook-aware surface landed as free dispatch
 functions in `node_codegen.rs` (`node_forward`, `node_field`,
-`node_register_imports`, `node_collect_snapshots`), not as new parameters on
+`node_register_imports`, `node_collect_tensors`), not as new parameters on
 the `NodeCodegen` trait. Adding `&HookRegistry` to the trait would have
 re-signatured every per-node impl (~150 files) for a parameter none of them
 use; `Node` is a foreign type, so inherent methods were not an option either.
@@ -1060,9 +1060,9 @@ and fail with a friendly message" before any codegen capability lands.
    Handled naturally; no extra design needed.
 
 4. `field()` and learnable params. The trait supports declaring a struct field.
-   `collect_snapshots` is included from day one to avoid a breaking trait
-   change later, and `create_lazy_snapshot` is exported so custom ops build
-   snapshots the same way built-in nodes do.
+   `collect_tensors` is included from day one to avoid a breaking trait
+   change later, and `create_deferred_tensor` is exported so custom ops build
+   tensors the same way built-in nodes do.
 
 5. Versioning of the `CustomOp` trait. It lives in `burn-onnx`'s public API.
    Any change is a semver event. The trait above is minimal on purpose;

--- a/DEVELOPMENT-GUIDE.md
+++ b/DEVELOPMENT-GUIDE.md
@@ -219,7 +219,7 @@ For example, the squeeze operation in `crates/onnx-ir/src/node/squeeze.rs` conta
    - `outputs(&self)` - Returns references to output arguments (usually just `&self.outputs`)
    - `forward(&self, scope)` - Generates Rust code for the operation using the `quote!` macro
    - `field(&self)` - (Optional) Declares module fields for parameters like weights
-   - `collect_snapshots(&self, field_name)` - (Optional) Collects tensor snapshots for burnpack
+   - `collect_tensors(&self, field_name)` - (Optional) Collects deferred tensors for burnpack
      serialization
 
 3. Use helper utilities from `argument_helpers.rs`:
@@ -1113,9 +1113,9 @@ generated code, or `ModelGen::development(true)` which dumps the parsed graph,
 to see the node types your override will actually be matched against.
 
 An override wins over the built-in for every node of the target type,
-including its `field()`/`collect_snapshots()`. The defaults suppress the
+including its `field()`/`collect_tensors()`. The defaults suppress the
 built-in's field, so overriding a weighted op (Conv, Gemm, ...) means
-reimplementing both `field()` and `collect_snapshots()` for it; the built-in
+reimplementing both `field()` and `collect_tensors()` for it; the built-in
 `Field` and its init code are not inherited. Override targets appearing
 inside `If`/`Loop`/`Scan` bodies are rejected at code generation (subgraph
 bodies always use built-in codegen).

--- a/crates/burn-onnx/src/import/burn/custom_op.rs
+++ b/crates/burn-onnx/src/import/burn/custom_op.rs
@@ -73,8 +73,8 @@ pub trait CustomOp: Send + Sync + 'static {
         Ok(None)
     }
 
-    /// Optional: weights/snapshot collection (parallels the built-in nodes).
-    fn collect_snapshots(
+    /// Optional: weights/tensor collection (parallels the built-in nodes).
+    fn collect_tensors(
         &self,
         _node: &CustomNode,
         _field_name: &str,
@@ -112,13 +112,13 @@ pub trait OpOverride: Send + Sync + 'static {
     /// Optional: declare a module field in place of the built-in's.
     ///
     /// The default (`Ok(None)`) suppresses the built-in's field: overriding a
-    /// weighted op means reimplementing both `field` and `collect_snapshots`.
+    /// weighted op means reimplementing both `field` and `collect_tensors`.
     fn field(&self, _node: &Node) -> Result<Option<Field>, ProcessError> {
         Ok(None)
     }
 
-    /// Optional: weights/snapshot collection in place of the built-in's.
-    fn collect_snapshots(
+    /// Optional: weights/tensor collection in place of the built-in's.
+    fn collect_tensors(
         &self,
         _node: &Node,
         _field_name: &str,

--- a/crates/burn-onnx/src/import/burn/graph.rs
+++ b/crates/burn-onnx/src/import/burn/graph.rs
@@ -82,32 +82,18 @@ impl BurnGraph {
         // Collect all tensor snapshots from nodes
         let snapshots = self.collect_all_snapshots();
 
-        // Materialize snapshots into the tensor-agnostic burnpack representation.
-        // This is currently eager because burn-pack doesn't accept lazy tensor providers.
-        // See https://github.com/tracel-ai/burn/issues/5219.
-        // FIXME: this is a regression that should be fixed for the official release
-        let tensors = snapshots
-            .iter()
-            .map(|snapshot| {
-                let data = snapshot.to_data().map_err(|e| (snapshot.full_path(), e))?;
-                Ok(Tensor::new(
-                    snapshot.full_path(),
-                    snapshot.dtype,
-                    snapshot.shape.clone(),
-                    snapshot.tensor_id.map(|id| id.val()),
-                    data.bytes,
-                ))
-            })
-            .collect::<Result<Vec<_>, (String, burn_store::TensorSnapshotError)>>()
-            .unwrap_or_else(|(path, e)| {
-                panic!("Failed to materialize tensor snapshot {path}: {e}")
-            });
+        // Convert snapshots into deferred burnpack tensors so the writer materializes
+        // them one at a time, bounding peak memory to the largest single tensor instead
+        // of the whole model.
+        let tensors = snapshots.into_iter().map(Tensor::from).collect();
 
-        // Write burnpack file
+        // Write burnpack file. The atomic variant builds the container in a scratch file
+        // and renames it into place, so a deferred provider failing mid-write can't leave
+        // a truncated .bpk behind.
         let burnpack_file = out_file.with_extension("bpk");
         Writer::new(tensors)
             .with_metadata("producer", "burn-onnx")
-            .write_to_file(&burnpack_file)
+            .write_to_file_atomic(&burnpack_file)
             .unwrap_or_else(|e| {
                 panic!(
                     "Failed to write burnpack file {}: {e}",

--- a/crates/burn-onnx/src/import/burn/graph.rs
+++ b/crates/burn-onnx/src/import/burn/graph.rs
@@ -3,7 +3,7 @@ use crate::LoadStrategy;
 use crate::burn::custom_op::HookRegistry;
 use crate::burn::node::NodeCodegen;
 use crate::burn::node_codegen::{
-    node_collect_snapshots, node_field, node_forward, node_register_imports,
+    node_collect_tensors, node_field, node_forward, node_register_imports,
 };
 use crate::burn::partition::{
     MIN_GRAPH_SIZE, Partition, reorder_constants_to_consumers, try_partition,
@@ -27,7 +27,7 @@ pub struct BurnGraph {
     graph_output_args: Vec<onnx_ir::Argument>,
     /// Whether to partition large graphs into submodules (default: true)
     partition: bool,
-    /// Cached partition result (computed once, reused by snapshot collection and codegen)
+    /// Cached partition result (computed once, reused by tensor collection and codegen)
     cached_partition: Option<Option<Partition>>,
     /// Graph I/O args that were converted from ScalarTensor to ScalarNative at the
     /// boundary. Maps arg name -> DType. Used to insert conversion code:
@@ -78,10 +78,10 @@ impl BurnGraph {
         // run before it (codegen() re-checks for direct codegen users).
         self.validate_hooks_in_subgraphs();
 
-        // Collect all tensor snapshots from nodes. Each one stays deferred: the writer
+        // Collect all deferred tensors from nodes. Each one stays deferred: the writer
         // draws its bytes one at a time, so peak memory is bounded by the largest single
         // tensor rather than by the whole model.
-        let tensors = self.collect_all_snapshots();
+        let tensors = self.collect_all_tensors();
 
         // Write burnpack file. The atomic variant builds the container in a scratch file
         // and renames it into place, so a deferred provider failing mid-write can't leave
@@ -105,22 +105,22 @@ impl BurnGraph {
         self
     }
 
-    /// Collect all tensor snapshots from nodes recursively.
+    /// Collect all deferred tensors from nodes recursively.
     ///
-    /// When partitioned into submodules, snapshot paths are prefixed with the submodule
+    /// When partitioned into submodules, tensor paths are prefixed with the submodule
     /// field name (e.g. "submodule1.linear1.weight") so that `load_from` routes weights
     /// to the correct nested module.
-    fn collect_all_snapshots(&mut self) -> Vec<PackTensor> {
+    fn collect_all_tensors(&mut self) -> Vec<PackTensor> {
         let partition = self.compute_partition();
 
         if let Some(partition) = partition {
-            self.collect_snapshots_partitioned(&partition)
+            self.collect_tensors_partitioned(&partition)
         } else {
-            self.collect_snapshots_flat()
+            self.collect_tensors_flat()
         }
     }
 
-    /// Compute the partition once and cache it for reuse by both snapshot
+    /// Compute the partition once and cache it for reuse by both tensor
     /// collection and codegen, avoiding redundant work and ensuring consistency.
     fn compute_partition(&mut self) -> Option<Partition> {
         if let Some(ref cached) = self.cached_partition {
@@ -141,36 +141,36 @@ impl BurnGraph {
         result
     }
 
-    fn collect_snapshots_flat(&self) -> Vec<PackTensor> {
-        let mut snapshots = Vec::new();
+    fn collect_tensors_flat(&self) -> Vec<PackTensor> {
+        let mut tensors = Vec::new();
         let mut field_name_counts: HashMap<String, usize> = HashMap::new();
-        collect_snapshots_from_nodes(
+        collect_tensors_from_nodes(
             &self.nodes,
             "",
             &mut field_name_counts,
-            &mut snapshots,
+            &mut tensors,
             &self.hooks,
         );
-        snapshots
+        tensors
     }
 
-    fn collect_snapshots_partitioned(&self, partition: &Partition) -> Vec<PackTensor> {
-        let mut snapshots = Vec::new();
+    fn collect_tensors_partitioned(&self, partition: &Partition) -> Vec<PackTensor> {
+        let mut tensors = Vec::new();
 
         for (chunk_idx, range) in partition.chunks.iter().enumerate() {
             let prefix = format!("submodule{}", chunk_idx + 1);
             let chunk_nodes = &self.nodes[range.clone()];
             // Each chunk gets its own counter to match collect_fields_for_nodes (per-chunk)
             let mut field_name_counts: HashMap<String, usize> = HashMap::new();
-            collect_snapshots_from_nodes(
+            collect_tensors_from_nodes(
                 chunk_nodes,
                 &prefix,
                 &mut field_name_counts,
-                &mut snapshots,
+                &mut tensors,
                 &self.hooks,
             );
         }
-        snapshots
+        tensors
     }
 
     /// Add blank spaces in some places
@@ -197,7 +197,7 @@ impl BurnGraph {
 
     /// Set the codegen hooks for custom (non-built-in) ops.
     ///
-    /// Must be applied before `with_burnpack`, which collects snapshots and
+    /// Must be applied before `with_burnpack`, which collects tensors and
     /// therefore consults the hooks for `Node::Custom` fields.
     pub(crate) fn with_hooks(mut self, hooks: Arc<HookRegistry>) -> Self {
         self.hooks = hooks;
@@ -1085,24 +1085,24 @@ fn collect_fields_for_nodes(nodes: &[Node], hooks: &HookRegistry) -> Vec<FieldTu
     all_fields
 }
 
-/// Collect tensor snapshots from a slice of nodes, optionally prefixing paths.
+/// Collect deferred tensors from a slice of nodes, optionally prefixing paths.
 ///
-/// When `prefix` is non-empty, snapshot paths become "prefix.field.weight" etc.
-fn collect_snapshots_from_nodes(
+/// When `prefix` is non-empty, tensor paths become "prefix.field.weight" etc.
+fn collect_tensors_from_nodes(
     nodes: &[Node],
     prefix: &str,
     field_name_counts: &mut HashMap<String, usize>,
-    snapshots: &mut Vec<PackTensor>,
+    tensors: &mut Vec<PackTensor>,
     hooks: &HookRegistry,
 ) {
     // Hook-free for the same reason as collect_subgraph_fields_recursive:
     // subgraph forward codegen is hook-free, and hook-relevant body nodes
     // are rejected up front.
-    fn collect_subgraph_snapshots_recursive(
+    fn collect_subgraph_tensors_recursive(
         subgraph: &onnx_ir::OnnxGraph,
         prefix: &str,
         field_name_counts: &mut HashMap<String, usize>,
-        snapshots: &mut Vec<PackTensor>,
+        tensors: &mut Vec<PackTensor>,
     ) {
         for node in &subgraph.nodes {
             if let Some(field) = NodeCodegen::field(node) {
@@ -1121,29 +1121,29 @@ fn collect_snapshots_from_nodes(
                 } else {
                     format!("{}.{}", prefix, unique_name)
                 };
-                let node_snapshots = NodeCodegen::collect_snapshots(node, &full_name);
-                snapshots.extend(node_snapshots);
+                let node_tensors = NodeCodegen::collect_tensors(node, &full_name);
+                tensors.extend(node_tensors);
             }
 
             if let Node::If(nested) = node {
-                collect_subgraph_snapshots_recursive(
+                collect_subgraph_tensors_recursive(
                     &nested.config.then_branch,
                     prefix,
                     field_name_counts,
-                    snapshots,
+                    tensors,
                 );
-                collect_subgraph_snapshots_recursive(
+                collect_subgraph_tensors_recursive(
                     &nested.config.else_branch,
                     prefix,
                     field_name_counts,
-                    snapshots,
+                    tensors,
                 );
             } else if let Node::Loop(nested) = node {
-                collect_subgraph_snapshots_recursive(
+                collect_subgraph_tensors_recursive(
                     &nested.config.body,
                     prefix,
                     field_name_counts,
-                    snapshots,
+                    tensors,
                 );
             }
         }
@@ -1166,29 +1166,29 @@ fn collect_snapshots_from_nodes(
             } else {
                 format!("{}.{}", prefix, unique_name)
             };
-            let node_snapshots = node_collect_snapshots(node, &full_name, hooks);
-            snapshots.extend(node_snapshots);
+            let node_tensors = node_collect_tensors(node, &full_name, hooks);
+            tensors.extend(node_tensors);
         }
 
         if let Node::If(if_node) = node {
-            collect_subgraph_snapshots_recursive(
+            collect_subgraph_tensors_recursive(
                 &if_node.config.then_branch,
                 prefix,
                 field_name_counts,
-                snapshots,
+                tensors,
             );
-            collect_subgraph_snapshots_recursive(
+            collect_subgraph_tensors_recursive(
                 &if_node.config.else_branch,
                 prefix,
                 field_name_counts,
-                snapshots,
+                tensors,
             );
         } else if let Node::Loop(loop_node) = node {
-            collect_subgraph_snapshots_recursive(
+            collect_subgraph_tensors_recursive(
                 &loop_node.config.body,
                 prefix,
                 field_name_counts,
-                snapshots,
+                tensors,
             );
         }
     }
@@ -1299,8 +1299,8 @@ mod tests {
         graph.codegen();
     }
 
-    /// Custom op that declares a module field and a weight snapshot,
-    /// exercising the node_field / node_collect_snapshots dispatch.
+    /// Custom op that declares a module field and a weight tensor,
+    /// exercising the node_field / node_collect_tensors dispatch.
     struct StatefulFftOp;
 
     impl crate::ext::CustomOp for StatefulFftOp {
@@ -1346,7 +1346,7 @@ mod tests {
             )))
         }
 
-        fn collect_snapshots(
+        fn collect_tensors(
             &self,
             _node: &onnx_ir::CustomNode,
             field_name: &str,
@@ -1364,21 +1364,20 @@ mod tests {
     }
 
     #[test]
-    fn custom_op_field_and_snapshots_dispatch_to_hook() {
+    fn custom_op_field_and_tensors_dispatch_to_hook() {
         let mut registry = HookRegistry::default();
         registry.add_custom_op(Box::new(StatefulFftOp));
         let registry = Arc::new(registry);
 
-        // Snapshot collection consults the hook's field and collect_snapshots
+        // Snapshot collection consults the hook's field and collect_tensors
         let graph = build_custom_op_graph().with_hooks(registry.clone());
         let node = &graph.nodes[0];
         let field =
             crate::burn::node_codegen::node_field(node, &registry).expect("hook-declared field");
         assert_eq!(field.name.to_string(), "fft_state");
-        let snapshots =
-            crate::burn::node_codegen::node_collect_snapshots(node, "fft_state", &registry);
-        assert_eq!(snapshots.len(), 1);
-        assert_eq!(snapshots[0].name, "fft_state.state");
+        let tensors = crate::burn::node_codegen::node_collect_tensors(node, "fft_state", &registry);
+        assert_eq!(tensors.len(), 1);
+        assert_eq!(tensors[0].name, "fft_state.state");
 
         // The generated struct and forward reference the hook's field
         let code = format_tokens(graph.codegen());

--- a/crates/burn-onnx/src/import/burn/node/batch_norm.rs
+++ b/crates/burn-onnx/src/import/burn/node/batch_norm.rs
@@ -103,45 +103,45 @@ impl NodeCodegen for BatchNormalizationNode {
         }
     }
 
-    fn collect_snapshots(&self, field_name: &str) -> Vec<PackTensor> {
+    fn collect_tensors(&self, field_name: &str) -> Vec<PackTensor> {
         match &self.config {
             BatchNormConfig::Static(_) => {
-                use crate::burn::node_traits::create_lazy_snapshot;
-                let mut snapshots = vec![];
+                use crate::burn::node_traits::create_deferred_tensor;
+                let mut tensors = vec![];
 
                 if let Some(gamma_input) = self.inputs.get(1) {
                     let gamma_path = format!("{}.gamma", field_name);
-                    if let Some(snapshot) = create_lazy_snapshot(gamma_input, &gamma_path) {
-                        snapshots.push(snapshot);
+                    if let Some(tensor) = create_deferred_tensor(gamma_input, &gamma_path) {
+                        tensors.push(tensor);
                     }
                 }
 
                 if let Some(beta_input) = self.inputs.get(2) {
                     let beta_path = format!("{}.beta", field_name);
-                    if let Some(snapshot) = create_lazy_snapshot(beta_input, &beta_path) {
-                        snapshots.push(snapshot);
+                    if let Some(tensor) = create_deferred_tensor(beta_input, &beta_path) {
+                        tensors.push(tensor);
                     }
                 }
 
                 if let Some(running_mean_input) = self.inputs.get(3) {
                     let running_mean_path = format!("{}.running_mean", field_name);
-                    if let Some(snapshot) =
-                        create_lazy_snapshot(running_mean_input, &running_mean_path)
+                    if let Some(tensor) =
+                        create_deferred_tensor(running_mean_input, &running_mean_path)
                     {
-                        snapshots.push(snapshot);
+                        tensors.push(tensor);
                     }
                 }
 
                 if let Some(running_var_input) = self.inputs.get(4) {
                     let running_var_path = format!("{}.running_var", field_name);
-                    if let Some(snapshot) =
-                        create_lazy_snapshot(running_var_input, &running_var_path)
+                    if let Some(tensor) =
+                        create_deferred_tensor(running_var_input, &running_var_path)
                     {
-                        snapshots.push(snapshot);
+                        tensors.push(tensor);
                     }
                 }
 
-                snapshots
+                tensors
             }
             BatchNormConfig::Runtime(_) => vec![],
         }

--- a/crates/burn-onnx/src/import/burn/node/constant.rs
+++ b/crates/burn-onnx/src/import/burn/node/constant.rs
@@ -186,20 +186,20 @@ impl NodeCodegen for onnx_ir::node::constant::ConstantNode {
         Some(Field::new(self.name.clone(), ty, init))
     }
 
-    fn collect_snapshots(&self, field_name: &str) -> Vec<PackTensor> {
-        use crate::burn::node_traits::create_lazy_snapshot;
+    fn collect_tensors(&self, field_name: &str) -> Vec<PackTensor> {
+        use crate::burn::node_traits::create_deferred_tensor;
 
         let output = self.outputs.first().unwrap();
 
-        // Collect snapshots for tensor and ScalarTensor constants.
+        // Collect deferred tensors for tensor and ScalarTensor constants.
         // ScalarTensor values are also embedded in the field initializer for Model::new(),
         // but burnpack needs them too for Model::from_file() / from_bytes() / from_embedded().
         match &output.ty {
             ArgType::Tensor(_) | ArgType::ScalarTensor(_) => {
                 if let Some(input) = self.inputs.first() {
                     // Use the field name as the path since constants are stored as single params
-                    if let Some(snapshot) = create_lazy_snapshot(input, field_name) {
-                        vec![snapshot]
+                    if let Some(tensor) = create_deferred_tensor(input, field_name) {
+                        vec![tensor]
                     } else {
                         vec![]
                     }

--- a/crates/burn-onnx/src/import/burn/node/conv1d.rs
+++ b/crates/burn-onnx/src/import/burn/node/conv1d.rs
@@ -69,27 +69,27 @@ impl NodeCodegen for onnx_ir::conv1d::Conv1dNode {
         imports.register("burn::nn::conv::Conv1dConfig");
     }
 
-    fn collect_snapshots(&self, field_name: &str) -> Vec<PackTensor> {
-        use crate::burn::node_traits::create_lazy_snapshot;
-        let mut snapshots = vec![];
+    fn collect_tensors(&self, field_name: &str) -> Vec<PackTensor> {
+        use crate::burn::node_traits::create_deferred_tensor;
+        let mut tensors = vec![];
 
         // Weight tensor (input index 1)
         if let Some(weight_input) = self.inputs.get(1) {
             let weight_path = format!("{}.weight", field_name);
-            if let Some(snapshot) = create_lazy_snapshot(weight_input, &weight_path) {
-                snapshots.push(snapshot);
+            if let Some(tensor) = create_deferred_tensor(weight_input, &weight_path) {
+                tensors.push(tensor);
             }
         }
 
         // Bias tensor if present (input index 2)
         if let Some(bias_input) = self.inputs.get(2) {
             let bias_path = format!("{}.bias", field_name);
-            if let Some(snapshot) = create_lazy_snapshot(bias_input, &bias_path) {
-                snapshots.push(snapshot);
+            if let Some(tensor) = create_deferred_tensor(bias_input, &bias_path) {
+                tensors.push(tensor);
             }
         }
 
-        snapshots
+        tensors
     }
 }
 

--- a/crates/burn-onnx/src/import/burn/node/conv2d.rs
+++ b/crates/burn-onnx/src/import/burn/node/conv2d.rs
@@ -51,16 +51,16 @@ impl NodeCodegen for onnx_ir::conv2d::Conv2dNode {
         ))
     }
 
-    fn collect_snapshots(&self, field_name: &str) -> Vec<PackTensor> {
-        use crate::burn::node_traits::create_lazy_snapshot;
+    fn collect_tensors(&self, field_name: &str) -> Vec<PackTensor> {
+        use crate::burn::node_traits::create_deferred_tensor;
 
-        let mut snapshots = vec![];
+        let mut tensors = vec![];
 
         // Weight tensor (input index 1)
         if let Some(weight_input) = self.inputs.get(1) {
             let weight_path = format!("{}.weight", field_name);
-            if let Some(snapshot) = create_lazy_snapshot(weight_input, &weight_path) {
-                snapshots.push(snapshot);
+            if let Some(tensor) = create_deferred_tensor(weight_input, &weight_path) {
+                tensors.push(tensor);
             }
         }
 
@@ -69,12 +69,12 @@ impl NodeCodegen for onnx_ir::conv2d::Conv2dNode {
             && let Some(bias_input) = self.inputs.get(2)
         {
             let bias_path = format!("{}.bias", field_name);
-            if let Some(snapshot) = create_lazy_snapshot(bias_input, &bias_path) {
-                snapshots.push(snapshot);
+            if let Some(tensor) = create_deferred_tensor(bias_input, &bias_path) {
+                tensors.push(tensor);
             }
         }
 
-        snapshots
+        tensors
     }
 
     fn forward(&self, scope: &mut ScopeAtPosition<'_>) -> TokenStream {

--- a/crates/burn-onnx/src/import/burn/node/conv3d.rs
+++ b/crates/burn-onnx/src/import/burn/node/conv3d.rs
@@ -68,27 +68,27 @@ impl NodeCodegen for onnx_ir::conv3d::Conv3dNode {
         imports.register("burn::nn::conv::Conv3dConfig");
     }
 
-    fn collect_snapshots(&self, field_name: &str) -> Vec<PackTensor> {
-        use crate::burn::node_traits::create_lazy_snapshot;
-        let mut snapshots = vec![];
+    fn collect_tensors(&self, field_name: &str) -> Vec<PackTensor> {
+        use crate::burn::node_traits::create_deferred_tensor;
+        let mut tensors = vec![];
 
         // Weight tensor (input index 1)
         if let Some(weight_input) = self.inputs.get(1) {
             let weight_path = format!("{}.weight", field_name);
-            if let Some(snapshot) = create_lazy_snapshot(weight_input, &weight_path) {
-                snapshots.push(snapshot);
+            if let Some(tensor) = create_deferred_tensor(weight_input, &weight_path) {
+                tensors.push(tensor);
             }
         }
 
         // Bias tensor if present (input index 2)
         if let Some(bias_input) = self.inputs.get(2) {
             let bias_path = format!("{}.bias", field_name);
-            if let Some(snapshot) = create_lazy_snapshot(bias_input, &bias_path) {
-                snapshots.push(snapshot);
+            if let Some(tensor) = create_deferred_tensor(bias_input, &bias_path) {
+                tensors.push(tensor);
             }
         }
 
-        snapshots
+        tensors
     }
 }
 

--- a/crates/burn-onnx/src/import/burn/node/conv_transpose_1d.rs
+++ b/crates/burn-onnx/src/import/burn/node/conv_transpose_1d.rs
@@ -60,10 +60,10 @@ impl NodeCodegen for onnx_ir::node::conv_transpose1d::ConvTranspose1dNode {
         imports.register("burn::nn::conv::ConvTranspose1dConfig");
     }
 
-    fn collect_snapshots(&self, field_name: &str) -> Vec<PackTensor> {
-        use crate::burn::node_traits::create_lazy_snapshot;
+    fn collect_tensors(&self, field_name: &str) -> Vec<PackTensor> {
+        use crate::burn::node_traits::create_deferred_tensor;
 
-        let mut snapshots = vec![];
+        let mut tensors = vec![];
 
         // Weight tensor (input index 1)
         // ONNX ConvTranspose weight: [in_channels, out_channels/groups, kL]
@@ -71,8 +71,8 @@ impl NodeCodegen for onnx_ir::node::conv_transpose1d::ConvTranspose1dNode {
         // These layouts match! No transformation needed.
         if let Some(weight_input) = self.inputs.get(1) {
             let weight_path = format!("{}.weight", field_name);
-            if let Some(snapshot) = create_lazy_snapshot(weight_input, &weight_path) {
-                snapshots.push(snapshot);
+            if let Some(tensor) = create_deferred_tensor(weight_input, &weight_path) {
+                tensors.push(tensor);
             }
         }
 
@@ -81,12 +81,12 @@ impl NodeCodegen for onnx_ir::node::conv_transpose1d::ConvTranspose1dNode {
             && let Some(bias_input) = self.inputs.get(2)
         {
             let bias_path = format!("{}.bias", field_name);
-            if let Some(snapshot) = create_lazy_snapshot(bias_input, &bias_path) {
-                snapshots.push(snapshot);
+            if let Some(tensor) = create_deferred_tensor(bias_input, &bias_path) {
+                tensors.push(tensor);
             }
         }
 
-        snapshots
+        tensors
     }
 }
 

--- a/crates/burn-onnx/src/import/burn/node/conv_transpose_2d.rs
+++ b/crates/burn-onnx/src/import/burn/node/conv_transpose_2d.rs
@@ -59,10 +59,10 @@ impl NodeCodegen for onnx_ir::node::conv_transpose2d::ConvTranspose2dNode {
         imports.register("burn::nn::conv::ConvTranspose2dConfig");
     }
 
-    fn collect_snapshots(&self, field_name: &str) -> Vec<PackTensor> {
-        use crate::burn::node_traits::create_lazy_snapshot;
+    fn collect_tensors(&self, field_name: &str) -> Vec<PackTensor> {
+        use crate::burn::node_traits::create_deferred_tensor;
 
-        let mut snapshots = vec![];
+        let mut tensors = vec![];
 
         // Weight tensor (input index 1)
         // ONNX ConvTranspose weight: [in_channels, out_channels/groups, kH, kW]
@@ -70,8 +70,8 @@ impl NodeCodegen for onnx_ir::node::conv_transpose2d::ConvTranspose2dNode {
         // These layouts match! No transformation needed.
         if let Some(weight_input) = self.inputs.get(1) {
             let weight_path = format!("{}.weight", field_name);
-            if let Some(snapshot) = create_lazy_snapshot(weight_input, &weight_path) {
-                snapshots.push(snapshot);
+            if let Some(tensor) = create_deferred_tensor(weight_input, &weight_path) {
+                tensors.push(tensor);
             }
         }
 
@@ -80,12 +80,12 @@ impl NodeCodegen for onnx_ir::node::conv_transpose2d::ConvTranspose2dNode {
             && let Some(bias_input) = self.inputs.get(2)
         {
             let bias_path = format!("{}.bias", field_name);
-            if let Some(snapshot) = create_lazy_snapshot(bias_input, &bias_path) {
-                snapshots.push(snapshot);
+            if let Some(tensor) = create_deferred_tensor(bias_input, &bias_path) {
+                tensors.push(tensor);
             }
         }
 
-        snapshots
+        tensors
     }
 }
 

--- a/crates/burn-onnx/src/import/burn/node/conv_transpose_3d.rs
+++ b/crates/burn-onnx/src/import/burn/node/conv_transpose_3d.rs
@@ -59,10 +59,10 @@ impl NodeCodegen for onnx_ir::node::conv_transpose3d::ConvTranspose3dNode {
         imports.register("burn::nn::conv::ConvTranspose3dConfig");
     }
 
-    fn collect_snapshots(&self, field_name: &str) -> Vec<PackTensor> {
-        use crate::burn::node_traits::create_lazy_snapshot;
+    fn collect_tensors(&self, field_name: &str) -> Vec<PackTensor> {
+        use crate::burn::node_traits::create_deferred_tensor;
 
-        let mut snapshots = vec![];
+        let mut tensors = vec![];
 
         // Weight tensor (input index 1)
         // ONNX ConvTranspose weight: [in_channels, out_channels/groups, kD, kH, kW]
@@ -70,8 +70,8 @@ impl NodeCodegen for onnx_ir::node::conv_transpose3d::ConvTranspose3dNode {
         // These layouts match! No transformation needed.
         if let Some(weight_input) = self.inputs.get(1) {
             let weight_path = format!("{}.weight", field_name);
-            if let Some(snapshot) = create_lazy_snapshot(weight_input, &weight_path) {
-                snapshots.push(snapshot);
+            if let Some(tensor) = create_deferred_tensor(weight_input, &weight_path) {
+                tensors.push(tensor);
             }
         }
 
@@ -80,12 +80,12 @@ impl NodeCodegen for onnx_ir::node::conv_transpose3d::ConvTranspose3dNode {
             && let Some(bias_input) = self.inputs.get(2)
         {
             let bias_path = format!("{}.bias", field_name);
-            if let Some(snapshot) = create_lazy_snapshot(bias_input, &bias_path) {
-                snapshots.push(snapshot);
+            if let Some(tensor) = create_deferred_tensor(bias_input, &bias_path) {
+                tensors.push(tensor);
             }
         }
 
-        snapshots
+        tensors
     }
 }
 

--- a/crates/burn-onnx/src/import/burn/node/deform_conv.rs
+++ b/crates/burn-onnx/src/import/burn/node/deform_conv.rs
@@ -83,15 +83,15 @@ impl NodeCodegen for DeformConvNode {
         ))
     }
 
-    fn collect_snapshots(&self, field_name: &str) -> Vec<PackTensor> {
-        use crate::burn::node_traits::create_lazy_snapshot;
+    fn collect_tensors(&self, field_name: &str) -> Vec<PackTensor> {
+        use crate::burn::node_traits::create_deferred_tensor;
 
-        let mut snapshots = vec![];
+        let mut tensors = vec![];
 
         if let Some(weight_input) = self.inputs.get(1) {
             let weight_path = format!("{}.weight", field_name);
-            if let Some(snapshot) = create_lazy_snapshot(weight_input, &weight_path) {
-                snapshots.push(snapshot);
+            if let Some(tensor) = create_deferred_tensor(weight_input, &weight_path) {
+                tensors.push(tensor);
             }
         }
 
@@ -99,12 +99,12 @@ impl NodeCodegen for DeformConvNode {
             && !bias_input.is_optional()
         {
             let bias_path = format!("{}.bias", field_name);
-            if let Some(snapshot) = create_lazy_snapshot(bias_input, &bias_path) {
-                snapshots.push(snapshot);
+            if let Some(tensor) = create_deferred_tensor(bias_input, &bias_path) {
+                tensors.push(tensor);
             }
         }
 
-        snapshots
+        tensors
     }
 
     fn forward(&self, scope: &mut ScopeAtPosition<'_>) -> TokenStream {
@@ -368,21 +368,21 @@ mod tests {
     }
 
     #[test]
-    fn test_deform_conv_collect_snapshots_with_bias() {
+    fn test_deform_conv_collect_tensors_with_bias() {
         use crate::burn::node_traits::NodeCodegen;
 
         let node = create_static_deform_conv_node("deform_conv1", true, false);
-        let snapshots = node.collect_snapshots("deform_conv1");
-        assert_eq!(snapshots.len(), 2);
+        let tensors = node.collect_tensors("deform_conv1");
+        assert_eq!(tensors.len(), 2);
     }
 
     #[test]
-    fn test_deform_conv_collect_snapshots_without_bias() {
+    fn test_deform_conv_collect_tensors_without_bias() {
         use crate::burn::node_traits::NodeCodegen;
 
         let node = create_static_deform_conv_node("deform_conv1", false, false);
-        let snapshots = node.collect_snapshots("deform_conv1");
-        assert_eq!(snapshots.len(), 1);
+        let tensors = node.collect_tensors("deform_conv1");
+        assert_eq!(tensors.len(), 1);
     }
 
     #[test]

--- a/crates/burn-onnx/src/import/burn/node/group_norm.rs
+++ b/crates/burn-onnx/src/import/burn/node/group_norm.rs
@@ -44,26 +44,26 @@ impl NodeCodegen for GroupNormalizationNode {
         ))
     }
 
-    fn collect_snapshots(&self, field_name: &str) -> Vec<PackTensor> {
-        use crate::burn::node_traits::create_lazy_snapshot;
+    fn collect_tensors(&self, field_name: &str) -> Vec<PackTensor> {
+        use crate::burn::node_traits::create_deferred_tensor;
 
-        let mut snapshots = vec![];
+        let mut tensors = vec![];
 
         if let Some(gamma_input) = self.inputs.get(1) {
             let gamma_path = format!("{}.gamma", field_name);
-            if let Some(snapshot) = create_lazy_snapshot(gamma_input, &gamma_path) {
-                snapshots.push(snapshot);
+            if let Some(tensor) = create_deferred_tensor(gamma_input, &gamma_path) {
+                tensors.push(tensor);
             }
         }
 
         if let Some(beta_input) = self.inputs.get(2) {
             let beta_path = format!("{}.beta", field_name);
-            if let Some(snapshot) = create_lazy_snapshot(beta_input, &beta_path) {
-                snapshots.push(snapshot);
+            if let Some(tensor) = create_deferred_tensor(beta_input, &beta_path) {
+                tensors.push(tensor);
             }
         }
 
-        snapshots
+        tensors
     }
 
     fn forward(&self, scope: &mut ScopeAtPosition<'_>) -> TokenStream {

--- a/crates/burn-onnx/src/import/burn/node/gru.rs
+++ b/crates/burn-onnx/src/import/burn/node/gru.rs
@@ -25,7 +25,7 @@ use burn_pack::Tensor as PackTensor;
 use burn_store::bridge;
 use onnx_ir::gru::{GruActivationFunction, GruDirection};
 
-/// Collect tensor snapshots for GRU burnpack serialization.
+/// Collect deferred tensors for GRU burnpack serialization.
 ///
 /// ONNX GRU weight layout:
 /// - W: `[num_directions, 3*hidden_size, input_size]` - gates ordered as [z, r, h]
@@ -37,7 +37,7 @@ use onnx_ir::gru::{GruActivationFunction, GruDirection};
 /// - update_gate.hidden_transform: weight `[hidden_size, hidden_size]`, bias `[hidden_size]`
 /// - reset_gate, new_gate: same structure
 #[allow(clippy::single_range_in_vec_init)]
-fn collect_gru_snapshots(
+fn collect_gru_tensors(
     field_name: &str,
     inputs: &[Argument],
     config: &onnx_ir::gru::GruConfig,
@@ -57,7 +57,7 @@ fn collect_gru_snapshots(
     // missing W/R, or a group split across initializers and graph inputs), so reaching
     // here means the tensor store lost a value we were promised. Returning an empty list
     // instead would rebuild the bug this path exists to fix: a struct full of gate
-    // `Param`s that no snapshot fills, which `from_file` reports as missing tensors and
+    // `Param`s that no tensor fills, which `from_file` reports as missing tensors and
     // `Model::new` silently fills with random values.
     let (Some(data_w), Some(data_r)) = (data_w, data_r) else {
         panic!(
@@ -83,12 +83,12 @@ fn collect_gru_snapshots(
         GruDirection::Bidirectional => vec!["forward.", "reverse."],
     };
 
-    let mut snapshots = Vec::new();
+    let mut tensors = Vec::new();
 
     // Create tensors from data, pinning the runtime dtype to the ONNX weight
     // dtype via `(device, dtype)`. A bare `&device` would let
     // `Tensor::from_data` resolve the dtype from the device default and
-    // silently truncate f64 weights before they enter the snapshot pipeline.
+    // silently truncate f64 weights before they enter the tensor pipeline.
     let w_tensor: Tensor<3> = Tensor::from_data(data_w.clone(), (&device, dtype));
     let r_tensor: Tensor<3> = Tensor::from_data(data_r.clone(), (&device, dtype));
     let b_tensor: Option<Tensor<2>> = data_b
@@ -135,7 +135,7 @@ fn collect_gru_snapshots(
                 "{}.{}{}.input_transform.weight",
                 field_name, dir_prefix, gate_name
             );
-            snapshots.push(create_snapshot_from_data(w_gate_data, &path, dtype));
+            tensors.push(create_tensor_from_data(w_gate_data, &path, dtype));
 
             // Input transform bias: Wb for this gate
             if let Some(ref b) = b_dir {
@@ -149,7 +149,7 @@ fn collect_gru_snapshots(
                     "{}.{}{}.input_transform.bias",
                     field_name, dir_prefix, gate_name
                 );
-                snapshots.push(create_snapshot_from_data(bias_data, &path, dtype));
+                tensors.push(create_tensor_from_data(bias_data, &path, dtype));
             }
 
             // Hidden transform weight: ONNX [hidden_size, hidden_size] -> Burn [hidden_size, hidden_size]
@@ -163,7 +163,7 @@ fn collect_gru_snapshots(
                 "{}.{}{}.hidden_transform.weight",
                 field_name, dir_prefix, gate_name
             );
-            snapshots.push(create_snapshot_from_data(r_gate_data, &path, dtype));
+            tensors.push(create_tensor_from_data(r_gate_data, &path, dtype));
 
             // Hidden transform bias: Rb for this gate
             if let Some(b) = &b_dir {
@@ -177,16 +177,16 @@ fn collect_gru_snapshots(
                     "{}.{}{}.hidden_transform.bias",
                     field_name, dir_prefix, gate_name
                 );
-                snapshots.push(create_snapshot_from_data(bias_data, &path, dtype));
+                tensors.push(create_tensor_from_data(bias_data, &path, dtype));
             }
         }
     }
 
-    snapshots
+    tensors
 }
 
 /// Create a burnpack tensor from TensorData already in hand.
-fn create_snapshot_from_data(
+fn create_tensor_from_data(
     data: burn::tensor::TensorData,
     path: &str,
     dtype: burn::tensor::DType,
@@ -488,8 +488,8 @@ impl NodeCodegen for onnx_ir::gru::GruNode {
         rnn_common::field(&self.name, &self.inputs, ty, init)
     }
 
-    fn collect_snapshots(&self, field_name: &str) -> Vec<PackTensor> {
-        collect_gru_snapshots(field_name, &self.inputs, &self.config)
+    fn collect_tensors(&self, field_name: &str) -> Vec<PackTensor> {
+        collect_gru_tensors(field_name, &self.inputs, &self.config)
     }
 
     fn forward(&self, scope: &mut ScopeAtPosition<'_>) -> TokenStream {
@@ -870,7 +870,7 @@ mod tests {
         assert!(
             NodeCodegen::field(&node).is_none(),
             "runtime weights must not declare a struct field, or `from_file` fails on \
-             tensors no snapshot can supply"
+             tensors no tensor can supply"
         );
     }
 

--- a/crates/burn-onnx/src/import/burn/node/instance_norm.rs
+++ b/crates/burn-onnx/src/import/burn/node/instance_norm.rs
@@ -43,26 +43,26 @@ impl NodeCodegen for InstanceNormalizationNode {
         ))
     }
 
-    fn collect_snapshots(&self, field_name: &str) -> Vec<PackTensor> {
-        use crate::burn::node_traits::create_lazy_snapshot;
+    fn collect_tensors(&self, field_name: &str) -> Vec<PackTensor> {
+        use crate::burn::node_traits::create_deferred_tensor;
 
-        let mut snapshots = vec![];
+        let mut tensors = vec![];
 
         if let Some(gamma_input) = self.inputs.get(1) {
             let gamma_path = format!("{}.gamma", field_name);
-            if let Some(snapshot) = create_lazy_snapshot(gamma_input, &gamma_path) {
-                snapshots.push(snapshot);
+            if let Some(tensor) = create_deferred_tensor(gamma_input, &gamma_path) {
+                tensors.push(tensor);
             }
         }
 
         if let Some(beta_input) = self.inputs.get(2) {
             let beta_path = format!("{}.beta", field_name);
-            if let Some(snapshot) = create_lazy_snapshot(beta_input, &beta_path) {
-                snapshots.push(snapshot);
+            if let Some(tensor) = create_deferred_tensor(beta_input, &beta_path) {
+                tensors.push(tensor);
             }
         }
 
-        snapshots
+        tensors
     }
 
     fn forward(&self, scope: &mut ScopeAtPosition<'_>) -> TokenStream {

--- a/crates/burn-onnx/src/import/burn/node/layer_norm.rs
+++ b/crates/burn-onnx/src/import/burn/node/layer_norm.rs
@@ -35,16 +35,16 @@ impl NodeCodegen for onnx_ir::node::layer_norm::LayerNormalizationNode {
         ))
     }
 
-    fn collect_snapshots(&self, field_name: &str) -> Vec<PackTensor> {
-        use crate::burn::node_traits::create_lazy_snapshot;
+    fn collect_tensors(&self, field_name: &str) -> Vec<PackTensor> {
+        use crate::burn::node_traits::create_deferred_tensor;
 
-        let mut snapshots = vec![];
+        let mut tensors = vec![];
 
         // Gamma (scale) tensor at input index 1
         if let Some(gamma_input) = self.inputs.get(1) {
             let gamma_path = format!("{}.gamma", field_name);
-            if let Some(snapshot) = create_lazy_snapshot(gamma_input, &gamma_path) {
-                snapshots.push(snapshot);
+            if let Some(tensor) = create_deferred_tensor(gamma_input, &gamma_path) {
+                tensors.push(tensor);
             }
         }
 
@@ -53,14 +53,14 @@ impl NodeCodegen for onnx_ir::node::layer_norm::LayerNormalizationNode {
             && let Some(beta_input) = self.inputs.get(2)
         {
             let beta_path = format!("{}.beta", field_name);
-            if let Some(snapshot) = create_lazy_snapshot(beta_input, &beta_path) {
-                snapshots.push(snapshot);
+            if let Some(tensor) = create_deferred_tensor(beta_input, &beta_path) {
+                tensors.push(tensor);
             }
         }
         // When bias is absent, Burn's LayerNorm is configured with .with_bias(false),
-        // so no beta parameter exists and no snapshot is needed
+        // so no beta parameter exists and no tensor is needed
 
-        snapshots
+        tensors
     }
 
     fn forward(&self, scope: &mut ScopeAtPosition<'_>) -> TokenStream {

--- a/crates/burn-onnx/src/import/burn/node/linear.rs
+++ b/crates/burn-onnx/src/import/burn/node/linear.rs
@@ -46,29 +46,29 @@ impl NodeCodegen for onnx_ir::linear::LinearNode {
         Some(Field::new(self.name.clone(), quote! { Linear }, init_code))
     }
 
-    fn collect_snapshots(&self, field_name: &str) -> Vec<PackTensor> {
-        use crate::burn::node_traits::create_lazy_snapshot;
+    fn collect_tensors(&self, field_name: &str) -> Vec<PackTensor> {
+        use crate::burn::node_traits::create_deferred_tensor;
 
-        let mut snapshots = vec![];
+        let mut tensors = vec![];
 
         // Weight tensor (input index 1)
         // No transposition needed - LinearLayout::Col handles ONNX [out, in] format
         if let Some(weight_input) = self.inputs.get(1) {
             let weight_path = format!("{}.weight", field_name);
-            if let Some(snapshot) = create_lazy_snapshot(weight_input, &weight_path) {
-                snapshots.push(snapshot);
+            if let Some(tensor) = create_deferred_tensor(weight_input, &weight_path) {
+                tensors.push(tensor);
             }
         }
 
         // Bias tensor (input index 2, optional)
         if let Some(bias_input) = self.inputs.get(2) {
             let bias_path = format!("{}.bias", field_name);
-            if let Some(snapshot) = create_lazy_snapshot(bias_input, &bias_path) {
-                snapshots.push(snapshot);
+            if let Some(tensor) = create_deferred_tensor(bias_input, &bias_path) {
+                tensors.push(tensor);
             }
         }
 
-        snapshots
+        tensors
     }
 
     fn forward(&self, scope: &mut ScopeAtPosition<'_>) -> TokenStream {

--- a/crates/burn-onnx/src/import/burn/node/lstm.rs
+++ b/crates/burn-onnx/src/import/burn/node/lstm.rs
@@ -57,7 +57,7 @@ fn to_burn_activation(onnx_activation: LstmActivationFunction) -> ActivationConf
     }
 }
 
-/// Collect tensor snapshots for LSTM burnpack serialization.
+/// Collect deferred tensors for LSTM burnpack serialization.
 ///
 /// This function handles the complex weight transformation from ONNX's packed format
 /// to Burn's individual GateController structure using the Flex CPU backend for tensor ops.
@@ -72,7 +72,7 @@ fn to_burn_activation(onnx_activation: LstmActivationFunction) -> ActivationConf
 /// - input_gate.hidden_transform: weight `[hidden_size, hidden_size]`, bias `[hidden_size]`
 /// - forget_gate, output_gate, cell_gate: same structure
 #[allow(clippy::single_range_in_vec_init)]
-fn collect_lstm_snapshots(
+fn collect_lstm_tensors(
     field_name: &str,
     inputs: &[Argument],
     config: &onnx_ir::lstm::LstmConfig,
@@ -93,7 +93,7 @@ fn collect_lstm_snapshots(
     // missing W/R, or a group split across initializers and graph inputs), so reaching
     // here means the tensor store lost a value we were promised. Returning an empty list
     // instead would rebuild the bug this path exists to fix: a struct full of gate
-    // `Param`s that no snapshot fills, which `from_file` reports as missing tensors and
+    // `Param`s that no tensor fills, which `from_file` reports as missing tensors and
     // `Model::new` silently fills with random values.
     let (Some(data_w), Some(data_r)) = (data_w, data_r) else {
         panic!(
@@ -120,13 +120,13 @@ fn collect_lstm_snapshots(
         LstmDirection::Bidirectional => vec!["forward.", "reverse."],
     };
 
-    let mut snapshots = Vec::new();
+    let mut tensors = Vec::new();
 
     // Create tensors from data, pinning the runtime dtype to the ONNX weight
     // dtype via `(device, dtype)`. A bare `&device` second argument would let
     // `Tensor::from_data` resolve the dtype from the device default and
-    // silently truncate f64 weights before they enter the snapshot pipeline.
-    // The later `convert_dtype(dtype)` in `create_snapshot_from_data` would
+    // silently truncate f64 weights before they enter the tensor pipeline.
+    // The later `convert_dtype(dtype)` in `create_tensor_from_data` would
     // restore the dtype tag but not the lost low bits.
     let w_tensor: Tensor<3> = Tensor::from_data(data_w.clone(), (&device, dtype));
     let r_tensor: Tensor<3> = Tensor::from_data(data_r.clone(), (&device, dtype));
@@ -176,7 +176,7 @@ fn collect_lstm_snapshots(
                 "{}.{}{}.input_transform.weight",
                 field_name, dir_prefix, gate_name
             );
-            snapshots.push(create_snapshot_from_data(w_gate_data, &path, dtype));
+            tensors.push(create_tensor_from_data(w_gate_data, &path, dtype));
 
             // Input transform bias: Wb + Rb for this gate
             if let Some(ref b) = b_dir {
@@ -194,7 +194,7 @@ fn collect_lstm_snapshots(
                     "{}.{}{}.input_transform.bias",
                     field_name, dir_prefix, gate_name
                 );
-                snapshots.push(create_snapshot_from_data(bias_data, &path, dtype));
+                tensors.push(create_tensor_from_data(bias_data, &path, dtype));
             }
 
             // Hidden transform weight: slice from R and transpose
@@ -209,7 +209,7 @@ fn collect_lstm_snapshots(
                 "{}.{}{}.hidden_transform.weight",
                 field_name, dir_prefix, gate_name
             );
-            snapshots.push(create_snapshot_from_data(r_gate_data, &path, dtype));
+            tensors.push(create_tensor_from_data(r_gate_data, &path, dtype));
 
             // Hidden transform bias: zeros (combined bias is in input_transform)
             if b_dir.is_some() {
@@ -220,12 +220,12 @@ fn collect_lstm_snapshots(
                     "{}.{}{}.hidden_transform.bias",
                     field_name, dir_prefix, gate_name
                 );
-                snapshots.push(create_snapshot_from_data(zeros_data, &path, dtype));
+                tensors.push(create_tensor_from_data(zeros_data, &path, dtype));
             }
         }
     }
 
-    snapshots
+    tensors
 }
 
 /// Create a burnpack tensor from TensorData already in hand.
@@ -234,9 +234,9 @@ fn collect_lstm_snapshots(
 /// weight-slicing pipeline already pins the dtype when building the intermediate
 /// `Tensor<_>` (via `from_data(data, (device, dtype))`),
 /// so this `convert_dtype` is ordinarily a no-op. It stays in place to guarantee
-/// the snapshot's dtype tag matches the tensor data even if a future refactor
+/// the tensor's dtype tag matches the tensor data even if a future refactor
 /// introduces a path that produces data in a different dtype.
-fn create_snapshot_from_data(
+fn create_tensor_from_data(
     data: burn::tensor::TensorData,
     path: &str,
     dtype: burn::tensor::DType,
@@ -374,8 +374,8 @@ impl NodeCodegen for onnx_ir::lstm::LstmNode {
         rnn_common::field(&self.name, &self.inputs, ty, init)
     }
 
-    fn collect_snapshots(&self, field_name: &str) -> Vec<PackTensor> {
-        collect_lstm_snapshots(field_name, &self.inputs, &self.config)
+    fn collect_tensors(&self, field_name: &str) -> Vec<PackTensor> {
+        collect_lstm_tensors(field_name, &self.inputs, &self.config)
     }
 
     fn forward(&self, scope: &mut ScopeAtPosition<'_>) -> TokenStream {
@@ -757,7 +757,7 @@ mod tests {
         assert!(
             NodeCodegen::field(&node).is_none(),
             "runtime weights must not declare a struct field, or `from_file` fails on \
-             tensors no snapshot can supply"
+             tensors no tensor can supply"
         );
     }
 

--- a/crates/burn-onnx/src/import/burn/node/prelu.rs
+++ b/crates/burn-onnx/src/import/burn/node/prelu.rs
@@ -49,20 +49,20 @@ impl NodeCodegen for PReluNode {
         ))
     }
 
-    fn collect_snapshots(&self, field_name: &str) -> Vec<PackTensor> {
-        use crate::burn::node_traits::create_lazy_snapshot;
+    fn collect_tensors(&self, field_name: &str) -> Vec<PackTensor> {
+        use crate::burn::node_traits::create_deferred_tensor;
 
-        let mut snapshots = vec![];
+        let mut tensors = vec![];
 
         if let Some(alpha_input) = self.inputs.get(1) {
             let alpha_path = format!("{}.alpha", field_name);
-            if let Some(mut snapshot) = create_lazy_snapshot(alpha_input, &alpha_path) {
-                snapshot.shape = Shape::from([num_parameters(self)]);
-                snapshots.push(snapshot);
+            if let Some(mut tensor) = create_deferred_tensor(alpha_input, &alpha_path) {
+                tensor.shape = Shape::from([num_parameters(self)]);
+                tensors.push(tensor);
             }
         }
 
-        snapshots
+        tensors
     }
 
     fn forward(&self, scope: &mut ScopeAtPosition<'_>) -> TokenStream {

--- a/crates/burn-onnx/src/import/burn/node/rnn.rs
+++ b/crates/burn-onnx/src/import/burn/node/rnn.rs
@@ -53,7 +53,7 @@ fn to_burn_activation(onnx_activation: RnnActivationFunction) -> ActivationConfi
     }
 }
 
-/// Collect tensor snapshots for Rnn burnpack serialization.
+/// Collect deferred tensors for Rnn burnpack serialization.
 ///
 /// This function handles the weight transformation from ONNX's packed RNN format
 /// to Burn's Rnn weight structure using the Flex CPU backend for tensor ops.
@@ -67,7 +67,7 @@ fn to_burn_activation(onnx_activation: RnnActivationFunction) -> ActivationConfi
 /// - input_transform: weight `[input_size, hidden_size]`, bias `[hidden_size]`
 /// - hidden_transform: weight `[hidden_size, hidden_size]`, bias `[hidden_size]`
 #[allow(clippy::single_range_in_vec_init)]
-fn collect_rnn_snapshots(
+fn collect_rnn_tensors(
     field_name: &str,
     inputs: &[Argument],
     config: &onnx_ir::rnn::RnnConfig,
@@ -88,7 +88,7 @@ fn collect_rnn_snapshots(
     // missing W/R, or a group split across initializers and graph inputs), so reaching
     // here means the tensor store lost a value we were promised. Returning an empty list
     // instead would rebuild the bug this path exists to fix: a struct full of gate
-    // `Param`s that no snapshot fills, which `from_file` reports as missing tensors and
+    // `Param`s that no tensor fills, which `from_file` reports as missing tensors and
     // `Model::new` silently fills with random values.
     let (Some(data_w), Some(data_r)) = (data_w, data_r) else {
         panic!(
@@ -115,12 +115,12 @@ fn collect_rnn_snapshots(
         RnnDirection::Bidirectional => vec!["forward.", "reverse."],
     };
 
-    let mut snapshots = Vec::new();
+    let mut tensors = Vec::new();
 
     // Create tensors from data, pinning the runtime dtype to the ONNX weight
     // dtype via `(device, dtype)`. A bare `&device` would let
     // `Tensor::from_data` resolve the dtype from the device default and
-    // silently truncate f64 weights before they enter the snapshot pipeline.
+    // silently truncate f64 weights before they enter the tensor pipeline.
     let w_tensor: Tensor<3> = Tensor::from_data(data_w.clone(), (&device, dtype));
     let r_tensor: Tensor<3> = Tensor::from_data(data_r.clone(), (&device, dtype));
     let b_tensor: Option<Tensor<2>> = data_b
@@ -169,7 +169,7 @@ fn collect_rnn_snapshots(
             "{}.{}{}.input_transform.weight",
             field_name, dir_prefix, gate_name
         );
-        snapshots.push(create_snapshot_from_data(w_gate_data, &path, dtype));
+        tensors.push(create_tensor_from_data(w_gate_data, &path, dtype));
 
         // Input transform bias: Wb + Rb for this gate
         if let Some(ref b) = b_dir {
@@ -187,7 +187,7 @@ fn collect_rnn_snapshots(
                 "{}.{}{}.input_transform.bias",
                 field_name, dir_prefix, gate_name
             );
-            snapshots.push(create_snapshot_from_data(bias_data, &path, dtype));
+            tensors.push(create_tensor_from_data(bias_data, &path, dtype));
         }
 
         // Hidden transform weight: slice from R and transpose
@@ -202,7 +202,7 @@ fn collect_rnn_snapshots(
             "{}.{}{}.hidden_transform.weight",
             field_name, dir_prefix, gate_name
         );
-        snapshots.push(create_snapshot_from_data(r_gate_data, &path, dtype));
+        tensors.push(create_tensor_from_data(r_gate_data, &path, dtype));
 
         // Hidden transform bias: zeros (combined bias is in input_transform)
         if b_dir.is_some() {
@@ -213,11 +213,11 @@ fn collect_rnn_snapshots(
                 "{}.{}{}.hidden_transform.bias",
                 field_name, dir_prefix, gate_name
             );
-            snapshots.push(create_snapshot_from_data(zeros_data, &path, dtype));
+            tensors.push(create_tensor_from_data(zeros_data, &path, dtype));
         }
     }
 
-    snapshots
+    tensors
 }
 
 /// Create a burnpack tensor from TensorData already in hand.
@@ -226,9 +226,9 @@ fn collect_rnn_snapshots(
 /// weight-slicing pipeline already pins the dtype when building the intermediate
 /// `Tensor<_>` (via `from_data(data, (device, dtype))`),
 /// so this `convert_dtype` is ordinarily a no-op. It stays in place to guarantee
-/// the snapshot's dtype tag matches the tensor data even if a future refactor
+/// the tensor's dtype tag matches the tensor data even if a future refactor
 /// introduces a path that produces data in a different dtype.
-fn create_snapshot_from_data(
+fn create_tensor_from_data(
     data: burn::tensor::TensorData,
     path: &str,
     dtype: burn::tensor::DType,
@@ -343,8 +343,8 @@ impl NodeCodegen for onnx_ir::rnn::RnnNode {
         rnn_common::field(&self.name, &self.inputs, ty, init)
     }
 
-    fn collect_snapshots(&self, field_name: &str) -> Vec<PackTensor> {
-        collect_rnn_snapshots(field_name, &self.inputs, &self.config)
+    fn collect_tensors(&self, field_name: &str) -> Vec<PackTensor> {
+        collect_rnn_tensors(field_name, &self.inputs, &self.config)
     }
 
     fn forward(&self, scope: &mut ScopeAtPosition<'_>) -> TokenStream {
@@ -675,7 +675,7 @@ mod tests {
         assert!(
             NodeCodegen::field(&node).is_none(),
             "runtime weights must not declare a struct field, or `from_file` fails on \
-             tensors no snapshot can supply"
+             tensors no tensor can supply"
         );
     }
 

--- a/crates/burn-onnx/src/import/burn/node/rnn_common.rs
+++ b/crates/burn-onnx/src/import/burn/node/rnn_common.rs
@@ -8,12 +8,12 @@
 //! - `B`: `[num_directions, 2 * gates * hidden_size]`, all of `Wb` then all of `Rb`
 //!
 //! When those arrive as initializers the split runs at build time in each op's
-//! `collect_*_snapshots` and the result is written into the `.bpk`. When they arrive
-//! as graph inputs there is nothing to snapshot, so the same split is emitted as
+//! `collect_*_tensors` and the result is written into the `.bpk`. When they arrive
+//! as graph inputs there is nothing to capture, so the same split is emitted as
 //! generated code and applied to a module built inside `forward`.
 //!
 //! The [`GateLayout`] each op declares names its gate order for both paths. Its
-//! [`BiasLayout`] drives the runtime path only: each `collect_*_snapshots` still encodes
+//! [`BiasLayout`] drives the runtime path only: each `collect_*_tensors` still encodes
 //! the same bias policy by hand, so the two have to be changed together.
 
 use super::prelude::*;
@@ -117,7 +117,7 @@ pub(crate) fn weights_are_runtime(inputs: &[Argument]) -> bool {
 
 /// The struct field holding this node's module, or `None` when the weights are runtime.
 ///
-/// A field on the runtime path would declare `Param`s that no snapshot can fill, which
+/// A field on the runtime path would declare `Param`s that no tensor can fill, which
 /// is what made `Model::from_file` panic before the weights were consumed.
 pub(crate) fn field(
     name: &str,
@@ -311,7 +311,7 @@ fn load_runtime_weights(
 /// `Argument::new` defaults to `ValueSource::Dynamic`, which is the state of a weight
 /// supplied as a graph input, so tests covering the static path have to say so. The
 /// fabricated `DataId` resolves in no store: these tests read `field`/`forward`, never
-/// `value()`. A test that calls `collect_snapshots` on one of these nodes will panic on
+/// `value()`. A test that calls `collect_tensors` on one of these nodes will panic on
 /// the unresolvable weight - back the argument with a real store instead of reaching for
 /// this helper there.
 #[cfg(test)]

--- a/crates/burn-onnx/src/import/burn/node_codegen.rs
+++ b/crates/burn-onnx/src/import/burn/node_codegen.rs
@@ -88,27 +88,27 @@ pub(crate) fn node_register_imports(node: &Node, imports: &mut BurnImports, hook
     NodeCodegen::register_imports(node, imports)
 }
 
-pub(crate) fn node_collect_snapshots(
+pub(crate) fn node_collect_tensors(
     node: &Node,
     field_name: &str,
     hooks: &HookRegistry,
 ) -> Vec<PackTensor> {
     if let Some(over) = hooks.override_for(&node.node_type()) {
         return expect_hook(
-            over.collect_snapshots(node, field_name),
-            "OpOverride::collect_snapshots",
+            over.collect_tensors(node, field_name),
+            "OpOverride::collect_tensors",
             node.name(),
         );
     }
     if let Node::Custom(c) = node {
         let hook = require_custom_hook(hooks, c);
         return expect_hook(
-            hook.collect_snapshots(c, field_name),
-            "CustomOp::collect_snapshots",
+            hook.collect_tensors(c, field_name),
+            "CustomOp::collect_tensors",
             &c.name,
         );
     }
-    NodeCodegen::collect_snapshots(node, field_name)
+    NodeCodegen::collect_tensors(node, field_name)
 }
 
 /// Macro to implement NodeCodegen on onnx_ir::Node by dispatching to individual node impls
@@ -165,9 +165,9 @@ macro_rules! impl_node_codegen_dispatch {
                 }
             }
 
-            fn collect_snapshots(&self, field_name: &str) -> Vec<PackTensor> {
+            fn collect_tensors(&self, field_name: &str) -> Vec<PackTensor> {
                 match self {
-                    $(Node::$variant(n) => n.collect_snapshots(field_name),)*
+                    $(Node::$variant(n) => n.collect_tensors(field_name),)*
                     _ => vec![],
                 }
             }

--- a/crates/burn-onnx/src/import/burn/node_traits.rs
+++ b/crates/burn-onnx/src/import/burn/node_traits.rs
@@ -117,10 +117,11 @@ pub trait NodeCodegen: std::fmt::Debug {
         None
     }
 
-    /// (Optional) Collect tensor snapshots for burnpack serialization.
+    /// (Optional) Collect deferred tensors for burnpack serialization.
     ///
-    /// Returns tensor snapshots with paths like "{field_name}.weight", "{field_name}.bias".
-    /// The snapshots must be lazy - data should only be loaded when `to_data()` is called.
+    /// Returns deferred tensors with paths like "{field_name}.weight", "{field_name}.bias".
+    /// The tensors must stay deferred - bytes should only be produced when the writer
+    /// requests them.
     ///
     /// # Arguments
     ///
@@ -129,7 +130,7 @@ pub trait NodeCodegen: std::fmt::Debug {
     /// # Notes
     ///
     /// For nodes without learnable parameters, the default implementation returns an empty vec.
-    fn collect_snapshots(&self, _field_name: &str) -> Vec<PackTensor> {
+    fn collect_tensors(&self, _field_name: &str) -> Vec<PackTensor> {
         vec![]
     }
 }
@@ -176,17 +177,17 @@ pub fn arg_to_ident(arg: &Argument) -> proc_macro2::Ident {
 }
 
 // ============================================================================
-// Tensor snapshot helpers
+// Deferred tensor helpers
 // ============================================================================
 //
 // Tensors created during ONNX import (e.g., for slicing weight blobs in the
-// rnn/lstm/gru snapshot helpers) MUST pin the runtime dtype via
+// rnn/lstm/gru tensor helpers) MUST pin the runtime dtype via
 // `Tensor::from_data(data, (&device, dtype))` rather than the bare `&device`
 // overload. The bare form lets `Tensor::from_data` resolve the dtype from the
 // device's default `FloatDType`, which can silently truncate f64 weights to
-// f32 before they enter the snapshot pipeline.
+// f32 before they enter the tensor pipeline.
 
-/// Create a lazy burnpack tensor from an ONNX argument.
+/// Create a deferred burnpack tensor from an ONNX argument.
 ///
 /// The returned tensor carries only metadata until its bytes are drawn: the closure
 /// captures the argument and calls `value()` only when the writer asks for the data.
@@ -200,12 +201,12 @@ pub fn arg_to_ident(arg: &Argument) -> proc_macro2::Ident {
 /// # Returns
 ///
 /// A deferred [`PackTensor`], or `None` when the input carries no static data
-pub fn create_lazy_snapshot(input: &Argument, path: &str) -> Option<PackTensor> {
+pub fn create_deferred_tensor(input: &Argument, path: &str) -> Option<PackTensor> {
     use burn::module::ParamId;
     use burn::tensor::TensorData;
     use onnx_ir::ir::ArgType;
 
-    // Skip Dynamic and Optional inputs: there is no static data to snapshot.
+    // Skip Dynamic and Optional inputs: there is no static data to capture.
     // Constant inputs are intentionally let through so an unlifted constant
     // fails loudly here rather than being silently dropped (which would
     // produce a model with zero-initialized weights at load time).
@@ -287,7 +288,7 @@ mod tests {
     }
 
     #[test]
-    fn create_lazy_snapshot_skips_dynamic_input() {
+    fn create_deferred_tensor_skips_dynamic_input() {
         use onnx_ir::ir::{ArgType, Argument, TensorType, ValueSource};
 
         let arg = Argument::new(
@@ -299,11 +300,11 @@ mod tests {
             }),
         );
         assert_eq!(arg.value_source, ValueSource::Dynamic);
-        assert!(create_lazy_snapshot(&arg, "prelu1.alpha").is_none());
+        assert!(create_deferred_tensor(&arg, "prelu1.alpha").is_none());
     }
 
     #[test]
-    fn create_lazy_snapshot_skips_optional_input() {
+    fn create_deferred_tensor_skips_optional_input() {
         use onnx_ir::ir::{ArgType, Argument, TensorType, ValueSource};
 
         let arg = Argument::new(
@@ -316,7 +317,7 @@ mod tests {
         );
         assert_eq!(arg.value_source, ValueSource::Optional);
 
-        assert!(create_lazy_snapshot(&arg, "deform_conv1.bias").is_none());
+        assert!(create_deferred_tensor(&arg, "deform_conv1.bias").is_none());
     }
 
     /// An unlifted constant fails when the writer draws its bytes, and that failure has to
@@ -339,7 +340,7 @@ mod tests {
         // Claims to be a constant, but nothing ever lifted a value into the store.
         arg.value_source = ValueSource::Constant;
 
-        let tensor = create_lazy_snapshot(&arg, "conv1.weight").expect("a constant is snapshotted");
+        let tensor = create_deferred_tensor(&arg, "conv1.weight").expect("a constant is captured");
 
         let err = burn_pack::Writer::new(vec![tensor])
             .into_bytes()

--- a/crates/burn-onnx/src/import/ext.rs
+++ b/crates/burn-onnx/src/import/ext.rs
@@ -10,7 +10,7 @@
 //! `burn-onnx` links against.
 
 pub use crate::burn::custom_op::{CustomOp, OpOverride};
-pub use crate::burn::node_traits::{Field, create_lazy_snapshot};
+pub use crate::burn::node_traits::{Field, create_deferred_tensor};
 
 /// Convert an argument's name to an identifier.
 ///


### PR DESCRIPTION
## Summary

Follow-up to the burnpack streaming migration (#479) for the regression tracked in tracel-ai/burn#5219.

With snapshots now staying deferred all the way to the writer, tensor bytes are produced mid-write, where a provider failure (e.g. device readback) previously would leave a truncated `.bpk` at the destination: `write_to_file` truncates the file as soon as writing starts. This switches to `write_to_file_atomic`, which builds the container in a scratch sibling and renames it into place only once every byte is on disk, so the destination either holds a complete container or is left as it was. The upstream docs on `write_to_file` explicitly direct deferred-tensor callers to the atomic variant.

Error reporting is unchanged: a provider failure is annotated with the failing tensor's path by the writer (`Error::in_tensor`) plus the output file path.

(Originally this PR also converted eagerly-materialized snapshots to deferred tensors; that half was superseded by #479, which pushed `PackTensor` through snapshot collection directly.)

## Testing

- `cargo check -p burn-onnx --all-features`: clean
- `cargo test -p burn-onnx --lib`: 936 passed
- `cargo test -p onnx-tests` (pre-merge state): 609 passed; the build regenerates every test model through the write path and loads weights back via `from_file`

## Also in this PR

Renames the stale "snapshot" terminology left over from the `TensorSnapshot` era: weight collection has produced `burn_pack::Tensor` values since #479, so `collect_snapshots` and friends are now `collect_tensors` (across `NodeCodegen`, the custom-op hook traits, and all node impls), and `create_lazy_snapshot` is `create_deferred_tensor`, matching `burn_pack::Tensor::deferred`. Purely mechanical; references to insta snapshot tests are untouched.
