### PR TITLE
Fix model-checks path filter and register arcface, rtmw3d, kokoro

### DIFF
--- a/.github/workflows/model-checks.yml
+++ b/.github/workflows/model-checks.yml
@@ -8,7 +8,9 @@ on:
       - '.github/workflows/model-checks.yml'
       - 'crates/burn-onnx/**'
       - 'crates/onnx-ir/**'
+      - 'crates/onnx-ir-derive/**'
       - 'crates/model-checks/**'
+      - 'xtask/**'
       - 'Cargo.lock'
       - 'Cargo.toml'
   pull_request:
@@ -17,7 +19,9 @@ on:
       - '.github/workflows/model-checks.yml'
       - 'crates/burn-onnx/**'
       - 'crates/onnx-ir/**'
+      - 'crates/onnx-ir-derive/**'
       - 'crates/model-checks/**'
+      - 'xtask/**'
       - 'Cargo.lock'
       - 'Cargo.toml'
   workflow_dispatch:

--- a/xtask/src/model_check.rs
+++ b/xtask/src/model_check.rs
@@ -139,12 +139,36 @@ const MODELS: &[ModelInfo] = &[
         blocked: false,
     },
     ModelInfo {
+        id: "arcface",
+        dir: "arcface",
+        name: "ArcFace (LResNet100E-IR)",
+        env: None,
+        download_args: &[],
+        blocked: false,
+    },
+    ModelInfo {
         id: "silero-vad",
         dir: "silero-vad",
         name: "Silero VAD",
         env: None,
         download_args: &[],
         blocked: false,
+    },
+    // Blocked on cost and on the divergence tracked in
+    // tracel-ai/burn-onnx#371: kokoro is 2,464 nodes / ~310 MB of weights and
+    // takes minutes to codegen and compile, and its audio still differs from
+    // the ORT reference by ~1.3x peak amplitude (Pearson r = 0.69). The
+    // default run only enforces a smoke tier (finite samples, r above a
+    // floor), so running it in CI would cost the compile without checking the
+    // numbers that matter. Unblock once #371 lands and `KOKORO_STRICT=1`
+    // passes. Still runnable via `--model kokoro`.
+    ModelInfo {
+        id: "kokoro",
+        dir: "kokoro",
+        name: "Kokoro v1.0 (TTS)",
+        env: None,
+        download_args: &[],
+        blocked: true,
     },
     ModelInfo {
         id: "all-minilm-l6-v2",
@@ -224,6 +248,14 @@ const MODELS: &[ModelInfo] = &[
         id: "mediapipe-face-detector",
         dir: "mediapipe-face-detector",
         name: "MediaPipe Face Detector",
+        env: None,
+        download_args: &[],
+        blocked: false,
+    },
+    ModelInfo {
+        id: "rtmw3d",
+        dir: "rtmw3d",
+        name: "RTMW3D-x",
         env: None,
         download_args: &[],
         blocked: false,


### PR DESCRIPTION
## Summary

Fixes both gaps in #506.

**1. Path filter misses the code that drives the workflow.** Added `xtask/**` and
`crates/onnx-ir-derive/**` to the `push` and `pull_request` path filters in
`.github/workflows/model-checks.yml`. The registry and runner live in
`xtask/src/model_check.rs`, so a PR that added a model, flipped a `blocked` flag, or
changed the runner never triggered the workflow that consumes it. `onnx-ir` depends on
`onnx-ir-derive`, so a derive-macro change could alter IR parsing for every model
without running a single model check.

**2. Three model-check crates were not in the registry.** `arcface`, `rtmw3d`, and
`kokoro` now have `ModelInfo` entries. Registry goes from 25 entries (18 default /
7 blocked) to 28 (20 default / 8 blocked).

Rather than guess whether the three were oversights or deliberate skips, I downloaded
the artifacts and ran each check locally with the flags xtask uses
(`--no-default-features --features flex --release`):

| Model | Result | Registered as |
|---|---|---|
| `arcface` | PASS, within 1e-4, 301 ms inference | `blocked: false` |
| `rtmw3d` | PASS, max abs diff 3e-6 vs a 1e-3 threshold, 808 ms inference | `blocked: false` |
| `kokoro` | not run | `blocked: true` + comment |

Both `arcface` and `rtmw3d` pass with wide margins, confirming they were forgotten
wiring rather than intentional exclusions.

### Why kokoro is blocked rather than enabled

Its `main.rs` splits acceptance into a smoke tier (default: finite samples, Pearson
above a 0.5 floor) and a strict tier gated behind `KOKORO_STRICT=1`. At the current
r=0.69 from #371 the default run exits 0. Enabling it would buy a 2,464-node
multi-minute compile plus a ~310 MB download while asserting essentially nothing. The
entry carries a comment saying this and naming #371 as the unblock condition.

The `depth-pro` / `stable-diffusion-xl` exclusion notes at the top of `MODELS` are
unchanged; both remain genuinely excluded.

## Test plan

- [x] `cargo build -p xtask`
- [x] `cargo fmt --check -p xtask`
- [x] `xtask model-check --model <bad>` lists all 28 ids
- [x] arcface passes (`uv run get_model.py`, then `cargo run --no-default-features --features flex --release`)
- [x] rtmw3d passes (same)
- [ ] kokoro not run locally; registered blocked, so CI does not run it either

## Not included

No drift guard. Registering these three fixes today's state but not the recurrence: a
future `crates/model-checks/<new>` can go unregistered the same way. A test asserting
every directory is either in `MODELS` or in an explicit exclusion list would close that
permanently, but it is beyond what the issue asks. Happy to add it here or in a
follow-up.

Closes #506
