### PR TITLE
fix(export): correct Conv, ArgMax, ArgMin, and ConstantOfShape lowering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -559,7 +559,7 @@ checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 [[package]]
 name = "burn"
 version = "0.22.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=046a21c436db4d86e90be54c162a57164d4f2862#046a21c436db4d86e90be54c162a57164d4f2862"
+source = "git+https://github.com/tracel-ai/burn?rev=dc4929708b2fa7699facbe1c16f6eaaca250573d#dc4929708b2fa7699facbe1c16f6eaaca250573d"
 dependencies = [
  "burn-core",
  "burn-nn",
@@ -572,7 +572,7 @@ dependencies = [
 [[package]]
 name = "burn-autodiff"
 version = "0.22.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=046a21c436db4d86e90be54c162a57164d4f2862#046a21c436db4d86e90be54c162a57164d4f2862"
+source = "git+https://github.com/tracel-ai/burn?rev=dc4929708b2fa7699facbe1c16f6eaaca250573d#dc4929708b2fa7699facbe1c16f6eaaca250573d"
 dependencies = [
  "burn-backend",
  "burn-std",
@@ -587,7 +587,7 @@ dependencies = [
 [[package]]
 name = "burn-backend"
 version = "0.22.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=046a21c436db4d86e90be54c162a57164d4f2862#046a21c436db4d86e90be54c162a57164d4f2862"
+source = "git+https://github.com/tracel-ai/burn?rev=dc4929708b2fa7699facbe1c16f6eaaca250573d#dc4929708b2fa7699facbe1c16f6eaaca250573d"
 dependencies = [
  "burn-std",
  "cubecl",
@@ -605,7 +605,7 @@ dependencies = [
 [[package]]
 name = "burn-backend-extension"
 version = "0.22.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=046a21c436db4d86e90be54c162a57164d4f2862#046a21c436db4d86e90be54c162a57164d4f2862"
+source = "git+https://github.com/tracel-ai/burn?rev=dc4929708b2fa7699facbe1c16f6eaaca250573d#dc4929708b2fa7699facbe1c16f6eaaca250573d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -615,7 +615,7 @@ dependencies = [
 [[package]]
 name = "burn-capture"
 version = "0.22.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=046a21c436db4d86e90be54c162a57164d4f2862#046a21c436db4d86e90be54c162a57164d4f2862"
+source = "git+https://github.com/tracel-ai/burn?rev=dc4929708b2fa7699facbe1c16f6eaaca250573d#dc4929708b2fa7699facbe1c16f6eaaca250573d"
 dependencies = [
  "burn-backend",
  "burn-ir",
@@ -629,7 +629,7 @@ dependencies = [
 [[package]]
 name = "burn-core"
 version = "0.22.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=046a21c436db4d86e90be54c162a57164d4f2862#046a21c436db4d86e90be54c162a57164d4f2862"
+source = "git+https://github.com/tracel-ai/burn?rev=dc4929708b2fa7699facbe1c16f6eaaca250573d#dc4929708b2fa7699facbe1c16f6eaaca250573d"
 dependencies = [
  "burn-backend",
  "burn-backend-extension",
@@ -655,7 +655,7 @@ dependencies = [
 [[package]]
 name = "burn-cpu"
 version = "0.22.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=046a21c436db4d86e90be54c162a57164d4f2862#046a21c436db4d86e90be54c162a57164d4f2862"
+source = "git+https://github.com/tracel-ai/burn?rev=dc4929708b2fa7699facbe1c16f6eaaca250573d#dc4929708b2fa7699facbe1c16f6eaaca250573d"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -666,7 +666,7 @@ dependencies = [
 [[package]]
 name = "burn-cubecl"
 version = "0.22.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=046a21c436db4d86e90be54c162a57164d4f2862#046a21c436db4d86e90be54c162a57164d4f2862"
+source = "git+https://github.com/tracel-ai/burn?rev=dc4929708b2fa7699facbe1c16f6eaaca250573d#dc4929708b2fa7699facbe1c16f6eaaca250573d"
 dependencies = [
  "burn-backend",
  "burn-cubecl-fusion",
@@ -685,7 +685,7 @@ dependencies = [
 [[package]]
 name = "burn-cubecl-fusion"
 version = "0.22.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=046a21c436db4d86e90be54c162a57164d4f2862#046a21c436db4d86e90be54c162a57164d4f2862"
+source = "git+https://github.com/tracel-ai/burn?rev=dc4929708b2fa7699facbe1c16f6eaaca250573d#dc4929708b2fa7699facbe1c16f6eaaca250573d"
 dependencies = [
  "burn-backend",
  "burn-fusion",
@@ -703,7 +703,7 @@ dependencies = [
 [[package]]
 name = "burn-cuda"
 version = "0.22.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=046a21c436db4d86e90be54c162a57164d4f2862#046a21c436db4d86e90be54c162a57164d4f2862"
+source = "git+https://github.com/tracel-ai/burn?rev=dc4929708b2fa7699facbe1c16f6eaaca250573d#dc4929708b2fa7699facbe1c16f6eaaca250573d"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -714,7 +714,7 @@ dependencies = [
 [[package]]
 name = "burn-dataset"
 version = "0.22.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=046a21c436db4d86e90be54c162a57164d4f2862#046a21c436db4d86e90be54c162a57164d4f2862"
+source = "git+https://github.com/tracel-ai/burn?rev=dc4929708b2fa7699facbe1c16f6eaaca250573d#dc4929708b2fa7699facbe1c16f6eaaca250573d"
 dependencies = [
  "burn-std",
  "csv",
@@ -736,7 +736,7 @@ dependencies = [
 [[package]]
 name = "burn-derive"
 version = "0.22.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=046a21c436db4d86e90be54c162a57164d4f2862#046a21c436db4d86e90be54c162a57164d4f2862"
+source = "git+https://github.com/tracel-ai/burn?rev=dc4929708b2fa7699facbe1c16f6eaaca250573d#dc4929708b2fa7699facbe1c16f6eaaca250573d"
 dependencies = [
  "derive-new",
  "proc-macro2",
@@ -747,7 +747,7 @@ dependencies = [
 [[package]]
 name = "burn-dispatch"
 version = "0.22.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=046a21c436db4d86e90be54c162a57164d4f2862#046a21c436db4d86e90be54c162a57164d4f2862"
+source = "git+https://github.com/tracel-ai/burn?rev=dc4929708b2fa7699facbe1c16f6eaaca250573d#dc4929708b2fa7699facbe1c16f6eaaca250573d"
 dependencies = [
  "burn-autodiff",
  "burn-backend",
@@ -767,7 +767,7 @@ dependencies = [
 [[package]]
 name = "burn-flex"
 version = "0.22.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=046a21c436db4d86e90be54c162a57164d4f2862#046a21c436db4d86e90be54c162a57164d4f2862"
+source = "git+https://github.com/tracel-ai/burn?rev=dc4929708b2fa7699facbe1c16f6eaaca250573d#dc4929708b2fa7699facbe1c16f6eaaca250573d"
 dependencies = [
  "burn-backend",
  "burn-ir",
@@ -784,7 +784,7 @@ dependencies = [
 [[package]]
 name = "burn-fusion"
 version = "0.22.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=046a21c436db4d86e90be54c162a57164d4f2862#046a21c436db4d86e90be54c162a57164d4f2862"
+source = "git+https://github.com/tracel-ai/burn?rev=dc4929708b2fa7699facbe1c16f6eaaca250573d#dc4929708b2fa7699facbe1c16f6eaaca250573d"
 dependencies = [
  "burn-backend",
  "burn-ir",
@@ -807,7 +807,7 @@ dependencies = [
 [[package]]
 name = "burn-ir"
 version = "0.22.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=046a21c436db4d86e90be54c162a57164d4f2862#046a21c436db4d86e90be54c162a57164d4f2862"
+source = "git+https://github.com/tracel-ai/burn?rev=dc4929708b2fa7699facbe1c16f6eaaca250573d#dc4929708b2fa7699facbe1c16f6eaaca250573d"
 dependencies = [
  "burn-backend",
  "burn-std",
@@ -818,7 +818,7 @@ dependencies = [
 [[package]]
 name = "burn-ndarray"
 version = "0.22.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=046a21c436db4d86e90be54c162a57164d4f2862#046a21c436db4d86e90be54c162a57164d4f2862"
+source = "git+https://github.com/tracel-ai/burn?rev=dc4929708b2fa7699facbe1c16f6eaaca250573d#dc4929708b2fa7699facbe1c16f6eaaca250573d"
 dependencies = [
  "atomic_float",
  "burn-backend",
@@ -837,7 +837,7 @@ dependencies = [
 [[package]]
 name = "burn-nn"
 version = "0.22.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=046a21c436db4d86e90be54c162a57164d4f2862#046a21c436db4d86e90be54c162a57164d4f2862"
+source = "git+https://github.com/tracel-ai/burn?rev=dc4929708b2fa7699facbe1c16f6eaaca250573d#dc4929708b2fa7699facbe1c16f6eaaca250573d"
 dependencies = [
  "burn-core",
  "num-traits",
@@ -1146,7 +1146,7 @@ dependencies = [
 [[package]]
 name = "burn-optim"
 version = "0.22.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=046a21c436db4d86e90be54c162a57164d4f2862#046a21c436db4d86e90be54c162a57164d4f2862"
+source = "git+https://github.com/tracel-ai/burn?rev=dc4929708b2fa7699facbe1c16f6eaaca250573d#dc4929708b2fa7699facbe1c16f6eaaca250573d"
 dependencies = [
  "burn-core",
  "burn-derive",
@@ -1161,7 +1161,7 @@ dependencies = [
 [[package]]
 name = "burn-pack"
 version = "0.22.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=046a21c436db4d86e90be54c162a57164d4f2862#046a21c436db4d86e90be54c162a57164d4f2862"
+source = "git+https://github.com/tracel-ai/burn?rev=dc4929708b2fa7699facbe1c16f6eaaca250573d#dc4929708b2fa7699facbe1c16f6eaaca250573d"
 dependencies = [
  "burn-std",
  "byteorder",
@@ -1172,7 +1172,7 @@ dependencies = [
 [[package]]
 name = "burn-remote"
 version = "0.22.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=046a21c436db4d86e90be54c162a57164d4f2862#046a21c436db4d86e90be54c162a57164d4f2862"
+source = "git+https://github.com/tracel-ai/burn?rev=dc4929708b2fa7699facbe1c16f6eaaca250573d#dc4929708b2fa7699facbe1c16f6eaaca250573d"
 dependencies = [
  "burn-backend",
  "burn-fusion",
@@ -1194,7 +1194,7 @@ dependencies = [
 [[package]]
 name = "burn-rocm"
 version = "0.22.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=046a21c436db4d86e90be54c162a57164d4f2862#046a21c436db4d86e90be54c162a57164d4f2862"
+source = "git+https://github.com/tracel-ai/burn?rev=dc4929708b2fa7699facbe1c16f6eaaca250573d#dc4929708b2fa7699facbe1c16f6eaaca250573d"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -1205,7 +1205,7 @@ dependencies = [
 [[package]]
 name = "burn-router"
 version = "0.22.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=046a21c436db4d86e90be54c162a57164d4f2862#046a21c436db4d86e90be54c162a57164d4f2862"
+source = "git+https://github.com/tracel-ai/burn?rev=dc4929708b2fa7699facbe1c16f6eaaca250573d#dc4929708b2fa7699facbe1c16f6eaaca250573d"
 dependencies = [
  "burn-backend",
  "burn-fusion",
@@ -1220,7 +1220,7 @@ dependencies = [
 [[package]]
 name = "burn-std"
 version = "0.22.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=046a21c436db4d86e90be54c162a57164d4f2862#046a21c436db4d86e90be54c162a57164d4f2862"
+source = "git+https://github.com/tracel-ai/burn?rev=dc4929708b2fa7699facbe1c16f6eaaca250573d#dc4929708b2fa7699facbe1c16f6eaaca250573d"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1248,7 +1248,7 @@ dependencies = [
 [[package]]
 name = "burn-store"
 version = "0.22.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=046a21c436db4d86e90be54c162a57164d4f2862#046a21c436db4d86e90be54c162a57164d4f2862"
+source = "git+https://github.com/tracel-ai/burn?rev=dc4929708b2fa7699facbe1c16f6eaaca250573d#dc4929708b2fa7699facbe1c16f6eaaca250573d"
 dependencies = [
  "burn-core",
  "burn-pack",
@@ -1271,7 +1271,7 @@ dependencies = [
 [[package]]
 name = "burn-tch"
 version = "0.22.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=046a21c436db4d86e90be54c162a57164d4f2862#046a21c436db4d86e90be54c162a57164d4f2862"
+source = "git+https://github.com/tracel-ai/burn?rev=dc4929708b2fa7699facbe1c16f6eaaca250573d#dc4929708b2fa7699facbe1c16f6eaaca250573d"
 dependencies = [
  "burn-backend",
  "cc",
@@ -1284,7 +1284,7 @@ dependencies = [
 [[package]]
 name = "burn-tensor"
 version = "0.22.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=046a21c436db4d86e90be54c162a57164d4f2862#046a21c436db4d86e90be54c162a57164d4f2862"
+source = "git+https://github.com/tracel-ai/burn?rev=dc4929708b2fa7699facbe1c16f6eaaca250573d#dc4929708b2fa7699facbe1c16f6eaaca250573d"
 dependencies = [
  "burn-backend",
  "burn-dispatch",
@@ -1298,7 +1298,7 @@ dependencies = [
 [[package]]
 name = "burn-vision"
 version = "0.22.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=046a21c436db4d86e90be54c162a57164d4f2862#046a21c436db4d86e90be54c162a57164d4f2862"
+source = "git+https://github.com/tracel-ai/burn?rev=dc4929708b2fa7699facbe1c16f6eaaca250573d#dc4929708b2fa7699facbe1c16f6eaaca250573d"
 dependencies = [
  "aligned-vec",
  "bon",
@@ -1320,7 +1320,7 @@ dependencies = [
 [[package]]
 name = "burn-wgpu"
 version = "0.22.0-pre.3"
-source = "git+https://github.com/tracel-ai/burn?rev=046a21c436db4d86e90be54c162a57164d4f2862#046a21c436db4d86e90be54c162a57164d4f2862"
+source = "git+https://github.com/tracel-ai/burn?rev=dc4929708b2fa7699facbe1c16f6eaaca250573d#dc4929708b2fa7699facbe1c16f6eaaca250573d"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -2324,7 +2324,7 @@ dependencies = [
 [[package]]
 name = "cubek"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=903c820c8c3e656a0c8aa0940f905e70bba58466#903c820c8c3e656a0c8aa0940f905e70bba58466"
+source = "git+https://github.com/tracel-ai/cubek?rev=8bd46c079fdaae2dd780ae21c40cdbd5b69521e4#8bd46c079fdaae2dd780ae21c40cdbd5b69521e4"
 dependencies = [
  "cubecl",
  "cubek-attention",
@@ -2342,7 +2342,7 @@ dependencies = [
 [[package]]
 name = "cubek-attention"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=903c820c8c3e656a0c8aa0940f905e70bba58466#903c820c8c3e656a0c8aa0940f905e70bba58466"
+source = "git+https://github.com/tracel-ai/cubek?rev=8bd46c079fdaae2dd780ae21c40cdbd5b69521e4#8bd46c079fdaae2dd780ae21c40cdbd5b69521e4"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2356,7 +2356,7 @@ dependencies = [
 [[package]]
 name = "cubek-convolution"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=903c820c8c3e656a0c8aa0940f905e70bba58466#903c820c8c3e656a0c8aa0940f905e70bba58466"
+source = "git+https://github.com/tracel-ai/cubek?rev=8bd46c079fdaae2dd780ae21c40cdbd5b69521e4#8bd46c079fdaae2dd780ae21c40cdbd5b69521e4"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2372,7 +2372,7 @@ dependencies = [
 [[package]]
 name = "cubek-fft"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=903c820c8c3e656a0c8aa0940f905e70bba58466#903c820c8c3e656a0c8aa0940f905e70bba58466"
+source = "git+https://github.com/tracel-ai/cubek?rev=8bd46c079fdaae2dd780ae21c40cdbd5b69521e4#8bd46c079fdaae2dd780ae21c40cdbd5b69521e4"
 dependencies = [
  "cubecl",
 ]
@@ -2380,7 +2380,7 @@ dependencies = [
 [[package]]
 name = "cubek-interpolate"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=903c820c8c3e656a0c8aa0940f905e70bba58466#903c820c8c3e656a0c8aa0940f905e70bba58466"
+source = "git+https://github.com/tracel-ai/cubek?rev=8bd46c079fdaae2dd780ae21c40cdbd5b69521e4#8bd46c079fdaae2dd780ae21c40cdbd5b69521e4"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2393,7 +2393,7 @@ dependencies = [
 [[package]]
 name = "cubek-matmul"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=903c820c8c3e656a0c8aa0940f905e70bba58466#903c820c8c3e656a0c8aa0940f905e70bba58466"
+source = "git+https://github.com/tracel-ai/cubek?rev=8bd46c079fdaae2dd780ae21c40cdbd5b69521e4#8bd46c079fdaae2dd780ae21c40cdbd5b69521e4"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2407,7 +2407,7 @@ dependencies = [
 [[package]]
 name = "cubek-pool"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=903c820c8c3e656a0c8aa0940f905e70bba58466#903c820c8c3e656a0c8aa0940f905e70bba58466"
+source = "git+https://github.com/tracel-ai/cubek?rev=8bd46c079fdaae2dd780ae21c40cdbd5b69521e4#8bd46c079fdaae2dd780ae21c40cdbd5b69521e4"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2417,7 +2417,7 @@ dependencies = [
 [[package]]
 name = "cubek-quant"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=903c820c8c3e656a0c8aa0940f905e70bba58466#903c820c8c3e656a0c8aa0940f905e70bba58466"
+source = "git+https://github.com/tracel-ai/cubek?rev=8bd46c079fdaae2dd780ae21c40cdbd5b69521e4#8bd46c079fdaae2dd780ae21c40cdbd5b69521e4"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2429,7 +2429,7 @@ dependencies = [
 [[package]]
 name = "cubek-random"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=903c820c8c3e656a0c8aa0940f905e70bba58466#903c820c8c3e656a0c8aa0940f905e70bba58466"
+source = "git+https://github.com/tracel-ai/cubek?rev=8bd46c079fdaae2dd780ae21c40cdbd5b69521e4#8bd46c079fdaae2dd780ae21c40cdbd5b69521e4"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2444,7 +2444,7 @@ dependencies = [
 [[package]]
 name = "cubek-reduce"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=903c820c8c3e656a0c8aa0940f905e70bba58466#903c820c8c3e656a0c8aa0940f905e70bba58466"
+source = "git+https://github.com/tracel-ai/cubek?rev=8bd46c079fdaae2dd780ae21c40cdbd5b69521e4#8bd46c079fdaae2dd780ae21c40cdbd5b69521e4"
 dependencies = [
  "cubecl",
  "cubek-std",
@@ -2457,7 +2457,7 @@ dependencies = [
 [[package]]
 name = "cubek-std"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=903c820c8c3e656a0c8aa0940f905e70bba58466#903c820c8c3e656a0c8aa0940f905e70bba58466"
+source = "git+https://github.com/tracel-ai/cubek?rev=8bd46c079fdaae2dd780ae21c40cdbd5b69521e4#8bd46c079fdaae2dd780ae21c40cdbd5b69521e4"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -2466,7 +2466,7 @@ dependencies = [
 [[package]]
 name = "cubek-tile"
 version = "0.3.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubek?rev=903c820c8c3e656a0c8aa0940f905e70bba58466#903c820c8c3e656a0c8aa0940f905e70bba58466"
+source = "git+https://github.com/tracel-ai/cubek?rev=8bd46c079fdaae2dd780ae21c40cdbd5b69521e4#8bd46c079fdaae2dd780ae21c40cdbd5b69521e4"
 dependencies = [
  "bytemuck",
  "cubecl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,11 +93,11 @@ tempfile = "3.24.0"
 thiserror = { version = "2", default-features = false }
 toml = { version = "1.1.2", default-features = false, features = ["parse", "serde"] }
 
-burn = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "046a21c436db4d86e90be54c162a57164d4f2862" }
-burn-flex = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "046a21c436db4d86e90be54c162a57164d4f2862" }
-burn-pack = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "046a21c436db4d86e90be54c162a57164d4f2862" }
-burn-store = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "046a21c436db4d86e90be54c162a57164d4f2862" }
-burn-tensor = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "046a21c436db4d86e90be54c162a57164d4f2862" }
+burn = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "dc4929708b2fa7699facbe1c16f6eaaca250573d" }
+burn-flex = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "dc4929708b2fa7699facbe1c16f6eaaca250573d" }
+burn-pack = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "dc4929708b2fa7699facbe1c16f6eaaca250573d" }
+burn-store = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "dc4929708b2fa7699facbe1c16f6eaaca250573d" }
+burn-tensor = { git = "https://github.com/tracel-ai/burn", default-features = false, rev = "dc4929708b2fa7699facbe1c16f6eaaca250573d" }
 
 ### For local development. ###
 # burn = { path = "../burn/crates/burn", default-features = false }

--- a/crates/burn-onnx/src/export/exporter.rs
+++ b/crates/burn-onnx/src/export/exporter.rs
@@ -280,6 +280,11 @@ impl OnnxExporter {
     /// `input_specs` are positional and must contain one entry per tensor in
     /// `sample_inputs`. Static axes must agree between both input sets; dynamic
     /// axes must differ. Repeated symbols must refer to identical dimensions.
+    ///
+    /// Export fails when capture has normalized away shape-dependent intent,
+    /// including slices over potentially dynamic axes and input-dependent
+    /// padding before a strided convolution. Rejecting these cases prevents a
+    /// model that is valid only for the two captured shapes from being emitted.
     pub fn export_dynamic<M, I, O, F>(
         &self,
         module: &M,

--- a/crates/burn-onnx/src/export/exporter.rs
+++ b/crates/burn-onnx/src/export/exporter.rs
@@ -281,10 +281,12 @@ impl OnnxExporter {
     /// `sample_inputs`. Static axes must agree between both input sets; dynamic
     /// axes must differ. Repeated symbols must refer to identical dimensions.
     ///
-    /// Export fails when capture has normalized away shape-dependent intent,
-    /// including slices over potentially dynamic axes and input-dependent
-    /// padding before a strided convolution. Rejecting these cases prevents a
-    /// model that is valid only for the two captured shapes from being emitted.
+    /// Export fails when capture has normalized away shape-dependent intent.
+    /// Any slice of a tensor with a potentially dynamic axis is rejected,
+    /// including a full `..` range on that axis, because Burn clamps every
+    /// range to the captured shape. Input-dependent padding before a strided
+    /// convolution is rejected too. These checks are conservative and can
+    /// reject explicit padding that would export correctly.
     pub fn export_dynamic<M, I, O, F>(
         &self,
         module: &M,

--- a/crates/burn-onnx/src/export/lower/base.rs
+++ b/crates/burn-onnx/src/export/lower/base.rs
@@ -155,9 +155,10 @@ fn lower_slice(context: &mut LoweringContext<'_>, index: usize, slice: &SliceOpI
 ///
 /// At capture time Burn has already clamped the ascending interval to the
 /// input shape. A negative step reverses that normalized interval; it is not a
-/// raw Python-style descending slice. The empty-interval conversion is kept so
-/// capture remains correct once Burn moves its empty-output bypass from the
-/// Tensor API to execution backends and preserves Slice in the captured IR.
+/// raw Python-style descending slice. `Tensor::slice` currently returns an
+/// empty tensor before the backend operation is recorded, so an empty interval
+/// never reaches the captured IR. The branch keeps the conversion total in case
+/// that changes.
 fn onnx_slice_bounds(start: isize, end: Option<isize>, step: isize) -> (i64, i64) {
     if step > 0 {
         return (start as i64, end.map_or(i64::MAX, |end| end as i64));
@@ -186,7 +187,12 @@ fn lower_creation(
 ) -> Result<(), ExportError> {
     let shape_name = context.shape_input(index, creation.out.id)?;
     let output = context.tensor_name(creation.out.id);
-    let constant_dtype = constant_of_shape_dtype(creation.out.dtype);
+    let constant_dtype = constant_of_shape_dtype(creation.out.dtype).ok_or_else(|| {
+        ExportError::UnsupportedDType {
+            tensor: creation.out.id,
+            dtype: format!("{:?}", creation.out.dtype),
+        }
+    })?;
     let constant_output = if constant_dtype == creation.out.dtype {
         output.clone()
     } else {
@@ -223,9 +229,10 @@ fn lower_creation(
 
 /// Return the dtype used for the `ConstantOfShape` value attribute.
 ///
-/// Opset 18 uses the version 9 `ConstantOfShape` schema. Unsupported output
-/// types are created as `I64` and converted by the following `Cast` node.
-fn constant_of_shape_dtype(dtype: DType) -> DType {
+/// Opset 18 uses the version 9 `ConstantOfShape` schema. `BF16` outputs are
+/// created as `F32` and converted by the following `Cast` node. Burn-specific
+/// dtypes without an ONNX representation are rejected.
+fn constant_of_shape_dtype(dtype: DType) -> Option<DType> {
     match dtype {
         DType::F16
         | DType::F32
@@ -238,8 +245,9 @@ fn constant_of_shape_dtype(dtype: DType) -> DType {
         | DType::U16
         | DType::U32
         | DType::U64
-        | DType::Bool(_) => dtype,
-        _ => DType::I64,
+        | DType::Bool(_) => Some(dtype),
+        DType::BF16 => Some(DType::F32),
+        DType::Flex32 | DType::QFloat(_) => None,
     }
 }
 
@@ -267,9 +275,10 @@ mod tests {
         ];
 
         for dtype in native_dtypes {
-            assert_eq!(constant_of_shape_dtype(dtype), dtype);
+            assert_eq!(constant_of_shape_dtype(dtype), Some(dtype));
         }
-        assert_eq!(constant_of_shape_dtype(DType::BF16), DType::I64);
+        assert_eq!(constant_of_shape_dtype(DType::BF16), Some(DType::F32));
+        assert_eq!(constant_of_shape_dtype(DType::Flex32), None);
     }
 
     #[test]

--- a/crates/burn-onnx/src/export/lower/base.rs
+++ b/crates/burn-onnx/src/export/lower/base.rs
@@ -151,16 +151,21 @@ fn lower_slice(context: &mut LoweringContext<'_>, index: usize, slice: &SliceOpI
     );
 }
 
+/// Convert a range normalized by Burn's slice API into ONNX bounds.
+///
+/// At capture time Burn has already clamped the ascending interval to the
+/// input shape. A negative step reverses that normalized interval; it is not a
+/// raw Python-style descending slice. The empty-interval conversion is kept so
+/// capture remains correct once Burn moves its empty-output bypass from the
+/// Tensor API to execution backends and preserves Slice in the captured IR.
 fn onnx_slice_bounds(start: isize, end: Option<isize>, step: isize) -> (i64, i64) {
     if step > 0 {
         return (start as i64, end.map_or(i64::MAX, |end| end as i64));
     }
     if end.is_some_and(|end| start >= end) {
-        // Burn permits empty intervals and returns no elements regardless of
-        // the step. Equal in-range ONNX bounds preserve that cardinality.
+        // Equal in-range ONNX bounds preserve Burn's empty interval.
         return (0, 0);
     }
-
     // Burn selects an ascending [start, end) interval and traverses it in
     // reverse. ONNX uses Python-style descending bounds, so swap the interval
     // endpoints and make each one inclusive/exclusive in the other direction.
@@ -181,7 +186,8 @@ fn lower_creation(
 ) -> Result<(), ExportError> {
     let shape_name = context.shape_input(index, creation.out.id)?;
     let output = context.tensor_name(creation.out.id);
-    let constant_output = if creation.out.dtype == DType::I64 {
+    let constant_dtype = constant_of_shape_dtype(creation.out.dtype);
+    let constant_output = if constant_dtype == creation.out.dtype {
         output.clone()
     } else {
         format!("node_{index}_constant")
@@ -194,7 +200,11 @@ fn lower_creation(
     );
     context.tensor_attribute(
         "value",
-        scalar_tensor(DType::I64, ScalarIr::Int(value), creation.out.id)?,
+        scalar_tensor(
+            constant_dtype,
+            ScalarIr::new(value, &constant_dtype),
+            creation.out.id,
+        )?,
     );
     if constant_output != output {
         context.node(
@@ -211,13 +221,65 @@ fn lower_creation(
     Ok(())
 }
 
+/// Return the dtype used for the `ConstantOfShape` value attribute.
+///
+/// Opset 18 uses the version 9 `ConstantOfShape` schema. Unsupported output
+/// types are created as `I64` and converted by the following `Cast` node.
+fn constant_of_shape_dtype(dtype: DType) -> DType {
+    match dtype {
+        DType::F16
+        | DType::F32
+        | DType::F64
+        | DType::I8
+        | DType::I16
+        | DType::I32
+        | DType::I64
+        | DType::U8
+        | DType::U16
+        | DType::U32
+        | DType::U64
+        | DType::Bool(_) => dtype,
+        _ => DType::I64,
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::onnx_slice_bounds;
+    use burn::backend::{BoolStore, DType};
+
+    use super::{constant_of_shape_dtype, onnx_slice_bounds};
+
+    #[test]
+    fn constant_of_shape_uses_all_opset_18_native_dtypes() {
+        let native_dtypes = [
+            DType::F16,
+            DType::F32,
+            DType::F64,
+            DType::I8,
+            DType::I16,
+            DType::I32,
+            DType::I64,
+            DType::U8,
+            DType::U16,
+            DType::U32,
+            DType::U64,
+            DType::Bool(BoolStore::Native),
+        ];
+
+        for dtype in native_dtypes {
+            assert_eq!(constant_of_shape_dtype(dtype), dtype);
+        }
+        assert_eq!(constant_of_shape_dtype(DType::BF16), DType::I64);
+    }
 
     #[test]
     fn negative_step_keeps_empty_intervals_empty() {
         assert_eq!(onnx_slice_bounds(0, Some(0), -1), (0, 0));
         assert_eq!(onnx_slice_bounds(3, Some(1), -2), (0, 0));
+    }
+
+    #[test]
+    fn negative_step_reverses_a_normalized_full_range() {
+        assert_eq!(onnx_slice_bounds(0, Some(5), -1), (4, i64::MIN));
     }
 }

--- a/crates/burn-onnx/src/export/lower/mod.rs
+++ b/crates/burn-onnx/src/export/lower/mod.rs
@@ -17,7 +17,7 @@ mod numeric;
 use std::collections::BTreeMap;
 
 use burn::backend::ir::{OperationIr, ScalarIr, TensorId, TensorIr};
-use burn::backend::{DType, TensorData};
+use burn::backend::{DType, TensorData, f16};
 use context::LoweringContext;
 use hashbrown::{HashMap, HashSet};
 use onnx_ir::{GraphProto, TensorProto, TypeProto, ValueInfoProto};
@@ -285,8 +285,16 @@ fn scalar_tensor(
     let bytes = match dtype {
         DType::F32 => value.elem::<f32>().to_le_bytes().to_vec(),
         DType::F64 => value.elem::<f64>().to_le_bytes().to_vec(),
+        DType::F16 => value.elem::<f16>().to_le_bytes().to_vec(),
+        DType::I8 => value.elem::<i8>().to_le_bytes().to_vec(),
+        DType::I16 => value.elem::<i16>().to_le_bytes().to_vec(),
         DType::I32 => value.elem::<i32>().to_le_bytes().to_vec(),
         DType::I64 => value.elem::<i64>().to_le_bytes().to_vec(),
+        DType::U8 => value.elem::<u8>().to_le_bytes().to_vec(),
+        DType::U16 => value.elem::<u16>().to_le_bytes().to_vec(),
+        DType::U32 => value.elem::<u32>().to_le_bytes().to_vec(),
+        DType::U64 => value.elem::<u64>().to_le_bytes().to_vec(),
+        DType::Bool(_) => vec![value.elem::<bool>() as u8],
         dtype => {
             return Err(ExportError::UnsupportedDType {
                 tensor,
@@ -308,6 +316,32 @@ mod tests {
 
     fn tensor(id: u64) -> TensorIr {
         TensorIr::uninit(TensorId::new(id), Shape::new([2, 3]), DType::F32)
+    }
+
+    #[test]
+    fn serializes_all_constant_of_shape_opset_18_scalar_dtypes() {
+        let cases = [
+            (DType::F16, vec![0, 60]),
+            (DType::F32, vec![0, 0, 128, 63]),
+            (DType::F64, vec![0, 0, 0, 0, 0, 0, 240, 63]),
+            (DType::I8, vec![1]),
+            (DType::I16, vec![1, 0]),
+            (DType::I32, vec![1, 0, 0, 0]),
+            (DType::I64, vec![1, 0, 0, 0, 0, 0, 0, 0]),
+            (DType::U8, vec![1]),
+            (DType::U16, vec![1, 0]),
+            (DType::U32, vec![1, 0, 0, 0]),
+            (DType::U64, vec![1, 0, 0, 0, 0, 0, 0, 0]),
+            (DType::Bool(burn::backend::BoolStore::Native), vec![1]),
+        ];
+
+        for (dtype, expected) in cases {
+            let tensor = TensorId::new(1);
+            let scalar = scalar_tensor(dtype, ScalarIr::new(1, &dtype), tensor).unwrap();
+
+            assert_eq!(scalar.data_type, onnx_dtype_parts(tensor, dtype).unwrap());
+            assert_eq!(scalar.raw_data.as_ref(), expected);
+        }
     }
 
     #[test]

--- a/crates/burn-onnx/src/export/lower/mod.rs
+++ b/crates/burn-onnx/src/export/lower/mod.rs
@@ -310,7 +310,9 @@ fn scalar_tensor(
 mod tests {
     use super::*;
     use burn::backend::Shape;
-    use burn::backend::ir::{BinaryOpIr, GraphIr, NumericOperationIr};
+    use burn::backend::ir::{
+        BinaryOpIr, GraphIr, NumericOperationIr, ReduceDimOpIr, ReduceDimWithIndicesOpIr,
+    };
     use onnx_ir::ModelProto;
     use protobuf::Message;
 
@@ -374,5 +376,88 @@ mod tests {
         assert_eq!(model.graph.node[0].op_type, "Add");
         assert_eq!(model.graph.input.len(), 2);
         assert_eq!(model.graph.output.len(), 1);
+    }
+
+    #[test]
+    fn casts_non_i64_topk_indices_without_swapping_outputs() {
+        let input = tensor(1);
+        let output = TensorIr::uninit(TensorId::new(2), Shape::new([2, 1]), DType::F32);
+        let indices = TensorIr::uninit(TensorId::new(3), Shape::new([2, 1]), DType::I32);
+        let graph = GraphIr::new(vec![OperationIr::NumericFloat(
+            DType::F32,
+            NumericOperationIr::MaxDimWithIndices(ReduceDimWithIndicesOpIr {
+                tensor: input,
+                dim: 1,
+                out: output,
+                out_indices: indices,
+            }),
+        )]);
+        let graph = ResolvedExportGraph {
+            graph,
+            shapes: vec![],
+            dynamic_axes: vec![],
+        };
+        let runtime_inputs = graph.graph.inputs.clone();
+        let model = export_graph_with_bindings_and_opset(
+            &graph,
+            &BTreeMap::new(),
+            &runtime_inputs,
+            &HashMap::new(),
+            Opset::default(),
+        )
+        .unwrap();
+        let model = ModelProto::parse_from_bytes(model.as_bytes()).unwrap();
+
+        assert_eq!(model.graph.node[0].op_type, "TopK");
+        assert_eq!(model.graph.node[0].output[0], "tensor_2");
+        assert_eq!(model.graph.node[0].output[1], "node_0_indices64");
+        assert_eq!(model.graph.node[1].op_type, "Cast");
+        assert_eq!(model.graph.node[1].input, ["node_0_indices64"]);
+        assert_eq!(model.graph.node[1].output, ["tensor_3"]);
+        assert_eq!(
+            model.graph.node[1]
+                .attribute
+                .iter()
+                .find(|attribute| attribute.name == "to")
+                .unwrap()
+                .i,
+            6
+        );
+    }
+
+    #[test]
+    fn casts_non_i64_arg_reduction_output() {
+        let input = tensor(1);
+        let output = TensorIr::uninit(TensorId::new(2), Shape::new([2, 1]), DType::I32);
+        let graph = GraphIr::new(vec![OperationIr::NumericFloat(
+            DType::F32,
+            NumericOperationIr::ArgMax(ReduceDimOpIr {
+                input,
+                out: output,
+                axis: 1,
+                accumulator_len: 3,
+            }),
+        )]);
+        let graph = ResolvedExportGraph {
+            graph,
+            shapes: vec![],
+            dynamic_axes: vec![],
+        };
+        let runtime_inputs = graph.graph.inputs.clone();
+        let model = export_graph_with_bindings_and_opset(
+            &graph,
+            &BTreeMap::new(),
+            &runtime_inputs,
+            &HashMap::new(),
+            Opset::default(),
+        )
+        .unwrap();
+        let model = ModelProto::parse_from_bytes(model.as_bytes()).unwrap();
+
+        assert_eq!(model.graph.node[0].op_type, "ArgMax");
+        assert_eq!(model.graph.node[0].output, ["node_0_indices64"]);
+        assert_eq!(model.graph.node[1].op_type, "Cast");
+        assert_eq!(model.graph.node[1].input, ["node_0_indices64"]);
+        assert_eq!(model.graph.node[1].output, ["tensor_2"]);
     }
 }

--- a/crates/burn-onnx/src/export/lower/module.rs
+++ b/crates/burn-onnx/src/export/lower/module.rs
@@ -40,7 +40,8 @@ pub(super) fn lower(
             context.node(format!("node_{index}"), "Conv", inputs, vec![output]);
             context.ints_attribute("strides", conv.options.stride);
             context.ints_attribute("dilations", conv.options.dilation);
-            context.ints_attribute("pads", [conv.options.padding[0], conv.options.padding[0]]);
+            let [(left, right)] = conv.options.padding;
+            context.ints_attribute("pads", [left, right]);
             context.int_attribute("group", conv.options.groups as i64);
             Ok(true)
         }
@@ -67,10 +68,10 @@ pub(super) fn lower(
             context.ints_attribute(
                 "pads",
                 [
-                    conv.options.padding[0],
-                    conv.options.padding[1],
-                    conv.options.padding[0],
-                    conv.options.padding[1],
+                    conv.options.padding[0].0,
+                    conv.options.padding[1].0,
+                    conv.options.padding[0].1,
+                    conv.options.padding[1].1,
                 ],
             );
             context.int_attribute("group", conv.options.groups as i64);

--- a/crates/burn-onnx/src/export/lower/numeric.rs
+++ b/crates/burn-onnx/src/export/lower/numeric.rs
@@ -86,11 +86,11 @@ pub(super) fn lower(
         return Ok(true);
     }
     if let NumericOperationIr::MaxDimWithIndices(reduce) = numeric {
-        lower_reduce_with_indices(context, index, reduce, "ArgMax")?;
+        lower_reduce_with_indices(context, index, reduce, true, "MaxDimWithIndices")?;
         return Ok(true);
     }
     if let NumericOperationIr::MinDimWithIndices(reduce) = numeric {
-        lower_reduce_with_indices(context, index, reduce, "ArgMin")?;
+        lower_reduce_with_indices(context, index, reduce, false, "MinDimWithIndices")?;
         return Ok(true);
     }
     if let Some((op_type, scalar)) = scalar_operation(numeric) {
@@ -140,45 +140,74 @@ fn lower_arg(
 
 /// Lower a max or min reduction that also yields the winning indices.
 ///
-/// `ArgMax`/`ArgMin` matches Burn's index-selection contract directly, and
-/// `GatherElements` reads the corresponding values back out.
+/// `TopK` with `K = 1` directly produces both rank-preserving outputs and uses
+/// the lowest index to break ties, matching Burn's non-NaN contract.
+/// ONNX does not specify NaN ordering for `TopK`, so NaN inputs may still
+/// differ from Burn's first-NaN behavior.
 fn lower_reduce_with_indices(
     context: &mut LoweringContext<'_>,
     index: usize,
     reduce: &ReduceDimWithIndicesOpIr,
-    arg_op: &'static str,
+    largest: bool,
+    operation: &'static str,
 ) -> Result<(), ExportError> {
-    // `GatherElements` needs indices of the input's rank, which only the
-    // dimension-keeping form provides.
+    // Opset 18 selects TopK-11, which does not support BF16.
+    if reduce.tensor.dtype == DType::BF16 {
+        return Err(ExportError::UnsupportedOperation {
+            operation: index,
+            kind: format!("{operation} with BF16 input in ONNX opset 18"),
+        });
+    }
     if reduce.out.shape.num_dims() != reduce.tensor.shape.num_dims()
         || reduce.out_indices.shape.num_dims() != reduce.tensor.shape.num_dims()
     {
         return Err(ExportError::UnsupportedOperation {
             operation: index,
+            kind: format!("invalid Burn IR: {operation} outputs must preserve the input rank"),
+        });
+    }
+    if !reduce.out_indices.dtype.is_int() && !reduce.out_indices.dtype.is_uint() {
+        return Err(ExportError::UnsupportedOperation {
+            operation: index,
             kind: format!(
-                "invalid Burn IR: {arg_op} with-indices outputs must preserve the input rank"
+                "{operation} with non-integer {:?} indices output",
+                reduce.out_indices.dtype
             ),
         });
     }
 
+    let k = format!("node_{index}_k");
+    context.i64_initializer(k.clone(), &[1]);
     let input = context.tensor_name(reduce.tensor.id);
-    let indices64 = lower_arg_indices(
-        context,
-        index,
-        &reduce.tensor,
-        &reduce.out_indices,
-        reduce.dim,
-        arg_op,
-        true,
-    )?;
     let output = context.tensor_name(reduce.out.id);
+    let indices_output = context.tensor_name(reduce.out_indices.id);
+    let indices64 = if reduce.out_indices.dtype == DType::I64 {
+        indices_output.clone()
+    } else {
+        format!("node_{index}_indices64")
+    };
     context.node(
         format!("node_{index}"),
-        "GatherElements",
-        vec![input, indices64],
-        vec![output],
+        "TopK",
+        vec![input, k],
+        vec![output, indices64.clone()],
     );
     context.int_attribute("axis", reduce.dim as i64);
+    context.int_attribute("largest", largest as i64);
+    context.int_attribute("sorted", 1);
+
+    if indices64 != indices_output {
+        context.node(
+            format!("node_{index}_indices_cast"),
+            "Cast",
+            vec![indices64],
+            vec![indices_output],
+        );
+        context.int_attribute(
+            "to",
+            onnx_dtype_parts(reduce.out_indices.id, reduce.out_indices.dtype)? as i64,
+        );
+    }
     Ok(())
 }
 

--- a/crates/burn-onnx/src/export/lower/numeric.rs
+++ b/crates/burn-onnx/src/export/lower/numeric.rs
@@ -134,8 +134,7 @@ fn lower_arg(
         reduce.axis,
         arg_op,
         keepdims,
-    )?;
-    Ok(())
+    )
 }
 
 /// Lower a max or min reduction that also yields the winning indices.
@@ -151,11 +150,27 @@ fn lower_reduce_with_indices(
     largest: bool,
     operation: &'static str,
 ) -> Result<(), ExportError> {
-    // Opset 18 selects TopK-11, which does not support BF16.
-    if reduce.tensor.dtype == DType::BF16 {
+    // Opset 18 selects TopK-11.
+    if !matches!(
+        reduce.tensor.dtype,
+        DType::F16
+            | DType::F32
+            | DType::F64
+            | DType::I8
+            | DType::I16
+            | DType::I32
+            | DType::I64
+            | DType::U8
+            | DType::U16
+            | DType::U32
+            | DType::U64
+    ) {
         return Err(ExportError::UnsupportedOperation {
             operation: index,
-            kind: format!("{operation} with BF16 input in ONNX opset 18"),
+            kind: format!(
+                "{operation} with {:?} input in ONNX opset 18",
+                reduce.tensor.dtype
+            ),
         });
     }
     if reduce.out.shape.num_dims() != reduce.tensor.shape.num_dims()
@@ -224,7 +239,7 @@ fn lower_arg_indices(
     axis: usize,
     arg_op: &'static str,
     keepdims: bool,
-) -> Result<String, ExportError> {
+) -> Result<(), ExportError> {
     if !output.dtype.is_int() && !output.dtype.is_uint() {
         return Err(ExportError::UnsupportedOperation {
             operation: index,
@@ -238,10 +253,11 @@ fn lower_arg_indices(
     } else {
         format!("node_{index}_indices64")
     };
+    let arg_input = context.tensor_name(input.id);
     context.node(
         format!("node_{index}_arg"),
         arg_op,
-        vec![context.tensor_name(input.id)],
+        vec![arg_input],
         vec![indices64.clone()],
     );
     context.int_attribute("axis", axis as i64);
@@ -252,13 +268,13 @@ fn lower_arg_indices(
         context.node(
             format!("node_{index}_indices_cast"),
             "Cast",
-            vec![indices64.clone()],
+            vec![indices64],
             vec![output_name],
         );
         context.int_attribute("to", onnx_dtype_parts(output.id, output.dtype)? as i64);
     }
 
-    Ok(indices64)
+    Ok(())
 }
 
 fn lower_pad(

--- a/crates/burn-onnx/src/export/lower/numeric.rs
+++ b/crates/burn-onnx/src/export/lower/numeric.rs
@@ -125,6 +125,7 @@ fn lower_arg(
     reduce: &ReduceDimOpIr,
     arg_op: &'static str,
 ) -> Result<(), ExportError> {
+    let keepdims = reduce.out.shape.num_dims() == reduce.input.shape.num_dims();
     lower_arg_indices(
         context,
         index,
@@ -132,14 +133,15 @@ fn lower_arg(
         &reduce.out,
         reduce.axis,
         arg_op,
+        keepdims,
     )?;
     Ok(())
 }
 
 /// Lower a max or min reduction that also yields the winning indices.
 ///
-/// ONNX has no single operator for this pair. `ArgMax`/`ArgMin` produces the
-/// indices, and `GatherElements` reads the values back out through them.
+/// `ArgMax`/`ArgMin` matches Burn's index-selection contract directly, and
+/// `GatherElements` reads the corresponding values back out.
 fn lower_reduce_with_indices(
     context: &mut LoweringContext<'_>,
     index: usize,
@@ -148,10 +150,14 @@ fn lower_reduce_with_indices(
 ) -> Result<(), ExportError> {
     // `GatherElements` needs indices of the input's rank, which only the
     // dimension-keeping form provides.
-    if reduce.out.shape.num_dims() != reduce.tensor.shape.num_dims() {
+    if reduce.out.shape.num_dims() != reduce.tensor.shape.num_dims()
+        || reduce.out_indices.shape.num_dims() != reduce.tensor.shape.num_dims()
+    {
         return Err(ExportError::UnsupportedOperation {
             operation: index,
-            kind: format!("{arg_op} reduction that drops the reduced dimension"),
+            kind: format!(
+                "invalid Burn IR: {arg_op} with-indices outputs must preserve the input rank"
+            ),
         });
     }
 
@@ -163,6 +169,7 @@ fn lower_reduce_with_indices(
         &reduce.out_indices,
         reduce.dim,
         arg_op,
+        true,
     )?;
     let output = context.tensor_name(reduce.out.id);
     context.node(
@@ -187,6 +194,7 @@ fn lower_arg_indices(
     output: &TensorIr,
     axis: usize,
     arg_op: &'static str,
+    keepdims: bool,
 ) -> Result<String, ExportError> {
     if !output.dtype.is_int() && !output.dtype.is_uint() {
         return Err(ExportError::UnsupportedOperation {
@@ -208,7 +216,7 @@ fn lower_arg_indices(
         vec![indices64.clone()],
     );
     context.int_attribute("axis", axis as i64);
-    context.int_attribute("keepdims", 1);
+    context.int_attribute("keepdims", keepdims as i64);
     context.int_attribute("select_last_index", 0);
 
     if indices64 != output_name {

--- a/crates/burn-onnx/src/export/shape/mod.rs
+++ b/crates/burn-onnx/src/export/shape/mod.rs
@@ -160,11 +160,87 @@ impl<'a> PairedTraceAnalysis<'a> {
             .collect::<Result<_, _>>()?;
         let potentially_dynamic =
             PotentiallyDynamicAxes::analyze(resolver.sample, resolver.validation, resolver.inputs);
-        Ok(Self {
+        let analysis = Self {
             resolver,
             inputs,
             potentially_dynamic,
-        })
+        };
+        analysis.validate_dynamic_operation_contracts()?;
+        Ok(analysis)
+    }
+
+    /// Reject operations whose runtime behavior depends on information that
+    /// Burn's captured IR has already normalized away.
+    fn validate_dynamic_operation_contracts(&self) -> Result<(), ExportError> {
+        for (index, operation) in self.resolver.sample.operations.iter().enumerate() {
+            match operation {
+                OperationIr::BaseFloat(BaseOperationIr::Slice(slice))
+                | OperationIr::BaseInt(BaseOperationIr::Slice(slice))
+                | OperationIr::BaseBool(BaseOperationIr::Slice(slice)) => {
+                    if let Some(axis) = (0..slice.ranges.len())
+                        .find(|&axis| self.potentially_dynamic.contains(slice.tensor.id, axis))
+                    {
+                        return Err(ExportError::DynamicShapeLost {
+                            tensor: slice.out.id,
+                            axis,
+                            reason: format!(
+                                "operation {index} has normalized slice bounds on a potentially dynamic axis"
+                            ),
+                        });
+                    }
+                }
+                OperationIr::Module(ModuleOperationIr::Conv1d(conv)) => {
+                    self.validate_strided_convolution_padding(
+                        index,
+                        &conv.x,
+                        &conv.options.stride,
+                        &conv.options.padding,
+                    )?;
+                }
+                OperationIr::Module(ModuleOperationIr::Conv2d(conv)) => {
+                    self.validate_strided_convolution_padding(
+                        index,
+                        &conv.x,
+                        &conv.options.stride,
+                        &conv.options.padding,
+                    )?;
+                }
+                _ => {}
+            }
+        }
+        Ok(())
+    }
+
+    fn validate_strided_convolution_padding<const D: usize>(
+        &self,
+        index: usize,
+        input: &TensorIr,
+        stride: &[usize; D],
+        padding: &[(usize, usize); D],
+    ) -> Result<(), ExportError> {
+        // Burn resolves `Same` to concrete start/end widths using the captured
+        // input shape. Asymmetric widths can change with the runtime input but
+        // the original `Same` intent is not retained in Conv*OpIr. Symmetric
+        // `Same` remains indistinguishable from explicit padding; Burn IR must
+        // retain the original padding intent to close that gap without
+        // rejecting valid explicit-padding convolutions.
+        let spatial_offset = input.shape.num_dims().saturating_sub(D);
+        for (spatial_axis, &stride) in stride.iter().enumerate() {
+            let axis = spatial_offset + spatial_axis;
+            if stride > 1
+                && self.potentially_dynamic.contains(input.id, axis)
+                && padding[spatial_axis].0 != padding[spatial_axis].1
+            {
+                return Err(ExportError::DynamicShapeLost {
+                    tensor: input.id,
+                    axis,
+                    reason: format!(
+                        "operation {index} has strided convolution padding on a potentially dynamic axis; captured IR does not preserve input-dependent padding intent"
+                    ),
+                });
+            }
+        }
+        Ok(())
     }
 
     fn dynamic_axes(&self) -> Result<Vec<DynamicAxis>, ExportError> {
@@ -294,7 +370,8 @@ impl<'a> PairedTraceAnalysis<'a> {
             [] if sample.source.is_none() => Err(ExportError::DynamicShapeLost {
                 tensor: sample.output.id,
                 axis,
-                reason: "Full dimension does not match an annotated dynamic input axis".into(),
+                reason: "created tensor dimension does not match an annotated dynamic input axis"
+                    .into(),
             }),
             [] => Ok(DimensionResolution::Infer),
             candidates => Err(ExportError::DynamicShapeLost {
@@ -399,7 +476,8 @@ impl<'a> PairedTraceAnalysis<'a> {
             Err(ExportError::DynamicShapeLost {
                 tensor: operation.output.id,
                 axis,
-                reason: "equal Full dimensions cannot be proven static from two captures".into(),
+                reason: "equal created tensor dimensions cannot be proven static from two captures"
+                    .into(),
             })
         }
     }

--- a/crates/burn-onnx/src/export/shape/mod.rs
+++ b/crates/burn-onnx/src/export/shape/mod.rs
@@ -116,6 +116,11 @@ struct PairedInput<'a> {
     spec: &'a InputSpec,
 }
 
+struct ConvolutionCapture<'a, const D: usize> {
+    input: &'a TensorIr,
+    padding: &'a [(usize, usize); D],
+}
+
 enum DimensionResolution {
     Resolved(ShapeExpr),
     Infer,
@@ -172,11 +177,21 @@ impl<'a> PairedTraceAnalysis<'a> {
     /// Reject operations whose runtime behavior depends on information that
     /// Burn's captured IR has already normalized away.
     fn validate_dynamic_operation_contracts(&self) -> Result<(), ExportError> {
-        for (index, operation) in self.resolver.sample.operations.iter().enumerate() {
-            match operation {
-                OperationIr::BaseFloat(BaseOperationIr::Slice(slice))
-                | OperationIr::BaseInt(BaseOperationIr::Slice(slice))
-                | OperationIr::BaseBool(BaseOperationIr::Slice(slice)) => {
+        for (index, (operation, validation_operation)) in self
+            .resolver
+            .sample
+            .operations
+            .iter()
+            .zip(&self.resolver.validation.operations)
+            .enumerate()
+        {
+            match (operation, validation_operation) {
+                (
+                    OperationIr::BaseFloat(BaseOperationIr::Slice(slice))
+                    | OperationIr::BaseInt(BaseOperationIr::Slice(slice))
+                    | OperationIr::BaseBool(BaseOperationIr::Slice(slice)),
+                    _,
+                ) => {
                     if let Some(axis) = (0..slice.ranges.len())
                         .find(|&axis| self.potentially_dynamic.contains(slice.tensor.id, axis))
                     {
@@ -184,25 +199,45 @@ impl<'a> PairedTraceAnalysis<'a> {
                             tensor: slice.out.id,
                             axis,
                             reason: format!(
-                                "operation {index} has normalized slice bounds on a potentially dynamic axis"
+                                "operation {index} slices a tensor with a potentially dynamic axis; Burn clamps every range, including `..`, to the captured shape, so the intended bounds cannot be recovered"
                             ),
                         });
                     }
                 }
-                OperationIr::Module(ModuleOperationIr::Conv1d(conv)) => {
+                (
+                    OperationIr::Module(ModuleOperationIr::Conv1d(conv)),
+                    OperationIr::Module(ModuleOperationIr::Conv1d(validation)),
+                ) => {
                     self.validate_strided_convolution_padding(
                         index,
-                        &conv.x,
+                        ConvolutionCapture {
+                            input: &conv.x,
+                            padding: &conv.options.padding,
+                        },
+                        ConvolutionCapture {
+                            input: &validation.x,
+                            padding: &validation.options.padding,
+                        },
+                        &conv.weight,
                         &conv.options.stride,
-                        &conv.options.padding,
                     )?;
                 }
-                OperationIr::Module(ModuleOperationIr::Conv2d(conv)) => {
+                (
+                    OperationIr::Module(ModuleOperationIr::Conv2d(conv)),
+                    OperationIr::Module(ModuleOperationIr::Conv2d(validation)),
+                ) => {
                     self.validate_strided_convolution_padding(
                         index,
-                        &conv.x,
+                        ConvolutionCapture {
+                            input: &conv.x,
+                            padding: &conv.options.padding,
+                        },
+                        ConvolutionCapture {
+                            input: &validation.x,
+                            padding: &validation.options.padding,
+                        },
+                        &conv.weight,
                         &conv.options.stride,
-                        &conv.options.padding,
                     )?;
                 }
                 _ => {}
@@ -214,25 +249,37 @@ impl<'a> PairedTraceAnalysis<'a> {
     fn validate_strided_convolution_padding<const D: usize>(
         &self,
         index: usize,
-        input: &TensorIr,
+        sample: ConvolutionCapture<'_, D>,
+        validation: ConvolutionCapture<'_, D>,
+        weight: &TensorIr,
         stride: &[usize; D],
-        padding: &[(usize, usize); D],
     ) -> Result<(), ExportError> {
+        let sample_input = sample.input;
+        let validation_input = validation.input;
         // Burn resolves `Same` to concrete start/end widths using the captured
-        // input shape. Asymmetric widths can change with the runtime input but
-        // the original `Same` intent is not retained in Conv*OpIr. Symmetric
-        // `Same` remains indistinguishable from explicit padding; Burn IR must
-        // retain the original padding intent to close that gap without
-        // rejecting valid explicit-padding convolutions.
-        let spatial_offset = input.shape.num_dims().saturating_sub(D);
+        // input shape, and the original intent is not retained in Conv op IR.
+        // Padding that differs between captures is rejected before this check.
+        // If both equal captures could have come from `Same`, reject them too;
+        // explicit padding can be disambiguated with a validation shape whose
+        // corresponding `Same` widths differ.
+        let sample_spatial_offset = sample_input.shape.num_dims().saturating_sub(D);
+        let validation_spatial_offset = validation_input.shape.num_dims().saturating_sub(D);
+        let kernel_spatial_offset = weight.shape.num_dims().saturating_sub(D);
         for (spatial_axis, &stride) in stride.iter().enumerate() {
-            let axis = spatial_offset + spatial_axis;
+            let axis = sample_spatial_offset + spatial_axis;
+            let validation_axis = validation_spatial_offset + spatial_axis;
+            let kernel_axis = kernel_spatial_offset + spatial_axis;
+            let kernel_size = weight.shape[kernel_axis];
             if stride > 1
-                && self.potentially_dynamic.contains(input.id, axis)
-                && padding[spatial_axis].0 != padding[spatial_axis].1
+                && kernel_size > 1
+                && self.potentially_dynamic.contains(sample_input.id, axis)
+                && sample.padding[spatial_axis]
+                    == same_padding(kernel_size, stride, sample_input.shape[axis])
+                && validation.padding[spatial_axis]
+                    == same_padding(kernel_size, stride, validation_input.shape[validation_axis])
             {
                 return Err(ExportError::DynamicShapeLost {
-                    tensor: input.id,
+                    tensor: sample_input.id,
                     axis,
                     reason: format!(
                         "operation {index} has strided convolution padding on a potentially dynamic axis; captured IR does not preserve input-dependent padding intent"
@@ -483,6 +530,17 @@ impl<'a> PairedTraceAnalysis<'a> {
     }
 }
 
+fn same_padding(kernel_size: usize, stride: usize, input_size: usize) -> (usize, usize) {
+    let output_size = input_size.div_ceil(stride);
+    let total = output_size
+        .saturating_sub(1)
+        .saturating_mul(stride)
+        .saturating_add(kernel_size)
+        .saturating_sub(input_size);
+    let start = total / 2;
+    (start, total - start)
+}
+
 /// Reject varying shape operands that the paired resolver cannot represent.
 ///
 /// Structural validation deliberately ignores these values. Every ignored
@@ -532,6 +590,46 @@ fn validate_shape_sensitive_operations(
                     tensor: sample.out.id,
                     axis,
                     reason: format!("operation {index} has a varying interpolation output size"),
+                });
+            }
+            (
+                OperationIr::Module(ModuleOperationIr::Conv1d(sample)),
+                OperationIr::Module(ModuleOperationIr::Conv1d(validation)),
+            ) if sample.options.padding != validation.options.padding => {
+                let spatial_axis = sample
+                    .options
+                    .padding
+                    .iter()
+                    .zip(&validation.options.padding)
+                    .position(|(sample, validation)| sample != validation)
+                    .unwrap_or(0);
+                let axis = sample.x.shape.num_dims().saturating_sub(1) + spatial_axis;
+                return Err(ExportError::DynamicShapeLost {
+                    tensor: sample.x.id,
+                    axis,
+                    reason: format!(
+                        "operation {index} has strided convolution padding on a potentially dynamic axis; captured IR does not preserve input-dependent padding intent"
+                    ),
+                });
+            }
+            (
+                OperationIr::Module(ModuleOperationIr::Conv2d(sample)),
+                OperationIr::Module(ModuleOperationIr::Conv2d(validation)),
+            ) if sample.options.padding != validation.options.padding => {
+                let spatial_axis = sample
+                    .options
+                    .padding
+                    .iter()
+                    .zip(&validation.options.padding)
+                    .position(|(sample, validation)| sample != validation)
+                    .unwrap_or(0);
+                let axis = sample.x.shape.num_dims().saturating_sub(2) + spatial_axis;
+                return Err(ExportError::DynamicShapeLost {
+                    tensor: sample.x.id,
+                    axis,
+                    reason: format!(
+                        "operation {index} has strided convolution padding on a potentially dynamic axis; captured IR does not preserve input-dependent padding intent"
+                    ),
                 });
             }
             (

--- a/crates/burn-onnx/src/export/validate.rs
+++ b/crates/burn-onnx/src/export/validate.rs
@@ -165,6 +165,12 @@ fn erase_shape_sensitive_attributes(operation: &mut OperationIr) {
         OperationIr::Module(ModuleOperationIr::Interpolate(operation)) => {
             operation.output_size = [0; 2];
         }
+        OperationIr::Module(ModuleOperationIr::Conv1d(operation)) => {
+            operation.options.padding.fill((0, 0));
+        }
+        OperationIr::Module(ModuleOperationIr::Conv2d(operation)) => {
+            operation.options.padding.fill((0, 0));
+        }
         OperationIr::NumericFloat(_, NumericOperationIr::Pad(operation))
         | OperationIr::NumericInt(_, NumericOperationIr::Pad(operation)) => {
             operation.padding.fill((0, 0));

--- a/crates/burn-onnx/tests/ort_numerical.rs
+++ b/crates/burn-onnx/tests/ort_numerical.rs
@@ -5,7 +5,7 @@ use std::cell::RefCell;
 use burn::backend::DType;
 use burn::module::{Module, Param};
 use burn::nn::{
-    Linear, LinearConfig, PaddingConfig1d, Relu,
+    Linear, LinearConfig, PaddingConfig1d, PaddingConfig2d, Relu,
     conv::{Conv1d, Conv1dConfig, Conv2d, Conv2dConfig},
     pool::{MaxPool2d, MaxPool2dConfig},
 };
@@ -103,11 +103,37 @@ impl SmallConv1d {
 }
 
 #[derive(Module, Debug)]
+struct SmallConv2d {
+    conv: Conv2d,
+}
+
+impl SmallConv2d {
+    fn forward(&self, input: Tensor<4>) -> Tensor<4> {
+        self.conv.forward(input)
+    }
+}
+
+#[derive(Module, Debug)]
+struct SliceAfterConv1d {
+    conv: Conv1d,
+}
+
+impl SliceAfterConv1d {
+    fn forward(&self, input: Tensor<3>) -> Tensor<3> {
+        self.conv.forward(input).slice(s![.., 0..1, ..])
+    }
+}
+
+#[derive(Module, Debug)]
 struct SteppedSlice;
 
 impl SteppedSlice {
-    fn forward(&self, input: Tensor<1>) -> (Tensor<1>, Tensor<1>) {
-        (input.clone().slice(s![1..9;2]), input.slice(s![2..8;-2]))
+    fn forward(&self, input: Tensor<1>) -> (Tensor<1>, Tensor<1>, Tensor<1>) {
+        (
+            input.clone().slice(s![1..9;2]),
+            input.clone().slice(s![2..8;-2]),
+            input.slice(s![..;-1]),
+        )
     }
 }
 
@@ -153,6 +179,28 @@ impl ScatterColumns {
         })
         .into()
     }
+
+    fn reference(&self, input: Tensor<2>) -> Vec<Tensor<2>> {
+        // The default test backend only implements element-wise scatter for
+        // `Add`. Its ScatterND implementation supports every reduction and is
+        // equivalent here because all update coordinates are unique.
+        let coordinates =
+            Tensor::<2, Int>::from_ints([[0, 0], [0, 2], [1, 1], [1, 0]], &input.device());
+        let values = self.values.clone().reshape([4]);
+        [
+            IndexingUpdateOp::Assign,
+            IndexingUpdateOp::Add,
+            IndexingUpdateOp::Mul,
+            IndexingUpdateOp::Min,
+            IndexingUpdateOp::Max,
+        ]
+        .map(|update| {
+            input
+                .clone()
+                .scatter_nd(coordinates.clone(), values.clone(), update)
+        })
+        .into()
+    }
 }
 
 #[derive(Module, Debug)]
@@ -160,6 +208,19 @@ struct BoolCreation;
 
 impl BoolCreation {
     fn forward(&self, input: Tensor<2>) -> (Tensor<2, Bool>, Tensor<2, Bool>) {
+        let shape = input.shape();
+        (
+            Tensor::zeros(shape.clone(), &input.device()),
+            Tensor::ones(shape, &input.device()),
+        )
+    }
+}
+
+#[derive(Module, Debug)]
+struct FloatCreation;
+
+impl FloatCreation {
+    fn forward(&self, input: Tensor<2>) -> (Tensor<2>, Tensor<2>) {
         let shape = input.shape();
         (
             Tensor::zeros(shape.clone(), &input.device()),
@@ -609,7 +670,7 @@ fn conv1d_matches_burn() {
             .with_stride(2)
             .with_dilation(2)
             .with_groups(2)
-            .with_padding(PaddingConfig1d::Explicit(2, 2))
+            .with_padding(PaddingConfig1d::Explicit(1, 2))
             .init(&device),
     };
     let input = (Tensor::<1, Int>::arange(0..18, &device).float() / 10.0).reshape([1, 2, 9]);
@@ -620,6 +681,26 @@ fn conv1d_matches_burn() {
         .unwrap();
 
     let actual = run_ort(model.as_bytes(), [1, 2, 9], input_values);
+    actual.assert_approx_eq::<f32>(&expected, Tolerance::rel_abs(RTOL, ATOL));
+}
+
+#[test]
+fn asymmetric_conv2d_matches_burn() {
+    let device = Device::default();
+    let module = SmallConv2d {
+        conv: Conv2dConfig::new([1, 2], [3, 2])
+            .with_stride([2, 1])
+            .with_padding(PaddingConfig2d::Explicit(1, 0, 2, 1))
+            .init(&device),
+    };
+    let input = (Tensor::<1, Int>::arange(0..25, &device).float() / 10.0).reshape([1, 1, 5, 5]);
+    let input_values = input.clone().into_data().try_to_vec::<f32>().unwrap();
+    let expected = module.forward(input.clone()).into_data();
+    let model = OnnxExporter::new()
+        .export(&module, input, SmallConv2d::forward)
+        .unwrap();
+
+    let actual = run_ort(model.as_bytes(), [1, 1, 5, 5], input_values);
     actual.assert_approx_eq::<f32>(&expected, Tolerance::rel_abs(RTOL, ATOL));
 }
 
@@ -654,7 +735,7 @@ fn dynamic_conv1d_handles_colliding_capture_shapes() {
     actual.assert_approx_eq::<f32>(&expected, Tolerance::rel_abs(RTOL, ATOL));
 
     let model = ModelProto::parse_from_bytes(model.as_bytes()).unwrap();
-    assert!(
+    assert_eq!(
         model.graph.output[0]
             .type_
             .as_ref()
@@ -662,8 +743,103 @@ fn dynamic_conv1d_handles_colliding_capture_shapes() {
             .tensor_type()
             .shape
             .dim[2]
-            .has_dim_param()
+            .dim_param(),
+        "output_0_dim_2"
     );
+}
+
+#[test]
+fn dynamic_slice_after_shape_collapse_is_rejected() {
+    let device = Device::default();
+    let module = SliceAfterConv1d {
+        conv: Conv1dConfig::new(1, 2, 2).with_stride(2).init(&device),
+    };
+    let sample = Tensor::<3>::zeros([1, 1, 4], &device);
+    let validation = Tensor::<3>::zeros([1, 1, 5], &device);
+    let specs = [InputSpec::new([
+        AxisSpec::Static,
+        AxisSpec::Static,
+        AxisSpec::dynamic("length"),
+    ])];
+
+    let result = OnnxExporter::new().export_dynamic(
+        &module,
+        sample,
+        validation,
+        &specs,
+        SliceAfterConv1d::forward,
+    );
+
+    assert!(matches!(
+        result,
+        Err(ExportError::DynamicShapeLost { reason, .. })
+            if reason.contains("normalized slice bounds")
+    ));
+}
+
+#[test]
+fn dynamic_padded_strided_conv1d_is_rejected() {
+    let device = Device::default();
+    let module = SmallConv1d {
+        conv: Conv1dConfig::new(1, 2, 3)
+            .with_stride(2)
+            .with_padding(PaddingConfig1d::Same)
+            .init(&device),
+    };
+    let sample = Tensor::<3>::zeros([1, 1, 4], &device);
+    let validation = Tensor::<3>::zeros([1, 1, 6], &device);
+    let specs = [InputSpec::new([
+        AxisSpec::Static,
+        AxisSpec::Static,
+        AxisSpec::dynamic("length"),
+    ])];
+
+    let result = OnnxExporter::new().export_dynamic(
+        &module,
+        sample,
+        validation,
+        &specs,
+        SmallConv1d::forward,
+    );
+
+    assert!(matches!(
+        result,
+        Err(ExportError::DynamicShapeLost { reason, .. })
+            if reason.contains("strided convolution padding")
+    ));
+}
+
+#[test]
+fn dynamic_padded_strided_conv2d_is_rejected() {
+    let device = Device::default();
+    let module = SmallConv2d {
+        conv: Conv2dConfig::new([1, 2], [3, 3])
+            .with_stride([2, 2])
+            .with_padding(PaddingConfig2d::Same)
+            .init(&device),
+    };
+    let sample = Tensor::<4>::zeros([1, 1, 4, 4], &device);
+    let validation = Tensor::<4>::zeros([1, 1, 6, 6], &device);
+    let specs = [InputSpec::new([
+        AxisSpec::Static,
+        AxisSpec::Static,
+        AxisSpec::dynamic("height"),
+        AxisSpec::dynamic("width"),
+    ])];
+
+    let result = OnnxExporter::new().export_dynamic(
+        &module,
+        sample,
+        validation,
+        &specs,
+        SmallConv2d::forward,
+    );
+
+    assert!(matches!(
+        result,
+        Err(ExportError::DynamicShapeLost { reason, .. })
+            if reason.contains("strided convolution padding")
+    ));
 }
 
 #[test]
@@ -671,7 +847,8 @@ fn stepped_slice_matches_burn() {
     let device = Device::default();
     let input = Tensor::<1, Int>::arange(0..10, &device).float();
     let input_values = input.clone().into_data().try_to_vec::<f32>().unwrap();
-    let (expected_positive, expected_negative) = SteppedSlice.forward(input.clone());
+    let (expected_positive, expected_negative, expected_reverse) =
+        SteppedSlice.forward(input.clone());
     let model = OnnxExporter::new()
         .export(&SteppedSlice, input, SteppedSlice::forward)
         .unwrap();
@@ -697,13 +874,21 @@ fn stepped_slice_matches_burn() {
         shape.iter().map(|&dim| dim as usize).collect::<Vec<_>>(),
     )
     .assert_approx_eq::<f32>(&expected_negative.into_data(), Tolerance::default());
+    let (shape, values) = outputs[2].try_extract_tensor::<f32>().unwrap();
+    TensorData::new(
+        values.to_vec(),
+        shape.iter().map(|&dim| dim as usize).collect::<Vec<_>>(),
+    )
+    .assert_approx_eq::<f32>(&expected_reverse.into_data(), Tolerance::default());
 }
 
 #[test]
 fn dynamic_slice_rejects_ambiguous_clamped_bounds() {
     let device = Device::default();
-    // Burn clamps `..5` to each captured input. The resulting `0..3` and
-    // `0..4` ranges cannot be distinguished from a genuinely open range.
+    // Burn normalizes every range before capture. For example, it clamps `..5`
+    // to `0..3` and `0..4` here, but the exporter cannot distinguish those
+    // bounds from a genuinely open range. It therefore rejects every slice on
+    // a potentially dynamic axis, even if two normalized captures agree.
     let sample = Tensor::<1>::zeros([3], &device);
     let validation = Tensor::<1>::zeros([4], &device);
     let specs = [InputSpec::new([AxisSpec::dynamic("length")])];
@@ -750,7 +935,12 @@ fn scatter_reductions_match_burn() {
     };
     let input = Tensor::from_floats([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], &device);
     let input_values = input.clone().into_data().try_to_vec::<f32>().unwrap();
-    let expected = [
+    let expected = module
+        .reference(input.clone())
+        .into_iter()
+        .map(Tensor::into_data)
+        .collect::<Vec<_>>();
+    let sanity = [
         [[10.0f32, 2.0, -2.0], [20.0, 3.0, 6.0]],
         [[11.0, 2.0, 1.0], [24.0, 8.0, 6.0]],
         [[10.0, 2.0, -6.0], [80.0, 15.0, 6.0]],
@@ -758,6 +948,9 @@ fn scatter_reductions_match_burn() {
         [[10.0, 2.0, 3.0], [20.0, 5.0, 6.0]],
     ]
     .map(TensorData::from);
+    for (actual, expected) in expected.iter().zip(sanity) {
+        actual.assert_approx_eq::<f32>(&expected, Tolerance::default());
+    }
     let model = OnnxExporter::new()
         .export(&module, input, ScatterColumns::forward)
         .unwrap();
@@ -800,6 +993,18 @@ fn dynamic_bool_zeros_and_ones_match_burn() {
         )
         .unwrap();
 
+    let proto = ModelProto::parse_from_bytes(model.as_bytes()).unwrap();
+    assert_eq!(
+        proto
+            .graph
+            .node
+            .iter()
+            .filter(|node| node.op_type == "ConstantOfShape")
+            .count(),
+        2
+    );
+    assert!(proto.graph.node.iter().all(|node| node.op_type != "Cast"));
+
     let runtime_values = vec![0.0f32; 21];
     let mut session = Session::builder()
         .unwrap()
@@ -816,6 +1021,26 @@ fn dynamic_bool_zeros_and_ones_match_burn() {
     let (shape, ones) = outputs[1].try_extract_tensor::<bool>().unwrap();
     assert_eq!(shape.iter().copied().collect::<Vec<_>>(), vec![7, 3]);
     assert!(ones.iter().all(|value| *value));
+}
+
+#[test]
+fn native_constant_of_shape_dtypes_do_not_add_casts() {
+    let device = Device::default();
+    let input = Tensor::<2>::zeros([2, 3], &device);
+    let model = OnnxExporter::new()
+        .export(&FloatCreation, input, FloatCreation::forward)
+        .unwrap();
+    let model = ModelProto::parse_from_bytes(model.as_bytes()).unwrap();
+
+    assert_eq!(
+        model
+            .graph
+            .node
+            .iter()
+            .map(|node| node.op_type.as_str())
+            .collect::<Vec<_>>(),
+        ["ConstantOfShape", "ConstantOfShape"]
+    );
 }
 
 #[test]
@@ -913,8 +1138,12 @@ fn arg_reductions_lower_directly_and_match_burn() {
         ])
         .unwrap();
     for (output, expected) in [(&outputs[0], expected_max), (&outputs[1], expected_min)] {
-        let (_, values) = output.try_extract_tensor::<i64>().unwrap();
-        TensorData::new(values.to_vec(), vec![2, 1]).assert_eq(&expected.into_data(), false);
+        let (shape, values) = output.try_extract_tensor::<i64>().unwrap();
+        TensorData::new(
+            values.to_vec(),
+            shape.iter().map(|&dim| dim as usize).collect::<Vec<_>>(),
+        )
+        .assert_eq(&expected.into_data(), false);
     }
 }
 

--- a/crates/burn-onnx/tests/ort_numerical.rs
+++ b/crates/burn-onnx/tests/ort_numerical.rs
@@ -1061,13 +1061,7 @@ fn dim_reductions_match_burn() {
             .iter()
             .map(|node| node.op_type.as_str())
             .collect::<Vec<_>>(),
-        [
-            "ReduceSum",
-            "ArgMax",
-            "GatherElements",
-            "ArgMin",
-            "GatherElements"
-        ]
+        ["ReduceSum", "TopK", "TopK"]
     );
 
     let mut session = Session::builder()
@@ -1157,6 +1151,19 @@ fn reduce_sum_rejects_unsupported_opset_18_dtype() {
         result,
         Err(ExportError::UnsupportedOperation { kind, .. })
             if kind.contains("ReduceSum") && kind.contains("I8")
+    ));
+}
+
+#[test]
+fn topk_reduction_rejects_bfloat16_for_opset_18() {
+    let device = Device::default();
+    let input = Tensor::<2>::ones([2, 3], &device).cast(DType::BF16);
+    let result = OnnxExporter::new().export(&DimReductions, input, DimReductions::forward);
+
+    assert!(matches!(
+        result,
+        Err(ExportError::UnsupportedOperation { kind, .. })
+            if kind.contains("MaxDimWithIndices") && kind.contains("BF16")
     ));
 }
 

--- a/crates/burn-onnx/tests/ort_numerical.rs
+++ b/crates/burn-onnx/tests/ort_numerical.rs
@@ -125,6 +125,15 @@ impl SliceAfterConv1d {
 }
 
 #[derive(Module, Debug)]
+struct SliceAfterReduction;
+
+impl SliceAfterReduction {
+    fn forward(&self, input: Tensor<2>) -> Tensor<2> {
+        input.sum_dim(0).slice(s![.., 0..2])
+    }
+}
+
+#[derive(Module, Debug)]
 struct SteppedSlice;
 
 impl SteppedSlice {
@@ -181,8 +190,8 @@ impl ScatterColumns {
     }
 
     fn reference(&self, input: Tensor<2>) -> Vec<Tensor<2>> {
-        // The default test backend only implements element-wise scatter for
-        // `Add`. Its ScatterND implementation supports every reduction and is
+        // The default backend has no element-wise scatter for `Min` and `Max`.
+        // Its ScatterND implementation supports every reduction and is
         // equivalent here because all update coordinates are unique.
         let coordinates =
             Tensor::<2, Int>::from_ints([[0, 0], [0, 2], [1, 1], [1, 0]], &input.device());
@@ -226,6 +235,28 @@ impl FloatCreation {
             Tensor::zeros(shape.clone(), &input.device()),
             Tensor::ones(shape, &input.device()),
         )
+    }
+}
+
+#[derive(Module, Debug)]
+struct IntCreation;
+
+impl IntCreation {
+    fn forward(&self, input: Tensor<2>) -> (Tensor<2, Int>, Tensor<2, Int>) {
+        let shape = input.shape();
+        (
+            Tensor::zeros(shape.clone(), (&input.device(), DType::I32)),
+            Tensor::ones(shape, (&input.device(), DType::I32)),
+        )
+    }
+}
+
+#[derive(Module, Debug)]
+struct BfloatCreation;
+
+impl BfloatCreation {
+    fn forward(&self, input: Tensor<2>) -> Tensor<2> {
+        Tensor::zeros(input.shape(), (&input.device(), DType::BF16))
     }
 }
 
@@ -673,14 +704,14 @@ fn conv1d_matches_burn() {
             .with_padding(PaddingConfig1d::Explicit(1, 2))
             .init(&device),
     };
-    let input = (Tensor::<1, Int>::arange(0..18, &device).float() / 10.0).reshape([1, 2, 9]);
+    let input = (Tensor::<1, Int>::arange(0..16, &device).float() / 10.0).reshape([1, 2, 8]);
     let input_values = input.clone().into_data().try_to_vec::<f32>().unwrap();
     let expected = module.forward(input.clone()).into_data();
     let model = OnnxExporter::new()
         .export(&module, input, SmallConv1d::forward)
         .unwrap();
 
-    let actual = run_ort(model.as_bytes(), [1, 2, 9], input_values);
+    let actual = run_ort(model.as_bytes(), [1, 2, 8], input_values);
     actual.assert_approx_eq::<f32>(&expected, Tolerance::rel_abs(RTOL, ATOL));
 }
 
@@ -693,14 +724,14 @@ fn asymmetric_conv2d_matches_burn() {
             .with_padding(PaddingConfig2d::Explicit(1, 0, 2, 1))
             .init(&device),
     };
-    let input = (Tensor::<1, Int>::arange(0..25, &device).float() / 10.0).reshape([1, 1, 5, 5]);
+    let input = (Tensor::<1, Int>::arange(0..20, &device).float() / 10.0).reshape([1, 1, 4, 5]);
     let input_values = input.clone().into_data().try_to_vec::<f32>().unwrap();
     let expected = module.forward(input.clone()).into_data();
     let model = OnnxExporter::new()
         .export(&module, input, SmallConv2d::forward)
         .unwrap();
 
-    let actual = run_ort(model.as_bytes(), [1, 1, 5, 5], input_values);
+    let actual = run_ort(model.as_bytes(), [1, 1, 4, 5], input_values);
     actual.assert_approx_eq::<f32>(&expected, Tolerance::rel_abs(RTOL, ATOL));
 }
 
@@ -762,6 +793,9 @@ fn dynamic_slice_after_shape_collapse_is_rejected() {
         AxisSpec::dynamic("length"),
     ])];
 
+    // Both captures normalize the slice to the same ranges, so the earlier
+    // varying-bounds check cannot reject it. Dynamic-axis analysis must catch
+    // that the full range still depends on the original input length.
     let result = OnnxExporter::new().export_dynamic(
         &module,
         sample,
@@ -773,8 +807,44 @@ fn dynamic_slice_after_shape_collapse_is_rejected() {
     assert!(matches!(
         result,
         Err(ExportError::DynamicShapeLost { reason, .. })
-            if reason.contains("normalized slice bounds")
+            if reason.contains("intended bounds cannot be recovered")
     ));
+}
+
+#[test]
+fn dynamic_slice_after_reduced_axis_matches_burn() {
+    let device = Device::default();
+    let sample = Tensor::<1, Int>::arange(0..12, &device)
+        .float()
+        .reshape([3, 4]);
+    let validation = Tensor::<1, Int>::arange(0..20, &device)
+        .float()
+        .reshape([5, 4]);
+    let specs = [InputSpec::new([
+        AxisSpec::dynamic("batch"),
+        AxisSpec::Static,
+    ])];
+    let model = OnnxExporter::new()
+        .export_dynamic(
+            &SliceAfterReduction,
+            sample,
+            validation,
+            &specs,
+            SliceAfterReduction::forward,
+        )
+        .unwrap();
+
+    let runtime_input = Tensor::<1, Int>::arange(0..28, &device)
+        .float()
+        .reshape([7, 4]);
+    let runtime_values = runtime_input
+        .clone()
+        .into_data()
+        .try_to_vec::<f32>()
+        .unwrap();
+    let expected = SliceAfterReduction.forward(runtime_input).into_data();
+    let actual = run_ort(model.as_bytes(), [7, 4], runtime_values);
+    actual.assert_approx_eq::<f32>(&expected, Tolerance::default());
 }
 
 #[test]
@@ -787,7 +857,7 @@ fn dynamic_padded_strided_conv1d_is_rejected() {
             .init(&device),
     };
     let sample = Tensor::<3>::zeros([1, 1, 4], &device);
-    let validation = Tensor::<3>::zeros([1, 1, 6], &device);
+    let validation = Tensor::<3>::zeros([1, 1, 5], &device);
     let specs = [InputSpec::new([
         AxisSpec::Static,
         AxisSpec::Static,
@@ -807,6 +877,104 @@ fn dynamic_padded_strided_conv1d_is_rejected() {
         Err(ExportError::DynamicShapeLost { reason, .. })
             if reason.contains("strided convolution padding")
     ));
+}
+
+#[test]
+fn dynamic_symmetric_same_strided_conv1d_is_rejected() {
+    let device = Device::default();
+    let module = SmallConv1d {
+        conv: Conv1dConfig::new(1, 2, 3)
+            .with_stride(2)
+            .with_padding(PaddingConfig1d::Same)
+            .init(&device),
+    };
+    let sample = Tensor::<3>::zeros([1, 1, 5], &device);
+    let validation = Tensor::<3>::zeros([1, 1, 7], &device);
+    let specs = [InputSpec::new([
+        AxisSpec::Static,
+        AxisSpec::Static,
+        AxisSpec::dynamic("length"),
+    ])];
+
+    let result = OnnxExporter::new().export_dynamic(
+        &module,
+        sample,
+        validation,
+        &specs,
+        SmallConv1d::forward,
+    );
+
+    assert!(matches!(
+        result,
+        Err(ExportError::DynamicShapeLost { reason, .. })
+            if reason.contains("strided convolution padding")
+    ));
+}
+
+#[test]
+fn dynamic_zero_padding_same_strided_conv1d_is_rejected() {
+    let device = Device::default();
+    let module = SmallConv1d {
+        conv: Conv1dConfig::new(1, 2, 2)
+            .with_stride(3)
+            .with_padding(PaddingConfig1d::Same)
+            .init(&device),
+    };
+    // Different residues still capture identical zero padding when the kernel
+    // is smaller than the stride, but another runtime residue needs padding.
+    let sample = Tensor::<3>::zeros([1, 1, 2], &device);
+    let validation = Tensor::<3>::zeros([1, 1, 3], &device);
+    let specs = [InputSpec::new([
+        AxisSpec::Static,
+        AxisSpec::Static,
+        AxisSpec::dynamic("length"),
+    ])];
+
+    let result = OnnxExporter::new().export_dynamic(
+        &module,
+        sample,
+        validation,
+        &specs,
+        SmallConv1d::forward,
+    );
+
+    assert!(matches!(
+        result,
+        Err(ExportError::DynamicShapeLost { reason, .. })
+            if reason.contains("strided convolution padding")
+    ));
+}
+
+#[test]
+fn dynamic_explicit_asymmetric_stride_one_conv1d_matches_burn() {
+    let device = Device::default();
+    let module = SmallConv1d {
+        conv: Conv1dConfig::new(1, 2, 2)
+            .with_padding(PaddingConfig1d::Explicit(0, 1))
+            .init(&device),
+    };
+    let sample = Tensor::<3>::zeros([1, 1, 5], &device);
+    let validation = Tensor::<3>::zeros([1, 1, 7], &device);
+    let specs = [InputSpec::new([
+        AxisSpec::Static,
+        AxisSpec::Static,
+        AxisSpec::dynamic("length"),
+    ])];
+    let model = OnnxExporter::new()
+        .export_dynamic(&module, sample, validation, &specs, SmallConv1d::forward)
+        .unwrap();
+
+    let runtime_input = Tensor::<1, Int>::arange(0..6, &device)
+        .float()
+        .reshape([1, 1, 6]);
+    let runtime_values = runtime_input
+        .clone()
+        .into_data()
+        .try_to_vec::<f32>()
+        .unwrap();
+    let expected = module.forward(runtime_input).into_data();
+    let actual = run_ort(model.as_bytes(), [1, 1, 6], runtime_values);
+    actual.assert_approx_eq::<f32>(&expected, Tolerance::rel_abs(RTOL, ATOL));
 }
 
 #[test]
@@ -887,8 +1055,9 @@ fn dynamic_slice_rejects_ambiguous_clamped_bounds() {
     let device = Device::default();
     // Burn normalizes every range before capture. For example, it clamps `..5`
     // to `0..3` and `0..4` here, but the exporter cannot distinguish those
-    // bounds from a genuinely open range. It therefore rejects every slice on
-    // a potentially dynamic axis, even if two normalized captures agree.
+    // bounds from a genuinely open range. The bounds differ between captures,
+    // so the shape-sensitive check rejects the slice before dynamic-axis
+    // analysis runs.
     let sample = Tensor::<1>::zeros([3], &device);
     let validation = Tensor::<1>::zeros([4], &device);
     let specs = [InputSpec::new([AxisSpec::dynamic("length")])];
@@ -1030,16 +1199,104 @@ fn native_constant_of_shape_dtypes_do_not_add_casts() {
     let model = OnnxExporter::new()
         .export(&FloatCreation, input, FloatCreation::forward)
         .unwrap();
-    let model = ModelProto::parse_from_bytes(model.as_bytes()).unwrap();
+    let proto = ModelProto::parse_from_bytes(model.as_bytes()).unwrap();
 
     assert_eq!(
-        model
+        proto
             .graph
             .node
             .iter()
             .map(|node| node.op_type.as_str())
             .collect::<Vec<_>>(),
         ["ConstantOfShape", "ConstantOfShape"]
+    );
+
+    let mut session = Session::builder()
+        .unwrap()
+        .commit_from_memory(model.as_bytes())
+        .unwrap();
+    let outputs = session
+        .run(ort::inputs![
+            OrtTensor::from_array(([2, 3], vec![0.0f32; 6])).unwrap()
+        ])
+        .unwrap();
+    let (_, zeros) = outputs[0].try_extract_tensor::<f32>().unwrap();
+    assert!(zeros.iter().all(|value| *value == 0.0));
+    let (_, ones) = outputs[1].try_extract_tensor::<f32>().unwrap();
+    assert!(ones.iter().all(|value| *value == 1.0));
+}
+
+#[test]
+fn int32_constant_of_shape_is_native_and_matches_burn() {
+    let device = Device::default();
+    let input = Tensor::<2>::zeros([2, 3], &device);
+    let model = OnnxExporter::new()
+        .export(&IntCreation, input, IntCreation::forward)
+        .unwrap();
+    let proto = ModelProto::parse_from_bytes(model.as_bytes()).unwrap();
+    assert_eq!(
+        proto
+            .graph
+            .node
+            .iter()
+            .map(|node| node.op_type.as_str())
+            .collect::<Vec<_>>(),
+        ["ConstantOfShape", "ConstantOfShape"]
+    );
+
+    let mut session = Session::builder()
+        .unwrap()
+        .commit_from_memory(model.as_bytes())
+        .unwrap();
+    let outputs = session
+        .run(ort::inputs![
+            OrtTensor::from_array(([2, 3], vec![0.0f32; 6])).unwrap()
+        ])
+        .unwrap();
+    let (_, zeros) = outputs[0].try_extract_tensor::<i32>().unwrap();
+    assert!(zeros.iter().all(|value| *value == 0));
+    let (_, ones) = outputs[1].try_extract_tensor::<i32>().unwrap();
+    assert!(ones.iter().all(|value| *value == 1));
+}
+
+#[test]
+fn bfloat16_constant_of_shape_uses_float32_then_cast() {
+    let device = Device::default();
+    let input = Tensor::<2>::zeros([2, 3], &device);
+    let model = OnnxExporter::new()
+        .export(&BfloatCreation, input, BfloatCreation::forward)
+        .unwrap();
+    let proto = ModelProto::parse_from_bytes(model.as_bytes()).unwrap();
+    assert_eq!(
+        proto
+            .graph
+            .node
+            .iter()
+            .map(|node| node.op_type.as_str())
+            .collect::<Vec<_>>(),
+        ["ConstantOfShape", "Cast"]
+    );
+    let constant = &proto.graph.node[0];
+    assert_eq!(
+        constant
+            .attribute
+            .iter()
+            .find(|attribute| attribute.name == "value")
+            .unwrap()
+            .t
+            .as_ref()
+            .unwrap()
+            .data_type,
+        1
+    );
+    let cast = &proto.graph.node[1];
+    assert_eq!(
+        cast.attribute
+            .iter()
+            .find(|attribute| attribute.name == "to")
+            .unwrap()
+            .i,
+        16
     );
 }
 


### PR DESCRIPTION
### Checklist

- [ ] Confirmed that `cargo xtask validate` command has been executed.
- [ ] Confirm relevant documentation has been updated.
- [ ] For new/modified ONNX operators: verified implementation matches `onnx-spec/ops/<OpName>.md`.

### Related Issues/PRs

Follow-up to #498
Addresses review comments https://github.com/tracel-ai/burn-onnx/pull/498#pullrequestreview-5094183178

### Changes

- Update burn and correctly lower asymmetric convolution padding (https://github.com/tracel-ai/burn/pull/5521)
- Preserve `ArgMax` / `ArgMin` output ranks
- Lower max/min with indices to `TopK` instead of `ArgMax`/`ArgMin` + `GatherElements`
- Emit opser 18 `ConstantOfShape` dtypes directly when supported
- Reject dynamics slices and convolution padding when capture loses runtime semantics

### Testing

Added coverage for these cases
