### PR TITLE
Mark bernoulli node tests flaky instead of fail-compare

### DIFF
--- a/crates/onnx-official-tests/expectations.toml
+++ b/crates/onnx-official-tests/expectations.toml
@@ -840,34 +840,34 @@ status = "skip-codegen"
 reason = "Node 'batchnormalization1' (BatchNormalization): BatchNorm: training_mode=1 is not supported (only inference mode)"
 
 [test_bernoulli]
-status = "fail-compare"
-reason = "comparison against reference tensor fails (classified by M2 first-run sweep; root cause not yet triaged)"
-tracking = "#311"
+status = "flaky"
+reason = "Bernoulli draws random samples; the vendored reference output is a single NumPy draw that no other RNG can reproduce. The 10-element draw matches it by chance in ~0.6% of runs, which intermittently trips the fail-compare drift gate. Codegen and shape are covered by crates/onnx-tests/tests/bernoulli."
+wontfix = true
 
 [test_bernoulli_double]
-status = "fail-compare"
-reason = "bernoulli op family comparison failure"
-tracking = "#311"
+status = "flaky"
+reason = "Bernoulli draws random samples; the vendored reference output is a single NumPy draw that no other RNG can reproduce. The 10-element draw matches it by chance in ~0.6% of runs, which intermittently trips the fail-compare drift gate. Codegen and shape are covered by crates/onnx-tests/tests/bernoulli."
+wontfix = true
 
 [test_bernoulli_double_expanded]
-status = "fail-compare"
-reason = "bernoulli op family comparison failure"
-tracking = "#311"
+status = "flaky"
+reason = "Bernoulli draws random samples; the vendored reference output is a single NumPy draw that no other RNG can reproduce. The 10-element draw matches it by chance in ~0.6% of runs, which intermittently trips the fail-compare drift gate. Codegen and shape are covered by crates/onnx-tests/tests/bernoulli."
+wontfix = true
 
 [test_bernoulli_expanded]
-status = "fail-compare"
-reason = "comparison against reference tensor fails (classified by M2 first-run sweep; root cause not yet triaged)"
-tracking = "#311"
+status = "flaky"
+reason = "Bernoulli draws random samples; the vendored reference output is a single NumPy draw that no other RNG can reproduce. The 10-element draw matches it by chance in ~0.6% of runs, which intermittently trips the fail-compare drift gate. Codegen and shape are covered by crates/onnx-tests/tests/bernoulli."
+wontfix = true
 
 [test_bernoulli_seed]
-status = "fail-compare"
-reason = "bernoulli op family comparison failure"
-tracking = "#311"
+status = "flaky"
+reason = "Bernoulli draws random samples; the vendored reference output is a single NumPy draw that no other RNG can reproduce. The 10-element draw matches it by chance in ~0.6% of runs, which intermittently trips the fail-compare drift gate. Codegen and shape are covered by crates/onnx-tests/tests/bernoulli."
+wontfix = true
 
 [test_bernoulli_seed_expanded]
-status = "fail-compare"
-reason = "bernoulli op family comparison failure"
-tracking = "#311"
+status = "flaky"
+reason = "Bernoulli draws random samples; the vendored reference output is a single NumPy draw that no other RNG can reproduce. The 10-element draw matches it by chance in ~0.6% of runs, which intermittently trips the fail-compare drift gate. Codegen and shape are covered by crates/onnx-tests/tests/bernoulli."
+wontfix = true
 
 [test_bitshift_left_uint16]
 status = "pass"


### PR DESCRIPTION
## Problem

CI on main fails intermittently in `verify_fail_compare_still_fails`:

```
fail-compare entries that now pass; flip their status to "pass" in expectations.toml:
  [
    "test_bernoulli_double",
]
```

This is not a real promotion. `Bernoulli` draws random samples, and the vendored
reference output is a single NumPy draw over 10 probabilities that no other RNG
can reproduce. The drift gate asserts every `fail-compare` entry still fails, so
it is sensitive to an accidental exact match.

Probability of a spurious match per test:

```
P = Pi p_i^o_i (1-p_i)^(1-o_i) = 0.0061
```

With six bernoulli rows in the fail-compare set that is ~3.6% per run, or roughly
1 red run in 28. A 60-run local loop against the pre-change binary reproduced it
once, on `test_bernoulli_seed` rather than `test_bernoulli_double`, confirming the
whole family is affected rather than a single test.

## Fix

Move the six bernoulli rows from `fail-compare` to `flaky`.

That status already exists for this exact case. `expectations.rs` documents it as
"Intermittent - do not gate CI on it", the `expectations.toml` header lists it as
"intermittent, ignored by the gate", and `build.rs` treats every status other than
`pass` / `fail-compare` as documentation only. It had no users until now.

## Verification

- Reproduced pre-change: 60 runs of the gate on the pre-edit binary, 1 flake
  (`test_bernoulli_seed`).
- Post-change: `cargo test -p onnx-official-tests --release` passes.
- Blast radius, by re-running `build.rs` against the pre-change file:
  `HARNESS_TESTS` 840 -> 840 (unchanged), `FAIL_COMPARE_RUNNERS` 69 -> 63.
  Exactly the six rows, nothing else.
- `cargo xtask diff-expectations` reports 6 sideways, 0 promotions, 0 regressions.

## Tradeoff

`flaky` entries are skipped by `ModelGen`, so this suite no longer compiles the
bernoulli models. Plain `Bernoulli` codegen and output shape stay covered by
`crates/onnx-tests/tests/bernoulli`. The `_expanded` decomposition
(`RandomUniformLike` + `Less` + `Cast`) loses direct coverage here, though each
component op is tested on its own.
