### PR TITLE
feat(export): support Conv1d, slicing, indexing, creation and reductions

### DIFF
--- a/crates/burn-onnx/src/export/lower/base.rs
+++ b/crates/burn-onnx/src/export/lower/base.rs
@@ -3,13 +3,15 @@
 //! This family contains operations requiring ONNX-specific operands or
 //! attributes, including reshape shape expressions and concatenation axes.
 
-use burn::backend::ir::{BaseOperationIr, CreationOpIr, OperationIr, ScalarIr, SliceOpIr};
+use burn::backend::DType;
+use burn::backend::ir::{
+    BaseOperationIr, CreationOpIr, OperationIr, ScalarIr, SliceOpIr, TensorIr,
+};
 use burn::backend::tensor::IndexingUpdateOp;
 
 use crate::export::ExportError;
 
-use super::context::LoweringContext;
-use super::scalar_tensor;
+use super::{context::LoweringContext, onnx_dtype_parts, scalar_tensor};
 
 pub(super) fn lower(
     context: &mut LoweringContext<'_>,
@@ -53,7 +55,7 @@ pub(super) fn lower(
         BaseOperationIr::Select(select) => {
             let inputs = vec![
                 context.tensor_name(select.tensor.id),
-                context.tensor_name(select.indices.id),
+                lower_indices(context, index, "select", &select.indices)?,
             ];
             let output = context.tensor_name(select.out.id);
             context.node(format!("node_{index}"), "Gather", inputs, vec![output]);
@@ -63,7 +65,7 @@ pub(super) fn lower(
         BaseOperationIr::Scatter(scatter) => {
             let inputs = vec![
                 context.tensor_name(scatter.tensor.id),
-                context.tensor_name(scatter.indices.id),
+                lower_indices(context, index, "scatter", &scatter.indices)?,
                 context.tensor_name(scatter.value.id),
             ];
             let output = context.tensor_name(scatter.out.id);
@@ -87,34 +89,46 @@ pub(super) fn lower(
             Ok(true)
         }
         BaseOperationIr::Zeros(creation) => {
-            lower_creation(context, index, creation, 0.0)?;
+            lower_creation(context, index, creation, 0)?;
             Ok(true)
         }
         BaseOperationIr::Ones(creation) => {
-            lower_creation(context, index, creation, 1.0)?;
+            lower_creation(context, index, creation, 1)?;
             Ok(true)
         }
         _ => Ok(false),
     }
 }
 
+fn lower_indices(
+    context: &mut LoweringContext<'_>,
+    index: usize,
+    kind: &'static str,
+    indices: &TensorIr,
+) -> Result<String, ExportError> {
+    let input = context.tensor_name(indices.id);
+    if matches!(indices.dtype, DType::I32 | DType::I64) {
+        return Ok(input);
+    }
+    if !indices.dtype.is_int() && !indices.dtype.is_uint() {
+        return Err(ExportError::UnsupportedOperation {
+            operation: index,
+            kind: format!("{kind} with non-integer {:?} indices", indices.dtype),
+        });
+    }
+
+    let output = format!("node_{index}_{kind}_indices64");
+    context.node(output.clone(), "Cast", vec![input], vec![output.clone()]);
+    context.int_attribute("to", 7);
+    Ok(output)
+}
+
 fn lower_slice(context: &mut LoweringContext<'_>, index: usize, slice: &SliceOpIr) {
-    let starts: Vec<i64> = slice
+    let (starts, ends): (Vec<_>, Vec<_>) = slice
         .ranges
         .iter()
-        .map(|range| range.start as i64)
-        .collect();
-    let ends: Vec<i64> = slice
-        .ranges
-        .iter()
-        .map(|range| match range.end {
-            Some(end) => end as i64,
-            // An open end takes everything the step direction can reach; ONNX
-            // clamps out-of-range bounds to the dimension.
-            None if range.step >= 0 => i64::MAX,
-            None => i64::MIN,
-        })
-        .collect();
+        .map(|range| onnx_slice_bounds(range.start, range.end, range.step))
+        .unzip();
     let axes: Vec<i64> = (0..slice.ranges.len() as i64).collect();
     let steps: Vec<i64> = slice.ranges.iter().map(|range| range.step as i64).collect();
 
@@ -137,27 +151,57 @@ fn lower_slice(context: &mut LoweringContext<'_>, index: usize, slice: &SliceOpI
     );
 }
 
+fn onnx_slice_bounds(start: isize, end: Option<isize>, step: isize) -> (i64, i64) {
+    if step > 0 {
+        return (start as i64, end.map_or(i64::MAX, |end| end as i64));
+    }
+
+    // Burn selects an ascending [start, end) interval and traverses it in
+    // reverse. ONNX uses Python-style descending bounds, so swap the interval
+    // endpoints and make each one inclusive/exclusive in the other direction.
+    let onnx_start = end.map_or(-1, |end| end.saturating_sub(1) as i64);
+    let onnx_end = if start == 0 {
+        i64::MIN
+    } else {
+        start.saturating_sub(1) as i64
+    };
+    (onnx_start, onnx_end)
+}
+
 fn lower_creation(
     context: &mut LoweringContext<'_>,
     index: usize,
     creation: &CreationOpIr,
-    value: f64,
+    value: i64,
 ) -> Result<(), ExportError> {
     let shape_name = context.shape_input(index, creation.out.id)?;
     let output = context.tensor_name(creation.out.id);
+    let constant_output = if creation.out.dtype == DType::I64 {
+        output.clone()
+    } else {
+        format!("node_{index}_constant")
+    };
     context.node(
-        format!("node_{index}"),
+        format!("node_{index}_constant"),
         "ConstantOfShape",
         vec![shape_name],
-        vec![output],
+        vec![constant_output.clone()],
     );
     context.tensor_attribute(
         "value",
-        scalar_tensor(
-            creation.out.dtype,
-            ScalarIr::new(value, &creation.out.dtype),
-            creation.out.id,
-        )?,
+        scalar_tensor(DType::I64, ScalarIr::Int(value), creation.out.id)?,
     );
+    if constant_output != output {
+        context.node(
+            format!("node_{index}"),
+            "Cast",
+            vec![constant_output],
+            vec![output],
+        );
+        context.int_attribute(
+            "to",
+            onnx_dtype_parts(creation.out.id, creation.out.dtype)? as i64,
+        );
+    }
     Ok(())
 }

--- a/crates/burn-onnx/src/export/lower/base.rs
+++ b/crates/burn-onnx/src/export/lower/base.rs
@@ -119,7 +119,7 @@ fn lower_indices(
 
     let output = format!("node_{index}_{kind}_indices64");
     context.node(output.clone(), "Cast", vec![input], vec![output.clone()]);
-    context.int_attribute("to", 7);
+    context.int_attribute("to", onnx_dtype_parts(indices.id, DType::I64)? as i64);
     Ok(output)
 }
 

--- a/crates/burn-onnx/src/export/lower/base.rs
+++ b/crates/burn-onnx/src/export/lower/base.rs
@@ -155,6 +155,11 @@ fn onnx_slice_bounds(start: isize, end: Option<isize>, step: isize) -> (i64, i64
     if step > 0 {
         return (start as i64, end.map_or(i64::MAX, |end| end as i64));
     }
+    if end.is_some_and(|end| start >= end) {
+        // Burn permits empty intervals and returns no elements regardless of
+        // the step. Equal in-range ONNX bounds preserve that cardinality.
+        return (0, 0);
+    }
 
     // Burn selects an ascending [start, end) interval and traverses it in
     // reverse. ONNX uses Python-style descending bounds, so swap the interval
@@ -204,4 +209,15 @@ fn lower_creation(
         );
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::onnx_slice_bounds;
+
+    #[test]
+    fn negative_step_keeps_empty_intervals_empty() {
+        assert_eq!(onnx_slice_bounds(0, Some(0), -1), (0, 0));
+        assert_eq!(onnx_slice_bounds(3, Some(1), -2), (0, 0));
+    }
 }

--- a/crates/burn-onnx/src/export/lower/base.rs
+++ b/crates/burn-onnx/src/export/lower/base.rs
@@ -3,11 +3,13 @@
 //! This family contains operations requiring ONNX-specific operands or
 //! attributes, including reshape shape expressions and concatenation axes.
 
-use burn::backend::ir::{BaseOperationIr, OperationIr};
+use burn::backend::ir::{BaseOperationIr, CreationOpIr, OperationIr, ScalarIr, SliceOpIr};
+use burn::backend::tensor::IndexingUpdateOp;
 
 use crate::export::ExportError;
 
 use super::context::LoweringContext;
+use super::scalar_tensor;
 
 pub(super) fn lower(
     context: &mut LoweringContext<'_>,
@@ -44,6 +46,118 @@ pub(super) fn lower(
             context.int_attribute("axis", cat.dim as i64);
             Ok(true)
         }
+        BaseOperationIr::Slice(slice) => {
+            lower_slice(context, index, slice);
+            Ok(true)
+        }
+        BaseOperationIr::Select(select) => {
+            let inputs = vec![
+                context.tensor_name(select.tensor.id),
+                context.tensor_name(select.indices.id),
+            ];
+            let output = context.tensor_name(select.out.id);
+            context.node(format!("node_{index}"), "Gather", inputs, vec![output]);
+            context.int_attribute("axis", select.dim as i64);
+            Ok(true)
+        }
+        BaseOperationIr::Scatter(scatter) => {
+            let inputs = vec![
+                context.tensor_name(scatter.tensor.id),
+                context.tensor_name(scatter.indices.id),
+                context.tensor_name(scatter.value.id),
+            ];
+            let output = context.tensor_name(scatter.out.id);
+            context.node(
+                format!("node_{index}"),
+                "ScatterElements",
+                inputs,
+                vec![output],
+            );
+            context.int_attribute("axis", scatter.dim as i64);
+            context.string_attribute(
+                "reduction",
+                match scatter.update {
+                    IndexingUpdateOp::Assign => "none",
+                    IndexingUpdateOp::Add => "add",
+                    IndexingUpdateOp::Mul => "mul",
+                    IndexingUpdateOp::Min => "min",
+                    IndexingUpdateOp::Max => "max",
+                },
+            );
+            Ok(true)
+        }
+        BaseOperationIr::Zeros(creation) => {
+            lower_creation(context, index, creation, 0.0)?;
+            Ok(true)
+        }
+        BaseOperationIr::Ones(creation) => {
+            lower_creation(context, index, creation, 1.0)?;
+            Ok(true)
+        }
         _ => Ok(false),
     }
+}
+
+fn lower_slice(context: &mut LoweringContext<'_>, index: usize, slice: &SliceOpIr) {
+    let starts: Vec<i64> = slice
+        .ranges
+        .iter()
+        .map(|range| range.start as i64)
+        .collect();
+    let ends: Vec<i64> = slice
+        .ranges
+        .iter()
+        .map(|range| match range.end {
+            Some(end) => end as i64,
+            // An open end takes everything the step direction can reach; ONNX
+            // clamps out-of-range bounds to the dimension.
+            None if range.step >= 0 => i64::MAX,
+            None => i64::MIN,
+        })
+        .collect();
+    let axes: Vec<i64> = (0..slice.ranges.len() as i64).collect();
+    let steps: Vec<i64> = slice.ranges.iter().map(|range| range.step as i64).collect();
+
+    let starts_name = format!("node_{index}_starts");
+    context.i64_initializer(starts_name.clone(), &starts);
+    let ends_name = format!("node_{index}_ends");
+    context.i64_initializer(ends_name.clone(), &ends);
+    let axes_name = format!("node_{index}_axes");
+    context.i64_initializer(axes_name.clone(), &axes);
+    let steps_name = format!("node_{index}_steps");
+    context.i64_initializer(steps_name.clone(), &steps);
+
+    let input = context.tensor_name(slice.tensor.id);
+    let output = context.tensor_name(slice.out.id);
+    context.node(
+        format!("node_{index}"),
+        "Slice",
+        vec![input, starts_name, ends_name, axes_name, steps_name],
+        vec![output],
+    );
+}
+
+fn lower_creation(
+    context: &mut LoweringContext<'_>,
+    index: usize,
+    creation: &CreationOpIr,
+    value: f64,
+) -> Result<(), ExportError> {
+    let shape_name = context.shape_input(index, creation.out.id)?;
+    let output = context.tensor_name(creation.out.id);
+    context.node(
+        format!("node_{index}"),
+        "ConstantOfShape",
+        vec![shape_name],
+        vec![output],
+    );
+    context.tensor_attribute(
+        "value",
+        scalar_tensor(
+            creation.out.dtype,
+            ScalarIr::new(value, &creation.out.dtype),
+            creation.out.id,
+        )?,
+    );
+    Ok(())
 }

--- a/crates/burn-onnx/src/export/lower/mod.rs
+++ b/crates/burn-onnx/src/export/lower/mod.rs
@@ -232,6 +232,7 @@ fn onnx_dtype_parts(tensor: TensorId, dtype: DType) -> Result<i32, ExportError> 
         DType::F32 => Ok(1),
         DType::U8 => Ok(2),
         DType::I8 => Ok(3),
+        DType::U16 => Ok(4),
         DType::I16 => Ok(5),
         DType::I32 => Ok(6),
         DType::I64 => Ok(7),

--- a/crates/burn-onnx/src/export/lower/module.rs
+++ b/crates/burn-onnx/src/export/lower/module.rs
@@ -19,6 +19,25 @@ pub(super) fn lower(
         return Ok(false);
     };
     match operation {
+        ModuleOperationIr::Conv1d(conv) => {
+            let mut inputs = vec![
+                context.tensor_name(conv.x.id),
+                context.tensor_name(conv.weight.id),
+            ];
+            if let Some(bias) = &conv.bias {
+                inputs.push(context.tensor_name(bias.id));
+            }
+            let output = context.tensor_name(conv.out.id);
+            context.node(format!("node_{index}"), "Conv", inputs, vec![output]);
+            context.ints_attribute("strides", conv.options.stride);
+            context.ints_attribute("dilations", conv.options.dilation);
+            context.ints_attribute(
+                "pads",
+                [conv.options.padding[0], conv.options.padding[0]],
+            );
+            context.int_attribute("group", conv.options.groups as i64);
+            Ok(true)
+        }
         ModuleOperationIr::Conv2d(conv) => {
             let mut inputs = vec![
                 context.tensor_name(conv.x.id),

--- a/crates/burn-onnx/src/export/lower/module.rs
+++ b/crates/burn-onnx/src/export/lower/module.rs
@@ -4,7 +4,8 @@
 //! owns opset-specific attributes for convolution, normalization, resize, and
 //! pooling operations.
 
-use burn::backend::ir::{InterpolateModeIr, ModuleOperationIr, OperationIr};
+use burn::backend::DType;
+use burn::backend::ir::{InterpolateModeIr, ModuleOperationIr, OperationIr, TensorIr};
 
 use crate::export::ExportError;
 
@@ -20,6 +21,14 @@ pub(super) fn lower(
     };
     match operation {
         ModuleOperationIr::Conv1d(conv) => {
+            validate_conv_dtypes(
+                index,
+                "Conv1d",
+                &conv.x,
+                &conv.weight,
+                conv.bias.as_ref(),
+                &conv.out,
+            )?;
             let mut inputs = vec![
                 context.tensor_name(conv.x.id),
                 context.tensor_name(conv.weight.id),
@@ -31,14 +40,19 @@ pub(super) fn lower(
             context.node(format!("node_{index}"), "Conv", inputs, vec![output]);
             context.ints_attribute("strides", conv.options.stride);
             context.ints_attribute("dilations", conv.options.dilation);
-            context.ints_attribute(
-                "pads",
-                [conv.options.padding[0], conv.options.padding[0]],
-            );
+            context.ints_attribute("pads", [conv.options.padding[0], conv.options.padding[0]]);
             context.int_attribute("group", conv.options.groups as i64);
             Ok(true)
         }
         ModuleOperationIr::Conv2d(conv) => {
+            validate_conv_dtypes(
+                index,
+                "Conv2d",
+                &conv.x,
+                &conv.weight,
+                conv.bias.as_ref(),
+                &conv.out,
+            )?;
             let mut inputs = vec![
                 context.tensor_name(conv.x.id),
                 context.tensor_name(conv.weight.id),
@@ -222,4 +236,31 @@ pub(super) fn lower(
         }
         _ => Ok(false),
     }
+}
+
+fn validate_conv_dtypes(
+    index: usize,
+    kind: &'static str,
+    input: &TensorIr,
+    weight: &TensorIr,
+    bias: Option<&TensorIr>,
+    output: &TensorIr,
+) -> Result<(), ExportError> {
+    let dtype = input.dtype;
+    if weight.dtype != dtype
+        || bias.is_some_and(|bias| bias.dtype != dtype)
+        || output.dtype != dtype
+    {
+        return Err(ExportError::UnsupportedOperation {
+            operation: index,
+            kind: format!("{kind} with mixed tensor dtypes"),
+        });
+    }
+    if !matches!(dtype, DType::F16 | DType::F32 | DType::F64) {
+        return Err(ExportError::UnsupportedOperation {
+            operation: index,
+            kind: format!("{kind} with {dtype:?} tensors in ONNX opset 18"),
+        });
+    }
+    Ok(())
 }

--- a/crates/burn-onnx/src/export/lower/numeric.rs
+++ b/crates/burn-onnx/src/export/lower/numeric.rs
@@ -3,11 +3,14 @@
 //! Scalar operands and creation shapes are materialized as ONNX initializers
 //! before their corresponding nodes are emitted.
 
-use burn::backend::ir::{NumericOperationIr, OperationIr, PadModeIr, PadOpIr, ScalarOpIr};
+use burn::backend::DType;
+use burn::backend::ir::{
+    NumericOperationIr, OperationIr, PadModeIr, PadOpIr, ReduceDimWithIndicesOpIr, ScalarOpIr,
+};
 
 use crate::export::ExportError;
 
-use super::{context::LoweringContext, scalar_tensor};
+use super::{context::LoweringContext, onnx_dtype_parts, scalar_tensor};
 
 pub(super) fn lower(
     context: &mut LoweringContext<'_>,
@@ -39,6 +42,29 @@ pub(super) fn lower(
         lower_pad(context, index, pad)?;
         return Ok(true);
     }
+    if let NumericOperationIr::SumDim(reduce) = numeric {
+        let axes_name = format!("node_{index}_axes");
+        context.i64_initializer(axes_name.clone(), &[reduce.axis as i64]);
+        let input = context.tensor_name(reduce.input.id);
+        let output = context.tensor_name(reduce.out.id);
+        context.node(
+            format!("node_{index}"),
+            "ReduceSum",
+            vec![input, axes_name],
+            vec![output],
+        );
+        let kept = reduce.out.shape.num_dims() == reduce.input.shape.num_dims();
+        context.int_attribute("keepdims", kept as i64);
+        return Ok(true);
+    }
+    if let NumericOperationIr::MaxDimWithIndices(reduce) = numeric {
+        lower_reduce_with_indices(context, index, reduce, "ArgMax")?;
+        return Ok(true);
+    }
+    if let NumericOperationIr::MinDimWithIndices(reduce) = numeric {
+        lower_reduce_with_indices(context, index, reduce, "ArgMin")?;
+        return Ok(true);
+    }
     if let Some((op_type, scalar)) = scalar_operation(numeric) {
         lower_scalar(context, index, op_type, scalar)?;
         return Ok(true);
@@ -62,6 +88,65 @@ pub(super) fn lower(
         .collect();
     context.node(format!("node_{index}"), op_type, inputs, outputs);
     Ok(true)
+}
+
+/// Lower a max or min reduction that also yields the winning indices.
+///
+/// ONNX has no single operator for this pair. `ArgMax`/`ArgMin` produces the
+/// indices, and `GatherElements` reads the values back out through them, which
+/// matches the reduction exactly instead of recomputing it.
+fn lower_reduce_with_indices(
+    context: &mut LoweringContext<'_>,
+    index: usize,
+    reduce: &ReduceDimWithIndicesOpIr,
+    arg_op: &'static str,
+) -> Result<(), ExportError> {
+    // `GatherElements` needs indices of the input's rank, which only the
+    // dimension-keeping form provides.
+    if reduce.out.shape.num_dims() != reduce.tensor.shape.num_dims() {
+        return Err(ExportError::UnsupportedOperation {
+            operation: index,
+            kind: format!("{arg_op} reduction that drops the reduced dimension"),
+        });
+    }
+
+    let indices = context.tensor_name(reduce.out_indices.id);
+    // `ArgMax`/`ArgMin` always produce `int64`; a cast reconciles the traced
+    // index dtype where it differs.
+    let indices64 = match reduce.out_indices.dtype {
+        DType::I64 => indices.clone(),
+        _ => format!("node_{index}_indices64"),
+    };
+    let input = context.tensor_name(reduce.tensor.id);
+    context.node(
+        format!("node_{index}_arg"),
+        arg_op,
+        vec![input.clone()],
+        vec![indices64.clone()],
+    );
+    context.int_attribute("axis", reduce.dim as i64);
+    context.int_attribute("keepdims", 1);
+    if indices64 != indices {
+        context.node(
+            format!("node_{index}_cast"),
+            "Cast",
+            vec![indices64.clone()],
+            vec![indices],
+        );
+        context.int_attribute(
+            "to",
+            onnx_dtype_parts(reduce.out_indices.id, reduce.out_indices.dtype)? as i64,
+        );
+    }
+    let output = context.tensor_name(reduce.out.id);
+    context.node(
+        format!("node_{index}"),
+        "GatherElements",
+        vec![input, indices64],
+        vec![output],
+    );
+    context.int_attribute("axis", reduce.dim as i64);
+    Ok(())
 }
 
 fn lower_pad(

--- a/crates/burn-onnx/src/export/lower/numeric.rs
+++ b/crates/burn-onnx/src/export/lower/numeric.rs
@@ -5,7 +5,8 @@
 
 use burn::backend::DType;
 use burn::backend::ir::{
-    NumericOperationIr, OperationIr, PadModeIr, PadOpIr, ReduceDimWithIndicesOpIr, ScalarOpIr,
+    NumericOperationIr, OperationIr, PadModeIr, PadOpIr, ReduceDimOpIr, ReduceDimWithIndicesOpIr,
+    ScalarOpIr, TensorIr,
 };
 
 use crate::export::ExportError;
@@ -76,6 +77,14 @@ pub(super) fn lower(
         context.int_attribute("keepdims", kept as i64);
         return Ok(true);
     }
+    if let NumericOperationIr::ArgMax(reduce) = numeric {
+        lower_arg(context, index, reduce, "ArgMax")?;
+        return Ok(true);
+    }
+    if let NumericOperationIr::ArgMin(reduce) = numeric {
+        lower_arg(context, index, reduce, "ArgMin")?;
+        return Ok(true);
+    }
     if let NumericOperationIr::MaxDimWithIndices(reduce) = numeric {
         lower_reduce_with_indices(context, index, reduce, "ArgMax")?;
         return Ok(true);
@@ -109,11 +118,28 @@ pub(super) fn lower(
     Ok(true)
 }
 
+/// Lower a reduction that returns only its winning indices.
+fn lower_arg(
+    context: &mut LoweringContext<'_>,
+    index: usize,
+    reduce: &ReduceDimOpIr,
+    arg_op: &'static str,
+) -> Result<(), ExportError> {
+    lower_arg_indices(
+        context,
+        index,
+        &reduce.input,
+        &reduce.out,
+        reduce.axis,
+        arg_op,
+    )?;
+    Ok(())
+}
+
 /// Lower a max or min reduction that also yields the winning indices.
 ///
 /// ONNX has no single operator for this pair. `ArgMax`/`ArgMin` produces the
-/// indices, and `GatherElements` reads the values back out through them. Float
-/// inputs need an additional NaN path because Burn propagates the first NaN.
+/// indices, and `GatherElements` reads the values back out through them.
 fn lower_reduce_with_indices(
     context: &mut LoweringContext<'_>,
     index: usize,
@@ -129,92 +155,15 @@ fn lower_reduce_with_indices(
         });
     }
 
-    let indices = context.tensor_name(reduce.out_indices.id);
-    // `ArgMax`/`ArgMin` always produce `int64`; a cast reconciles the traced
-    // index dtype where it differs.
-    let indices64 = match reduce.out_indices.dtype {
-        DType::I64 => indices.clone(),
-        _ => format!("node_{index}_indices64"),
-    };
     let input = context.tensor_name(reduce.tensor.id);
-    let normal_indices64 = if reduce.tensor.dtype.is_float() {
-        format!("node_{index}_normal_indices64")
-    } else {
-        indices64.clone()
-    };
-    context.node(
-        format!("node_{index}_arg"),
+    let indices64 = lower_arg_indices(
+        context,
+        index,
+        &reduce.tensor,
+        &reduce.out_indices,
+        reduce.dim,
         arg_op,
-        vec![input.clone()],
-        vec![normal_indices64.clone()],
-    );
-    context.int_attribute("axis", reduce.dim as i64);
-    context.int_attribute("keepdims", 1);
-
-    if reduce.tensor.dtype.is_float() {
-        let nan_mask = format!("node_{index}_nan_mask");
-        context.node(
-            nan_mask.clone(),
-            "IsNaN",
-            vec![input.clone()],
-            vec![nan_mask.clone()],
-        );
-        let nan_mask64 = format!("node_{index}_nan_mask64");
-        context.node(
-            nan_mask64.clone(),
-            "Cast",
-            vec![nan_mask],
-            vec![nan_mask64.clone()],
-        );
-        context.int_attribute("to", 7);
-
-        let nan_indices64 = format!("node_{index}_nan_indices64");
-        context.node(
-            nan_indices64.clone(),
-            "ArgMax",
-            vec![nan_mask64.clone()],
-            vec![nan_indices64.clone()],
-        );
-        context.int_attribute("axis", reduce.dim as i64);
-        context.int_attribute("keepdims", 1);
-
-        let has_nan64 = format!("node_{index}_has_nan64");
-        context.node(
-            has_nan64.clone(),
-            "GatherElements",
-            vec![nan_mask64, nan_indices64.clone()],
-            vec![has_nan64.clone()],
-        );
-        context.int_attribute("axis", reduce.dim as i64);
-        let has_nan = format!("node_{index}_has_nan");
-        context.node(
-            has_nan.clone(),
-            "Cast",
-            vec![has_nan64],
-            vec![has_nan.clone()],
-        );
-        context.int_attribute("to", 9);
-
-        context.node(
-            format!("node_{index}_select_indices"),
-            "Where",
-            vec![has_nan, nan_indices64, normal_indices64],
-            vec![indices64.clone()],
-        );
-    }
-
-    if indices64 != indices {
-        context.node(
-            format!("node_{index}_cast"),
-            "Cast",
-            vec![indices64.clone()],
-            vec![indices],
-        );
-        context.int_attribute(
-            "to",
-            onnx_dtype_parts(reduce.out_indices.id, reduce.out_indices.dtype)? as i64,
-        );
-    }
+    )?;
     let output = context.tensor_name(reduce.out.id);
     context.node(
         format!("node_{index}"),
@@ -224,6 +173,55 @@ fn lower_reduce_with_indices(
     );
     context.int_attribute("axis", reduce.dim as i64);
     Ok(())
+}
+
+/// Emit canonical ONNX `ArgMax`/`ArgMin` lowering and reconcile its fixed
+/// `int64` output with the dtype captured by Burn.
+///
+/// ONNX does not specify NaN precedence for these operators. Consequently,
+/// runtime behavior for NaN inputs may differ from Burn's first-NaN contract.
+fn lower_arg_indices(
+    context: &mut LoweringContext<'_>,
+    index: usize,
+    input: &TensorIr,
+    output: &TensorIr,
+    axis: usize,
+    arg_op: &'static str,
+) -> Result<String, ExportError> {
+    if !output.dtype.is_int() && !output.dtype.is_uint() {
+        return Err(ExportError::UnsupportedOperation {
+            operation: index,
+            kind: format!("{arg_op} with non-integer {:?} output", output.dtype),
+        });
+    }
+
+    let output_name = context.tensor_name(output.id);
+    let indices64 = if output.dtype == DType::I64 {
+        output_name.clone()
+    } else {
+        format!("node_{index}_indices64")
+    };
+    context.node(
+        format!("node_{index}_arg"),
+        arg_op,
+        vec![context.tensor_name(input.id)],
+        vec![indices64.clone()],
+    );
+    context.int_attribute("axis", axis as i64);
+    context.int_attribute("keepdims", 1);
+    context.int_attribute("select_last_index", 0);
+
+    if indices64 != output_name {
+        context.node(
+            format!("node_{index}_indices_cast"),
+            "Cast",
+            vec![indices64.clone()],
+            vec![output_name],
+        );
+        context.int_attribute("to", onnx_dtype_parts(output.id, output.dtype)? as i64);
+    }
+
+    Ok(indices64)
 }
 
 fn lower_pad(

--- a/crates/burn-onnx/src/export/lower/numeric.rs
+++ b/crates/burn-onnx/src/export/lower/numeric.rs
@@ -43,6 +43,25 @@ pub(super) fn lower(
         return Ok(true);
     }
     if let NumericOperationIr::SumDim(reduce) = numeric {
+        if !matches!(
+            reduce.input.dtype,
+            DType::F16
+                | DType::BF16
+                | DType::F32
+                | DType::F64
+                | DType::I32
+                | DType::I64
+                | DType::U32
+                | DType::U64
+        ) {
+            return Err(ExportError::UnsupportedOperation {
+                operation: index,
+                kind: format!(
+                    "ReduceSum with {:?} input in ONNX opset 18",
+                    reduce.input.dtype
+                ),
+            });
+        }
         let axes_name = format!("node_{index}_axes");
         context.i64_initializer(axes_name.clone(), &[reduce.axis as i64]);
         let input = context.tensor_name(reduce.input.id);
@@ -93,8 +112,8 @@ pub(super) fn lower(
 /// Lower a max or min reduction that also yields the winning indices.
 ///
 /// ONNX has no single operator for this pair. `ArgMax`/`ArgMin` produces the
-/// indices, and `GatherElements` reads the values back out through them, which
-/// matches the reduction exactly instead of recomputing it.
+/// indices, and `GatherElements` reads the values back out through them. Float
+/// inputs need an additional NaN path because Burn propagates the first NaN.
 fn lower_reduce_with_indices(
     context: &mut LoweringContext<'_>,
     index: usize,
@@ -118,14 +137,72 @@ fn lower_reduce_with_indices(
         _ => format!("node_{index}_indices64"),
     };
     let input = context.tensor_name(reduce.tensor.id);
+    let normal_indices64 = if reduce.tensor.dtype.is_float() {
+        format!("node_{index}_normal_indices64")
+    } else {
+        indices64.clone()
+    };
     context.node(
         format!("node_{index}_arg"),
         arg_op,
         vec![input.clone()],
-        vec![indices64.clone()],
+        vec![normal_indices64.clone()],
     );
     context.int_attribute("axis", reduce.dim as i64);
     context.int_attribute("keepdims", 1);
+
+    if reduce.tensor.dtype.is_float() {
+        let nan_mask = format!("node_{index}_nan_mask");
+        context.node(
+            nan_mask.clone(),
+            "IsNaN",
+            vec![input.clone()],
+            vec![nan_mask.clone()],
+        );
+        let nan_mask64 = format!("node_{index}_nan_mask64");
+        context.node(
+            nan_mask64.clone(),
+            "Cast",
+            vec![nan_mask],
+            vec![nan_mask64.clone()],
+        );
+        context.int_attribute("to", 7);
+
+        let nan_indices64 = format!("node_{index}_nan_indices64");
+        context.node(
+            nan_indices64.clone(),
+            "ArgMax",
+            vec![nan_mask64.clone()],
+            vec![nan_indices64.clone()],
+        );
+        context.int_attribute("axis", reduce.dim as i64);
+        context.int_attribute("keepdims", 1);
+
+        let has_nan64 = format!("node_{index}_has_nan64");
+        context.node(
+            has_nan64.clone(),
+            "GatherElements",
+            vec![nan_mask64, nan_indices64.clone()],
+            vec![has_nan64.clone()],
+        );
+        context.int_attribute("axis", reduce.dim as i64);
+        let has_nan = format!("node_{index}_has_nan");
+        context.node(
+            has_nan.clone(),
+            "Cast",
+            vec![has_nan64],
+            vec![has_nan.clone()],
+        );
+        context.int_attribute("to", 9);
+
+        context.node(
+            format!("node_{index}_select_indices"),
+            "Where",
+            vec![has_nan, nan_indices64, normal_indices64],
+            vec![indices64.clone()],
+        );
+    }
+
     if indices64 != indices {
         context.node(
             format!("node_{index}_cast"),

--- a/crates/burn-onnx/src/export/shape/dynamic_axes.rs
+++ b/crates/burn-onnx/src/export/shape/dynamic_axes.rs
@@ -220,7 +220,9 @@ impl AxisTracker {
             }
             NumericOperationIr::MeanDim(operation)
             | NumericOperationIr::SumDim(operation)
-            | NumericOperationIr::ProdDim(operation) => {
+            | NumericOperationIr::ProdDim(operation)
+            | NumericOperationIr::ArgMax(operation)
+            | NumericOperationIr::ArgMin(operation) => {
                 self.reduced_axes(&operation.input, &operation.out, operation.axis)
             }
             NumericOperationIr::MaxDimWithIndices(operation)
@@ -484,14 +486,18 @@ fn slice_covers_axis(range: &burn::backend::Slice, dimension: usize) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use burn::backend::ir::{AdaptiveAvgPool2dOpIr, MatmulOpIr, SwapDimsOpIr};
+    use burn::backend::ir::{AdaptiveAvgPool2dOpIr, MatmulOpIr, ReduceDimOpIr, SwapDimsOpIr};
     use burn::backend::{DType, Shape};
 
     fn tensor(id: u64, shape: &[usize]) -> TensorIr {
+        tensor_with_dtype(id, shape, DType::F32)
+    }
+
+    fn tensor_with_dtype(id: u64, shape: &[usize], dtype: DType) -> TensorIr {
         TensorIr::uninit(
             TensorId::new(id),
             shape.iter().copied().collect::<Shape>(),
-            DType::F32,
+            dtype,
         )
     }
 
@@ -570,6 +576,45 @@ mod tests {
 
         assert!(!dynamic.contains(TensorId::new(3), 0));
         assert!(!dynamic.contains(TensorId::new(3), 1));
+    }
+
+    #[test]
+    fn arg_reduction_preserves_only_non_reduced_dynamic_axes() {
+        let sample = graph(
+            OperationIr::NumericFloat(
+                DType::F32,
+                NumericOperationIr::ArgMax(ReduceDimOpIr {
+                    input: tensor(1, &[2, 4]),
+                    out: tensor_with_dtype(2, &[2, 1], DType::I64),
+                    axis: 1,
+                    accumulator_len: 4,
+                }),
+            ),
+            &[1],
+            &[2],
+        );
+        let validation = graph(
+            OperationIr::NumericFloat(
+                DType::F32,
+                NumericOperationIr::ArgMax(ReduceDimOpIr {
+                    input: tensor(11, &[5, 6]),
+                    out: tensor_with_dtype(12, &[5, 1], DType::I64),
+                    axis: 1,
+                    accumulator_len: 6,
+                }),
+            ),
+            &[11],
+            &[12],
+        );
+        let specs = [InputSpec::new([
+            AxisSpec::dynamic("rows"),
+            AxisSpec::dynamic("columns"),
+        ])];
+
+        let dynamic = PotentiallyDynamicAxes::analyze(&sample, &validation, &specs);
+
+        assert_eq!(dynamic.symbol(TensorId::new(2), 0), Some("rows"));
+        assert!(!dynamic.contains(TensorId::new(2), 1));
     }
 
     #[test]

--- a/crates/burn-onnx/src/export/shape/dynamic_axes.rs
+++ b/crates/burn-onnx/src/export/shape/dynamic_axes.rs
@@ -2,7 +2,7 @@
 
 use burn::backend::ir::{
     ActivationOperationIr, BaseOperationIr, FloatOperationIr, GraphIr, IntOperationIr,
-    ModuleOperationIr, NumericOperationIr, OperationIr, TensorId, TensorIr,
+    ModuleOperationIr, NumericOperationIr, OperationIr, SliceOpIr, TensorId, TensorIr,
 };
 use hashbrown::HashMap;
 
@@ -21,6 +21,7 @@ impl PotentiallyDynamicAxes {
             sample.operations.iter().zip(&validation.operations)
         {
             tracker.transfer(sample_operation);
+            tracker.transfer_slice(sample_operation, validation_operation);
             tracker.transfer_reshape(sample_operation, validation_operation);
             tracker.observe_changes(sample_operation, validation_operation);
         }
@@ -169,6 +170,18 @@ impl AxisTracker {
                     }
                 }
             }
+            BaseOperationIr::Select(operation) => {
+                for axis in 0..operation.out.shape.num_dims() {
+                    if axis == operation.dim {
+                        self.axis(&operation.indices, 0, &operation.out, axis);
+                    } else {
+                        self.axis(&operation.tensor, axis, &operation.out, axis);
+                    }
+                }
+            }
+            BaseOperationIr::Scatter(operation) => {
+                self.same_axes(&operation.tensor, &operation.out)
+            }
             BaseOperationIr::Cast(operation) => self.same_axes(&operation.input, &operation.out),
             BaseOperationIr::AllDim(operation) | BaseOperationIr::AnyDim(operation) => {
                 self.reduced_axes(&operation.input, &operation.out, operation.axis)
@@ -210,6 +223,11 @@ impl AxisTracker {
             | NumericOperationIr::ProdDim(operation) => {
                 self.reduced_axes(&operation.input, &operation.out, operation.axis)
             }
+            NumericOperationIr::MaxDimWithIndices(operation)
+            | NumericOperationIr::MinDimWithIndices(operation) => {
+                self.reduced_axes(&operation.tensor, &operation.out, operation.dim);
+                self.reduced_axes(&operation.tensor, &operation.out_indices, operation.dim);
+            }
             _ => {}
         }
     }
@@ -229,6 +247,10 @@ impl AxisTracker {
 
     fn transfer_module(&mut self, operation: &ModuleOperationIr) {
         match operation {
+            ModuleOperationIr::Conv1d(operation) => {
+                self.axis(&operation.x, 0, &operation.out, 0);
+                self.derived_axis(&operation.x, 2, &operation.out, 2);
+            }
             ModuleOperationIr::Conv2d(operation) => {
                 self.axis(&operation.x, 0, &operation.out, 0);
                 self.derived_axis(&operation.x, 2, &operation.out, 2);
@@ -257,6 +279,42 @@ impl AxisTracker {
                 operation.out.shape.num_dims().saturating_sub(1),
             ),
             _ => {}
+        }
+    }
+
+    fn transfer_slice(&mut self, sample: &OperationIr, validation: &OperationIr) {
+        let (Some(sample), Some(validation)) =
+            (slice_operation(sample), slice_operation(validation))
+        else {
+            return;
+        };
+        for axis in 0..sample.out.shape.num_dims() {
+            let dimensions = sample
+                .tensor
+                .shape
+                .get(axis)
+                .zip(validation.tensor.shape.get(axis));
+            let exact = sample
+                .ranges
+                .get(axis)
+                .zip(validation.ranges.get(axis))
+                .zip(dimensions)
+                .is_some_and(
+                    |(
+                        (sample_range, validation_range),
+                        (&sample_dimension, &validation_dimension),
+                    )| {
+                        sample_range.step == validation_range.step
+                            && sample_range.step.unsigned_abs() == 1
+                            && slice_covers_axis(sample_range, sample_dimension)
+                            && slice_covers_axis(validation_range, validation_dimension)
+                    },
+                );
+            if exact {
+                self.axis(&sample.tensor, axis, &sample.out, axis);
+            } else {
+                self.derived_axis(&sample.tensor, axis, &sample.out, axis);
+            }
         }
     }
 
@@ -407,6 +465,20 @@ fn reshape_tensors(operation: &OperationIr) -> Option<(&TensorIr, &TensorIr)> {
         }
         _ => None,
     }
+}
+
+fn slice_operation(operation: &OperationIr) -> Option<&SliceOpIr> {
+    match operation {
+        OperationIr::BaseFloat(BaseOperationIr::Slice(operation))
+        | OperationIr::BaseInt(BaseOperationIr::Slice(operation))
+        | OperationIr::BaseBool(BaseOperationIr::Slice(operation)) => Some(operation),
+        _ => None,
+    }
+}
+
+fn slice_covers_axis(range: &burn::backend::Slice, dimension: usize) -> bool {
+    range.start == 0
+        && isize::try_from(dimension).is_ok_and(|dimension| range.end == Some(dimension))
 }
 
 #[cfg(test)]

--- a/crates/burn-onnx/src/export/shape/mod.rs
+++ b/crates/burn-onnx/src/export/shape/mod.rs
@@ -640,9 +640,7 @@ fn shape_operations(graph: &GraphIr) -> impl Iterator<Item = ShapeOperation<'_>>
                 source: None,
                 output: &op.out,
             }),
-            OperationIr::BaseFloat(
-                BaseOperationIr::Zeros(op) | BaseOperationIr::Ones(op),
-            )
+            OperationIr::BaseFloat(BaseOperationIr::Zeros(op) | BaseOperationIr::Ones(op))
             | OperationIr::BaseInt(BaseOperationIr::Zeros(op) | BaseOperationIr::Ones(op))
             | OperationIr::BaseBool(BaseOperationIr::Zeros(op) | BaseOperationIr::Ones(op)) => {
                 Some(ShapeOperation {
@@ -667,8 +665,8 @@ fn tensor(graph: &GraphIr, id: TensorId) -> Option<&TensorIr> {
 mod tests {
     use super::*;
     use burn::backend::ir::{
-        FullOpIr, InterpolateModeIr, InterpolateOpIr, InterpolateOptionsIr, ScalarIr, ShapeOpIr,
-        SwapDimsOpIr, TensorIr,
+        CreationOpIr, FullOpIr, InterpolateModeIr, InterpolateOpIr, InterpolateOptionsIr, ScalarIr,
+        ShapeOpIr, SwapDimsOpIr, TensorIr,
     };
     use burn::backend::{DType, Shape};
 
@@ -696,6 +694,29 @@ mod tests {
         assert_eq!(
             resolved.shapes[0].dimensions,
             vec![ShapeExpr::Static(2), ShapeExpr::Static(12)]
+        );
+    }
+
+    #[test]
+    fn static_resolver_handles_zeros_and_ones() {
+        let graph = GraphIr::new(vec![
+            OperationIr::BaseFloat(BaseOperationIr::Zeros(CreationOpIr {
+                out: tensor(1, &[2, 3]),
+            })),
+            OperationIr::BaseFloat(BaseOperationIr::Ones(CreationOpIr {
+                out: tensor(2, &[4, 5]),
+            })),
+        ]);
+
+        let resolved = StaticShapeResolver { graph: &graph }.resolve().unwrap();
+
+        assert_eq!(
+            resolved.shapes[0].dimensions,
+            vec![ShapeExpr::Static(2), ShapeExpr::Static(3)]
+        );
+        assert_eq!(
+            resolved.shapes[1].dimensions,
+            vec![ShapeExpr::Static(4), ShapeExpr::Static(5)]
         );
     }
 

--- a/crates/burn-onnx/src/export/shape/mod.rs
+++ b/crates/burn-onnx/src/export/shape/mod.rs
@@ -640,6 +640,17 @@ fn shape_operations(graph: &GraphIr) -> impl Iterator<Item = ShapeOperation<'_>>
                 source: None,
                 output: &op.out,
             }),
+            OperationIr::BaseFloat(
+                BaseOperationIr::Zeros(op) | BaseOperationIr::Ones(op),
+            )
+            | OperationIr::BaseInt(BaseOperationIr::Zeros(op) | BaseOperationIr::Ones(op))
+            | OperationIr::BaseBool(BaseOperationIr::Zeros(op) | BaseOperationIr::Ones(op)) => {
+                Some(ShapeOperation {
+                    index,
+                    source: None,
+                    output: &op.out,
+                })
+            }
             _ => None,
         })
 }

--- a/crates/burn-onnx/tests/ort_numerical.rs
+++ b/crates/burn-onnx/tests/ort_numerical.rs
@@ -2,16 +2,17 @@
 
 use std::cell::RefCell;
 
+use burn::backend::DType;
 use burn::module::{Module, Param};
 use burn::nn::{
-    Linear, LinearConfig, Relu,
-    conv::{Conv2d, Conv2dConfig},
+    Linear, LinearConfig, PaddingConfig1d, Relu,
+    conv::{Conv1d, Conv1dConfig, Conv2d, Conv2dConfig},
     pool::{MaxPool2d, MaxPool2dConfig},
 };
-use burn::tensor::{Device, Int, Tensor, TensorData, Tolerance};
+use burn::tensor::{Bool, Device, Int, Tensor, TensorData, Tolerance, s};
 use burn::tensor::{
-    module::interpolate,
-    ops::{InterpolateMode, InterpolateOptions, PadMode},
+    module::{conv1d, interpolate},
+    ops::{ConvOptions, IndexingUpdateOp, InterpolateMode, InterpolateOptions, PadMode},
 };
 use burn_onnx::export::{AxisSpec, ExportError, InputSpec, OnnxExporter};
 use onnx_ir::ModelProto;
@@ -88,6 +89,126 @@ struct SmallCnn {
     conv: Conv2d,
     activation: Relu,
     pool: MaxPool2d,
+}
+
+#[derive(Module, Debug)]
+struct SmallConv1d {
+    conv: Conv1d,
+}
+
+impl SmallConv1d {
+    fn forward(&self, input: Tensor<3>) -> Tensor<3> {
+        self.conv.forward(input)
+    }
+}
+
+#[derive(Module, Debug)]
+struct SteppedSlice;
+
+impl SteppedSlice {
+    fn forward(&self, input: Tensor<1>) -> (Tensor<1>, Tensor<1>) {
+        (input.clone().slice(s![1..9;2]), input.slice(s![2..8;-2]))
+    }
+}
+
+#[derive(Module, Debug)]
+struct FixedUpperSlice;
+
+impl FixedUpperSlice {
+    fn forward(&self, input: Tensor<1>) -> Tensor<1> {
+        input.slice(s![..5])
+    }
+}
+
+#[derive(Module, Debug)]
+struct SelectColumns {
+    indices: Tensor<1, Int>,
+}
+
+impl SelectColumns {
+    fn forward(&self, input: Tensor<2>) -> Tensor<2> {
+        input.select(1, self.indices.clone())
+    }
+}
+
+#[derive(Module, Debug)]
+struct ScatterColumns {
+    indices: Tensor<2, Int>,
+    values: Tensor<2>,
+}
+
+impl ScatterColumns {
+    fn forward(&self, input: Tensor<2>) -> Vec<Tensor<2>> {
+        [
+            IndexingUpdateOp::Assign,
+            IndexingUpdateOp::Add,
+            IndexingUpdateOp::Mul,
+            IndexingUpdateOp::Min,
+            IndexingUpdateOp::Max,
+        ]
+        .map(|update| {
+            input
+                .clone()
+                .scatter(1, self.indices.clone(), self.values.clone(), update)
+        })
+        .into()
+    }
+}
+
+#[derive(Module, Debug)]
+struct BoolCreation;
+
+impl BoolCreation {
+    fn forward(&self, input: Tensor<2>) -> (Tensor<2, Bool>, Tensor<2, Bool>) {
+        let shape = input.shape();
+        (
+            Tensor::zeros(shape.clone(), &input.device()),
+            Tensor::ones(shape, &input.device()),
+        )
+    }
+}
+
+#[derive(Module, Debug)]
+struct DimReductions;
+
+#[derive(Module, Debug)]
+struct IntSum;
+
+impl IntSum {
+    fn forward(&self, input: Tensor<2, Int>) -> Tensor<2, Int> {
+        input.sum_dim(1)
+    }
+}
+
+#[derive(Module, Debug)]
+struct RawConv1d {
+    weight: Tensor<3>,
+}
+
+impl RawConv1d {
+    fn forward(&self, input: Tensor<3>) -> Tensor<3> {
+        conv1d(
+            input,
+            self.weight.clone(),
+            None,
+            ConvOptions::new([1], [0], [1], 1),
+        )
+    }
+}
+
+type DimReductionOutputs = (
+    Tensor<2>,
+    (Tensor<2>, Tensor<2, Int>),
+    (Tensor<2>, Tensor<2, Int>),
+);
+
+impl DimReductions {
+    fn forward(&self, input: Tensor<2>) -> DimReductionOutputs {
+        let sum = input.clone().sum_dim(1);
+        let (max, max_indices) = input.clone().max_dim_with_indices(1);
+        let (min, min_indices) = input.min_dim_with_indices(1);
+        (sum, (max, max_indices), (min, min_indices))
+    }
 }
 
 #[derive(Module, Debug)]
@@ -469,6 +590,329 @@ fn small_cnn_matches_burn() {
 
     let actual = run_ort(model.as_bytes(), [1, 1, 5, 5], input_values);
     actual.assert_approx_eq::<f32>(&expected, Tolerance::rel_abs(RTOL, ATOL));
+}
+
+#[test]
+fn conv1d_matches_burn() {
+    let device = Device::default();
+    let module = SmallConv1d {
+        conv: Conv1dConfig::new(2, 2, 3)
+            .with_stride(2)
+            .with_dilation(2)
+            .with_groups(2)
+            .with_padding(PaddingConfig1d::Explicit(2, 2))
+            .init(&device),
+    };
+    let input = (Tensor::<1, Int>::arange(0..18, &device).float() / 10.0).reshape([1, 2, 9]);
+    let input_values = input.clone().into_data().try_to_vec::<f32>().unwrap();
+    let expected = module.forward(input.clone()).into_data();
+    let model = OnnxExporter::new()
+        .export(&module, input, SmallConv1d::forward)
+        .unwrap();
+
+    let actual = run_ort(model.as_bytes(), [1, 2, 9], input_values);
+    actual.assert_approx_eq::<f32>(&expected, Tolerance::rel_abs(RTOL, ATOL));
+}
+
+#[test]
+fn dynamic_conv1d_handles_colliding_capture_shapes() {
+    let device = Device::default();
+    let module = SmallConv1d {
+        conv: Conv1dConfig::new(1, 2, 2).with_stride(2).init(&device),
+    };
+    // Lengths 4 and 5 both convolve to 2, but runtime length 6 convolves to 3.
+    let sample = Tensor::<3>::zeros([1, 1, 4], &device);
+    let validation = Tensor::<3>::zeros([1, 1, 5], &device);
+    let specs = [InputSpec::new([
+        AxisSpec::Static,
+        AxisSpec::Static,
+        AxisSpec::dynamic("length"),
+    ])];
+    let model = OnnxExporter::new()
+        .export_dynamic(&module, sample, validation, &specs, SmallConv1d::forward)
+        .unwrap();
+
+    let runtime_input = Tensor::<1, Int>::arange(0..6, &device)
+        .float()
+        .reshape([1, 1, 6]);
+    let runtime_values = runtime_input
+        .clone()
+        .into_data()
+        .try_to_vec::<f32>()
+        .unwrap();
+    let expected = module.forward(runtime_input).into_data();
+    let actual = run_ort(model.as_bytes(), [1, 1, 6], runtime_values);
+    actual.assert_approx_eq::<f32>(&expected, Tolerance::rel_abs(RTOL, ATOL));
+
+    let model = ModelProto::parse_from_bytes(model.as_bytes()).unwrap();
+    assert!(
+        model.graph.output[0]
+            .type_
+            .as_ref()
+            .unwrap()
+            .tensor_type()
+            .shape
+            .dim[2]
+            .has_dim_param()
+    );
+}
+
+#[test]
+fn stepped_slice_matches_burn() {
+    let device = Device::default();
+    let input = Tensor::<1, Int>::arange(0..10, &device).float();
+    let input_values = input.clone().into_data().try_to_vec::<f32>().unwrap();
+    let (expected_positive, expected_negative) = SteppedSlice.forward(input.clone());
+    let model = OnnxExporter::new()
+        .export(&SteppedSlice, input, SteppedSlice::forward)
+        .unwrap();
+
+    let mut session = Session::builder()
+        .unwrap()
+        .commit_from_memory(model.as_bytes())
+        .unwrap();
+    let outputs = session
+        .run(ort::inputs![
+            OrtTensor::from_array(([10], input_values)).unwrap()
+        ])
+        .unwrap();
+    let (shape, values) = outputs[0].try_extract_tensor::<f32>().unwrap();
+    TensorData::new(
+        values.to_vec(),
+        shape.iter().map(|&dim| dim as usize).collect::<Vec<_>>(),
+    )
+    .assert_approx_eq::<f32>(&expected_positive.into_data(), Tolerance::default());
+    let (shape, values) = outputs[1].try_extract_tensor::<f32>().unwrap();
+    TensorData::new(
+        values.to_vec(),
+        shape.iter().map(|&dim| dim as usize).collect::<Vec<_>>(),
+    )
+    .assert_approx_eq::<f32>(&expected_negative.into_data(), Tolerance::default());
+}
+
+#[test]
+fn dynamic_slice_rejects_ambiguous_clamped_bounds() {
+    let device = Device::default();
+    // Burn clamps `..5` to each captured input. The resulting `0..3` and
+    // `0..4` ranges cannot be distinguished from a genuinely open range.
+    let sample = Tensor::<1>::zeros([3], &device);
+    let validation = Tensor::<1>::zeros([4], &device);
+    let specs = [InputSpec::new([AxisSpec::dynamic("length")])];
+    let result = OnnxExporter::new().export_dynamic(
+        &FixedUpperSlice,
+        sample,
+        validation,
+        &specs,
+        FixedUpperSlice::forward,
+    );
+
+    assert!(matches!(
+        result,
+        Err(ExportError::DynamicShapeLost { reason, .. })
+            if reason.contains("varying slice bounds")
+    ));
+}
+
+#[test]
+fn select_matches_burn() {
+    let device = Device::default();
+    let module = SelectColumns {
+        indices: Tensor::from_ints([3, 1], &device).cast(DType::I8),
+    };
+    let input = Tensor::<1, Int>::arange(0..8, &device)
+        .float()
+        .reshape([2, 4]);
+    let input_values = input.clone().into_data().try_to_vec::<f32>().unwrap();
+    let expected = module.forward(input.clone()).into_data();
+    let model = OnnxExporter::new()
+        .export(&module, input, SelectColumns::forward)
+        .unwrap();
+
+    let actual = run_ort(model.as_bytes(), [2, 4], input_values);
+    actual.assert_approx_eq::<f32>(&expected, Tolerance::default());
+}
+
+#[test]
+fn scatter_reductions_match_burn() {
+    let device = Device::default();
+    let module = ScatterColumns {
+        indices: Tensor::from_ints([[0, 2], [1, 0]], &device).cast(DType::I8),
+        values: Tensor::from_floats([[10.0, -2.0], [3.0, 20.0]], &device),
+    };
+    let input = Tensor::from_floats([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], &device);
+    let input_values = input.clone().into_data().try_to_vec::<f32>().unwrap();
+    let expected = [
+        [[10.0f32, 2.0, -2.0], [20.0, 3.0, 6.0]],
+        [[11.0, 2.0, 1.0], [24.0, 8.0, 6.0]],
+        [[10.0, 2.0, -6.0], [80.0, 15.0, 6.0]],
+        [[1.0, 2.0, -2.0], [4.0, 3.0, 6.0]],
+        [[10.0, 2.0, 3.0], [20.0, 5.0, 6.0]],
+    ]
+    .map(TensorData::from);
+    let model = OnnxExporter::new()
+        .export(&module, input, ScatterColumns::forward)
+        .unwrap();
+
+    let mut session = Session::builder()
+        .unwrap()
+        .commit_from_memory(model.as_bytes())
+        .unwrap();
+    let outputs = session
+        .run(ort::inputs![
+            OrtTensor::from_array(([2, 3], input_values)).unwrap()
+        ])
+        .unwrap();
+    for (output, expected) in outputs.values().zip(expected) {
+        let (shape, values) = output.try_extract_tensor::<f32>().unwrap();
+        TensorData::new(
+            values.to_vec(),
+            shape.iter().map(|&dim| dim as usize).collect::<Vec<_>>(),
+        )
+        .assert_approx_eq::<f32>(&expected, Tolerance::default());
+    }
+}
+
+#[test]
+fn dynamic_bool_zeros_and_ones_match_burn() {
+    let device = Device::default();
+    let sample = Tensor::<2>::zeros([2, 3], &device);
+    let validation = Tensor::<2>::zeros([5, 3], &device);
+    let specs = [InputSpec::new([
+        AxisSpec::dynamic("batch"),
+        AxisSpec::Static,
+    ])];
+    let model = OnnxExporter::new()
+        .export_dynamic(
+            &BoolCreation,
+            sample,
+            validation,
+            &specs,
+            BoolCreation::forward,
+        )
+        .unwrap();
+
+    let runtime_values = vec![0.0f32; 21];
+    let mut session = Session::builder()
+        .unwrap()
+        .commit_from_memory(model.as_bytes())
+        .unwrap();
+    let outputs = session
+        .run(ort::inputs![
+            OrtTensor::from_array(([7, 3], runtime_values)).unwrap()
+        ])
+        .unwrap();
+    let (shape, zeros) = outputs[0].try_extract_tensor::<bool>().unwrap();
+    assert_eq!(shape.iter().copied().collect::<Vec<_>>(), vec![7, 3]);
+    assert!(zeros.iter().all(|value| !value));
+    let (shape, ones) = outputs[1].try_extract_tensor::<bool>().unwrap();
+    assert_eq!(shape.iter().copied().collect::<Vec<_>>(), vec![7, 3]);
+    assert!(ones.iter().all(|value| *value));
+}
+
+#[test]
+fn dim_reductions_match_burn() {
+    let device = Device::default();
+    let input = Tensor::from_floats([[3.0, -2.0, 7.0, 7.0], [5.0, 9.0, -1.0, 4.0]], &device);
+    let input_values = input.clone().into_data().try_to_vec::<f32>().unwrap();
+    let (expected_sum, (expected_max, expected_max_indices), (expected_min, expected_min_indices)) =
+        DimReductions.forward(input.clone());
+    let model = OnnxExporter::new()
+        .export(&DimReductions, input, DimReductions::forward)
+        .unwrap();
+
+    let mut session = Session::builder()
+        .unwrap()
+        .commit_from_memory(model.as_bytes())
+        .unwrap();
+    let outputs = session
+        .run(ort::inputs![
+            OrtTensor::from_array(([2, 4], input_values)).unwrap()
+        ])
+        .unwrap();
+    for (position, expected) in [expected_sum, expected_max, expected_min]
+        .into_iter()
+        .enumerate()
+    {
+        let output = if position < 2 {
+            &outputs[position]
+        } else {
+            &outputs[3]
+        };
+        let (shape, values) = output.try_extract_tensor::<f32>().unwrap();
+        TensorData::new(
+            values.to_vec(),
+            shape.iter().map(|&dim| dim as usize).collect::<Vec<_>>(),
+        )
+        .assert_approx_eq::<f32>(&expected.into_data(), Tolerance::default());
+    }
+    for (output, expected) in [
+        (&outputs[2], expected_max_indices),
+        (&outputs[4], expected_min_indices),
+    ] {
+        let (shape, values) = output.try_extract_tensor::<i64>().unwrap();
+        TensorData::new(
+            values.to_vec(),
+            shape.iter().map(|&dim| dim as usize).collect::<Vec<_>>(),
+        )
+        .assert_eq(&expected.into_data(), false);
+    }
+}
+
+#[test]
+fn dim_reductions_propagate_the_first_nan() {
+    let device = Device::default();
+    let input = Tensor::from_floats([[1.0, f32::NAN, -3.0]], &device);
+    let input_values = input.clone().into_data().try_to_vec::<f32>().unwrap();
+    let model = OnnxExporter::new()
+        .export(&DimReductions, input, DimReductions::forward)
+        .unwrap();
+
+    let mut session = Session::builder()
+        .unwrap()
+        .commit_from_memory(model.as_bytes())
+        .unwrap();
+    let outputs = session
+        .run(ort::inputs![
+            OrtTensor::from_array(([1, 3], input_values)).unwrap()
+        ])
+        .unwrap();
+    for output in [&outputs[1], &outputs[3]] {
+        let (_, values) = output.try_extract_tensor::<f32>().unwrap();
+        assert!(values[0].is_nan());
+    }
+    for output in [&outputs[2], &outputs[4]] {
+        let (_, values) = output.try_extract_tensor::<i64>().unwrap();
+        assert_eq!(values, [1]);
+    }
+}
+
+#[test]
+fn reduce_sum_rejects_unsupported_opset_18_dtype() {
+    let device = Device::default();
+    let input = Tensor::<2, Int>::from_ints([[1, 2], [3, 4]], &device).cast(DType::I8);
+    let result = OnnxExporter::new().export(&IntSum, input, IntSum::forward);
+
+    assert!(matches!(
+        result,
+        Err(ExportError::UnsupportedOperation { kind, .. })
+            if kind.contains("ReduceSum") && kind.contains("I8")
+    ));
+}
+
+#[test]
+fn conv1d_rejects_bfloat16_for_opset_18() {
+    let device = Device::default();
+    let module = RawConv1d {
+        weight: Tensor::<3>::ones([1, 1, 2], &device).cast(DType::BF16),
+    };
+    let input = Tensor::<3>::ones([1, 1, 4], &device).cast(DType::BF16);
+    let result = OnnxExporter::new().export(&module, input, RawConv1d::forward);
+
+    assert!(matches!(
+        result,
+        Err(ExportError::UnsupportedOperation { kind, .. })
+            if kind.contains("Conv1d") && kind.contains("BF16")
+    ));
 }
 
 #[test]

--- a/crates/burn-onnx/tests/ort_numerical.rs
+++ b/crates/burn-onnx/tests/ort_numerical.rs
@@ -172,6 +172,9 @@ impl BoolCreation {
 struct DimReductions;
 
 #[derive(Module, Debug)]
+struct ArgReductions;
+
+#[derive(Module, Debug)]
 struct IntSum;
 
 impl IntSum {
@@ -208,6 +211,12 @@ impl DimReductions {
         let (max, max_indices) = input.clone().max_dim_with_indices(1);
         let (min, min_indices) = input.min_dim_with_indices(1);
         (sum, (max, max_indices), (min, min_indices))
+    }
+}
+
+impl ArgReductions {
+    fn forward(&self, input: Tensor<2>) -> (Tensor<2, Int>, Tensor<2, Int>) {
+        (input.clone().argmax(1), input.argmin(1))
     }
 }
 
@@ -819,6 +828,22 @@ fn dim_reductions_match_burn() {
     let model = OnnxExporter::new()
         .export(&DimReductions, input, DimReductions::forward)
         .unwrap();
+    let model_proto = ModelProto::parse_from_bytes(model.as_bytes()).unwrap();
+    assert_eq!(
+        model_proto
+            .graph
+            .node
+            .iter()
+            .map(|node| node.op_type.as_str())
+            .collect::<Vec<_>>(),
+        [
+            "ReduceSum",
+            "ArgMax",
+            "GatherElements",
+            "ArgMin",
+            "GatherElements"
+        ]
+    );
 
     let mut session = Session::builder()
         .unwrap()
@@ -859,13 +884,24 @@ fn dim_reductions_match_burn() {
 }
 
 #[test]
-fn dim_reductions_propagate_the_first_nan() {
+fn arg_reductions_lower_directly_and_match_burn() {
     let device = Device::default();
-    let input = Tensor::from_floats([[1.0, f32::NAN, -3.0]], &device);
+    let input = Tensor::from_floats([[3.0, -2.0, 7.0, 7.0], [5.0, 9.0, -1.0, 4.0]], &device);
     let input_values = input.clone().into_data().try_to_vec::<f32>().unwrap();
+    let (expected_max, expected_min) = ArgReductions.forward(input.clone());
     let model = OnnxExporter::new()
-        .export(&DimReductions, input, DimReductions::forward)
+        .export(&ArgReductions, input, ArgReductions::forward)
         .unwrap();
+    let model_proto = ModelProto::parse_from_bytes(model.as_bytes()).unwrap();
+    assert_eq!(
+        model_proto
+            .graph
+            .node
+            .iter()
+            .map(|node| node.op_type.as_str())
+            .collect::<Vec<_>>(),
+        ["ArgMax", "ArgMin"]
+    );
 
     let mut session = Session::builder()
         .unwrap()
@@ -873,16 +909,12 @@ fn dim_reductions_propagate_the_first_nan() {
         .unwrap();
     let outputs = session
         .run(ort::inputs![
-            OrtTensor::from_array(([1, 3], input_values)).unwrap()
+            OrtTensor::from_array(([2, 4], input_values)).unwrap()
         ])
         .unwrap();
-    for output in [&outputs[1], &outputs[3]] {
-        let (_, values) = output.try_extract_tensor::<f32>().unwrap();
-        assert!(values[0].is_nan());
-    }
-    for output in [&outputs[2], &outputs[4]] {
+    for (output, expected) in [(&outputs[0], expected_max), (&outputs[1], expected_min)] {
         let (_, values) = output.try_extract_tensor::<i64>().unwrap();
-        assert_eq!(values, [1]);
+        TensorData::new(values.to_vec(), vec![2, 1]).assert_eq(&expected.into_data(), false);
     }
 }
 


### PR DESCRIPTION
Extends the ONNX exporter with support for:

- `slice` -> ONNX `Slice`, including negative steps
- `select` -> ONNX `Gather`
- `scatter` -> ONNX `ScatterElements`, including assign/add/mul/min/max reductions
- `zeros` / `ones` -> ONNX `ConstantOfShape` with explicit dtype casting
- `sum_dim` -> ONNX `ReduceSum`
- `argmax` / `argmin` -> ONNX `ArgMax` / `ArgMin`
- `max_dim_with_indices` / `min_dim_with_indices` -> `ArgMax` / `ArgMin` with `GatherElements`
- `conv1d` -> ONNX `Conv`
